### PR TITLE
Add maven plugin to create project and source zip files

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -151,7 +151,25 @@
 					<finalName>OpenHospital20/bin/OH-core</finalName>
 				</configuration>
 			</plugin>
-
+			<plugin>
+				<artifactId>maven-assembly-plugin</artifactId>
+				<version>3.1.1</version>
+				<configuration>
+					<descriptorRefs>
+						<descriptorRef>project</descriptorRef>
+						<descriptorRef>src</descriptorRef>
+					</descriptorRefs>
+				</configuration>
+				<executions>
+					<execution>
+						<id>make-assembly</id>
+						<phase>package</phase>
+						<goals>
+							<goal>single</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
 		</plugins>
 	</build>
 


### PR DESCRIPTION
This PR adds the [Maven Assembly Plugin](http://maven.apache.org/plugins/maven-assembly-plugin/index.html) to package source and project files as zip.  
It uses the *project* and *src* descriptor files packaged with the plugin (see [here](http://maven.apache.org/plugins/maven-assembly-plugin/descriptor-refs.html)).  
These are the generated artefacts upon issuing `mvn install` or `mvn assembly:single`:
```
OH-core-1.9-project.tar.bz2
OH-core-1.9-project.tar.gz
OH-core-1.9-project.zip
OH-core-1.9-src.tar.bz2
OH-core-1.9-src.tar.gz
OH-core-1.9-src.zip
```
The "project" artifact contain all project files needed to build the project, while the "src" files only contain the source files. If needed, this can be further customized by using a custom assembly descriptor (see [here](https://maven.apache.org/plugins/maven-assembly-plugin/usage.html)).


Alternatives:
 - the [Maven Source Plugin](https://maven.apache.org/plugins/maven-source-plugin/index.html) allows creating jar files containing sources. However, AFAIK, there's no way to generate zip rather than jar files, or include anything other then source files.


[OP-71](https://openhospital.atlassian.net/projects/OP/issues/OP-71?filter=allopenissues)