### PR TITLE
remove data jpa schema version

### DIFF
--- a/rsc/applicationContext.xml
+++ b/rsc/applicationContext.xml
@@ -9,17 +9,17 @@
 	xmlns:repository="http://www.springframework.org/schema/data/repository"
 	
 	xsi:schemaLocation="http://www.springframework.org/schema/beans 
-		http://www.springframework.org/schema/beans/spring-beans-4.3.xsd
+		http://www.springframework.org/schema/beans/spring-beans.xsd
 		http://www.springframework.org/schema/context 
-		http://www.springframework.org/schema/context/spring-context-4.3.xsd
+		http://www.springframework.org/schema/context/spring-context.xsd
 		http://www.springframework.org/schema/aop 
-		http://www.springframework.org/schema/aop/spring-aop-4.3.xsd
+		http://www.springframework.org/schema/aop/spring-aop.xsd
 		http://www.springframework.org/schema/data/jpa 
 		http://www.springframework.org/schema/data/jpa/spring-jpa.xsd
 		http://www.springframework.org/schema/tx 
-		http://www.springframework.org/schema/tx/spring-tx-4.3.xsd
+		http://www.springframework.org/schema/tx/spring-tx.xsd
 		http://www.springframework.org/schema/data/repository 
-		http://www.springframework.org/schema/data/repository/spring-repository-1.11.xsd
+		http://www.springframework.org/schema/data/repository/spring-repository.xsd
 		">
 		
 	<context:component-scan base-package="org.isf" />

--- a/rsc/applicationContext.xml
+++ b/rsc/applicationContext.xml
@@ -15,7 +15,7 @@
 		http://www.springframework.org/schema/aop 
 		http://www.springframework.org/schema/aop/spring-aop-4.3.xsd
 		http://www.springframework.org/schema/data/jpa 
-		http://www.springframework.org/schema/data/jpa/spring-jpa-1.11.xsd
+		http://www.springframework.org/schema/data/jpa/spring-jpa.xsd
 		http://www.springframework.org/schema/tx 
 		http://www.springframework.org/schema/tx/spring-tx-4.3.xsd
 		http://www.springframework.org/schema/data/repository 


### PR DESCRIPTION
To support different spring data jpa minor versions, it's been reference the unversioned xsd schema from the namespace declaration.

In this way the xsd, which **is** present in the jars, is not fetched via http and the application starts even without internet connection.

More detail in Jira issue: https://openhospital.atlassian.net/browse/OP-141