### PR TITLE
Remove reference to Boundless maven repository

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,4 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" 
+<project xmlns="http://maven.apache.org/POM/4.0.0"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
@@ -413,14 +413,6 @@
 			<url>http://www.dcm4che.org/maven2/</url>
 			<snapshots>
 				<enabled>false</enabled>
-			</snapshots>
-		</repository>
-		<repository>
-			<id>boundless</id>
-			<name>Boundless Repository</name>
-			<url>https://repo.boundlessgeo.com/main//</url>
-			<snapshots>
-				<enabled>true</enabled>
 			</snapshots>
 		</repository>
 	</repositories>


### PR DESCRIPTION
The Boundless repository appears to be offline and is causing CI builds failures - see for instance https://travis-ci.org/github/informatici/openhospital-core/jobs/676842582#L1085

This repository builds fine without it anyway.