### PR TITLE
Op 206: Replace native SQL with JPQL (modules from O to P)

### DIFF
--- a/src/org/isf/accounting/service/AccountingBillIoOperationRepository.java
+++ b/src/org/isf/accounting/service/AccountingBillIoOperationRepository.java
@@ -22,6 +22,8 @@ public interface AccountingBillIoOperationRepository
 
 	List<Bill> findAllByOrderByDateDesc();
 
+	List<Bill> findByPatient_code(int patientCode);
+
 	@Modifying
 	@Query(value = "UPDATE BILLS SET BLL_STATUS = 'D' WHERE BLL_ID = :billId", nativeQuery = true)
 	void updateDeleteWhereId(@Param("billId") Integer billId);

--- a/src/org/isf/accounting/service/AccountingIoOperations.java
+++ b/src/org/isf/accounting/service/AccountingIoOperations.java
@@ -3,6 +3,7 @@ package org.isf.accounting.service;
 import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.GregorianCalendar;
+import java.util.List;
 
 import org.isf.accounting.model.Bill;
 import org.isf.accounting.model.BillItems;
@@ -391,6 +392,16 @@ public class AccountingIoOperations {
 	public ArrayList<Bill> getPendingBillsAffiliate(int patID) throws OHServiceException {
 		ArrayList<Bill> pendingBills = billRepository.findAllPendindBillsByPatient(patID);
 		return pendingBills;
+	}
+
+	/**
+	 *
+	 * @param patID
+	 * @return
+	 * @throws OHServiceException
+	 */
+	public List<Bill> getAllPatientsBills(int patID) throws OHServiceException {
+		return billRepository.findByPatient_code(patID);
 	}
 
 	/**

--- a/src/org/isf/accounting/service/AccountingPatientMergedEventListener.java
+++ b/src/org/isf/accounting/service/AccountingPatientMergedEventListener.java
@@ -1,0 +1,26 @@
+package org.isf.accounting.service;
+
+import org.isf.accounting.model.Bill;
+import org.isf.patient.model.PatientMergedEvent;
+import org.isf.utils.exception.OHServiceException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Component
+public class AccountingPatientMergedEventListener {
+	@Autowired
+	AccountingIoOperations accountingIoOperations;
+
+	@EventListener
+	@Transactional
+	public void handle(PatientMergedEvent patientMergedEvent) throws OHServiceException {
+		List<Bill> bills = accountingIoOperations.getAllPatientsBills(patientMergedEvent.getObsoletePatient().getCode());
+		for (Bill bill : bills) {
+			bill.setPatient(patientMergedEvent.getMergedPatient());
+		}
+	}
+}

--- a/src/org/isf/admission/service/AdmissionPatientMergedEventListener.java
+++ b/src/org/isf/admission/service/AdmissionPatientMergedEventListener.java
@@ -1,0 +1,26 @@
+package org.isf.admission.service;
+
+import org.isf.admission.model.Admission;
+import org.isf.patient.model.PatientMergedEvent;
+import org.isf.utils.exception.OHServiceException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Component
+public class AdmissionPatientMergedEventListener {
+	@Autowired
+	AdmissionIoOperations admissionIoOperations;
+
+	@EventListener
+	public void handle(PatientMergedEvent patientMergedEvent) throws OHServiceException {
+		List<Admission> admissions = admissionIoOperations.getAdmissions(patientMergedEvent.getObsoletePatient());
+		for (Admission admission : admissions) {
+			admission.setPatient(patientMergedEvent.getMergedPatient());
+		}
+	}
+
+}

--- a/src/org/isf/examination/service/ExaminationPatientMergedEventListener.java
+++ b/src/org/isf/examination/service/ExaminationPatientMergedEventListener.java
@@ -1,0 +1,27 @@
+package org.isf.examination.service;
+
+import org.isf.examination.model.PatientExamination;
+import org.isf.patient.model.PatientMergedEvent;
+import org.isf.utils.exception.OHServiceException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Component
+public class ExaminationPatientMergedEventListener {
+	@Autowired
+	private ExaminationOperations examinationOperations;
+
+	@EventListener
+	@Transactional
+	public void handle(PatientMergedEvent patientMergedEvent) throws OHServiceException {
+		List<PatientExamination> patientExaminations = examinationOperations.getByPatID(patientMergedEvent.getObsoletePatient().getCode());
+		for (PatientExamination examination : patientExaminations) {
+			examination.setPatient(patientMergedEvent.getMergedPatient());
+		}
+	}
+
+}

--- a/src/org/isf/examination/test/Tests.java
+++ b/src/org/isf/examination/test/Tests.java
@@ -8,6 +8,7 @@ import java.util.ArrayList;
 import org.isf.examination.model.PatientExamination;
 import org.isf.examination.service.ExaminationOperations;
 import org.isf.patient.model.Patient;
+import org.isf.patient.model.PatientMergedEvent;
 import org.isf.patient.test.TestPatient;
 import org.isf.patient.test.TestPatientContext;
 import org.isf.utils.db.DbJpaUtil;
@@ -19,6 +20,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringRunner;
 
@@ -34,6 +36,8 @@ public class Tests
 
     @Autowired
     ExaminationOperations examinationOperations;
+    @Autowired
+	ApplicationEventPublisher applicationEventPublisher;
 	
 	@BeforeClass
     public static void setUpClass()  
@@ -278,7 +282,36 @@ public class Tests
 		}
 		
 		return;
-	}	
+	}
+
+	@Test
+	public void testListenerShouldUpdatePatientToMergedWhenPatientMergedEventArrive() {
+		try {
+			// given:
+			int id = _setupTestPatientExamination(false);
+			PatientExamination found = (PatientExamination) jpa.find(PatientExamination.class, id);
+			Patient mergedPatient = _setupTestPatient(false);
+
+			// when:
+			applicationEventPublisher.publishEvent(new PatientMergedEvent(found.getPatient(), mergedPatient));
+
+			// then:
+			PatientExamination result = (PatientExamination)jpa.find(PatientExamination.class, id);
+			assertEquals(mergedPatient.getCode(), result.getPatient().getCode());
+		} catch (Exception e) {
+			e.printStackTrace();
+			assertEquals(true, false);
+		}
+	}
+
+	private Patient _setupTestPatient(boolean usingSet) throws OHException {
+		jpa.beginTransaction();
+		Patient patient = testPatient.setup(usingSet);
+		jpa.persist(patient);
+		jpa.commitTransaction();
+
+		return patient;
+	}
 
 	private void _saveContext() throws OHException 
     {	

--- a/src/org/isf/lab/service/LabPatientMergedEventListener.java
+++ b/src/org/isf/lab/service/LabPatientMergedEventListener.java
@@ -1,0 +1,31 @@
+package org.isf.lab.service;
+
+import org.isf.lab.model.Laboratory;
+import org.isf.patient.model.Patient;
+import org.isf.patient.model.PatientMergedEvent;
+import org.isf.utils.exception.OHServiceException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Component
+public class LabPatientMergedEventListener {
+	@Autowired
+	LabIoOperations labIoOperations;
+
+	@EventListener
+	@Transactional
+	public void handle(PatientMergedEvent patientMergedEvent) throws OHServiceException {
+		List<Laboratory> laboratories = labIoOperations.getLaboratory(patientMergedEvent.getObsoletePatient());
+		for (Laboratory laboratory : laboratories) {
+			Patient mergedPatient = patientMergedEvent.getMergedPatient();
+			laboratory.setPatient(mergedPatient);
+			laboratory.setPatName(mergedPatient.getName());
+			laboratory.setAge(mergedPatient.getAge());
+			laboratory.setSex(String.valueOf(mergedPatient.getSex()));
+		}
+	}
+}

--- a/src/org/isf/medicalstockward/service/MedicalStockWardIoOperations.java
+++ b/src/org/isf/medicalstockward/service/MedicalStockWardIoOperations.java
@@ -4,6 +4,7 @@ import org.isf.medicals.model.Medical;
 import org.isf.medicalstock.model.Movement;
 import org.isf.medicalstockward.model.MedicalWard;
 import org.isf.medicalstockward.model.MovementWard;
+import org.isf.patient.model.Patient;
 import org.isf.utils.db.TranslateOHServiceException;
 import org.isf.utils.exception.OHServiceException;
 import org.isf.ward.model.Ward;
@@ -15,6 +16,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
 import java.util.GregorianCalendar;
+import java.util.List;
 
 /**
  * @author mwithi
@@ -271,5 +273,9 @@ public class MedicalStockWardIoOperations
 		}
 		
 		return medicalWards;
+	}
+
+	public List<MovementWard> findAllForPatient(Patient patient) {
+		return movementRepository.findByPatient_code(patient.getCode());
 	}
 }

--- a/src/org/isf/medicalstockward/service/MovementWardIoOperationRepository.java
+++ b/src/org/isf/medicalstockward/service/MovementWardIoOperationRepository.java
@@ -8,6 +8,7 @@ import org.springframework.stereotype.Repository;
 
 import java.util.ArrayList;
 import java.util.GregorianCalendar;
+import java.util.List;
 
 @Repository
 public interface MovementWardIoOperationRepository extends JpaRepository<MovementWard, Integer>{      
@@ -15,4 +16,6 @@ public interface MovementWardIoOperationRepository extends JpaRepository<Movemen
     ArrayList<MovementWard> findWardMovements(@Param("idwardto") String idWardTo,
                                               @Param("datefrom") GregorianCalendar dateFrom,
                                               @Param("dateto") GregorianCalendar dateTo);
+
+    List<MovementWard> findByPatient_code(int code);
 }

--- a/src/org/isf/medicalstockward/service/MovementWardPatientMergedEventListener.java
+++ b/src/org/isf/medicalstockward/service/MovementWardPatientMergedEventListener.java
@@ -1,0 +1,26 @@
+package org.isf.medicalstockward.service;
+
+import org.isf.medicalstockward.model.MovementWard;
+import org.isf.patient.model.PatientMergedEvent;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Component
+public class MovementWardPatientMergedEventListener {
+	@Autowired
+	MedicalStockWardIoOperations medicalStockWardIoOperations;
+
+	@EventListener
+	@Transactional
+	public void handle(PatientMergedEvent patientMergedEvent) {
+		List<MovementWard> movementWards = medicalStockWardIoOperations.findAllForPatient(patientMergedEvent.getObsoletePatient());
+		for (MovementWard movementWard : movementWards) {
+			movementWard.setPatient(patientMergedEvent.getMergedPatient());
+		}
+	}
+
+}

--- a/src/org/isf/medicalstockward/test/Tests.java
+++ b/src/org/isf/medicalstockward/test/Tests.java
@@ -7,6 +7,7 @@ import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.GregorianCalendar;
 
+import org.isf.examination.model.PatientExamination;
 import org.isf.medicals.model.Medical;
 import org.isf.medicals.test.TestMedical;
 import org.isf.medicals.test.TestMedicalContext;
@@ -24,6 +25,7 @@ import org.isf.medtype.model.MedicalType;
 import org.isf.medtype.test.TestMedicalType;
 import org.isf.medtype.test.TestMedicalTypeContext;
 import org.isf.patient.model.Patient;
+import org.isf.patient.model.PatientMergedEvent;
 import org.isf.patient.test.TestPatient;
 import org.isf.patient.test.TestPatientContext;
 import org.isf.supplier.test.TestSupplier;
@@ -40,6 +42,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringRunner; 
 
@@ -71,6 +74,8 @@ public class Tests
 
     @Autowired
     MedicalStockWardIoOperations medicalIoOperation;
+    @Autowired
+    ApplicationEventPublisher applicationEventPublisher;
 	
 	@BeforeClass
     public static void setUpClass()  
@@ -403,6 +408,35 @@ public class Tests
 		}
 		
 		return;
+	}
+
+	@Test
+	public void testListenerShouldUpdatePatientToMergedWhenPatientMergedEventArrive() {
+		try {
+			// given:
+			int id = _setupTestMovementWard(false);
+			MovementWard found = (MovementWard) jpa.find(MovementWard.class, id);
+			Patient mergedPatient = _setupTestPatient(false);
+
+			// when:
+			applicationEventPublisher.publishEvent(new PatientMergedEvent(found.getPatient(), mergedPatient));
+
+			// then:
+			MovementWard result = (MovementWard)jpa.find(MovementWard.class, id);
+			assertEquals(mergedPatient.getCode(), result.getPatient().getCode());
+		} catch (Exception e) {
+			e.printStackTrace();
+			assertEquals(true, false);
+		}
+	}
+
+	private Patient _setupTestPatient(boolean usingSet) throws OHException	{
+		jpa.beginTransaction();
+		Patient patient = testPatient.setup(usingSet);
+		jpa.persist(patient);
+		jpa.commitTransaction();
+
+		return patient;
 	}
 	
 	

--- a/src/org/isf/opd/service/OpdIoOperationRepository.java
+++ b/src/org/isf/opd/service/OpdIoOperationRepository.java
@@ -1,34 +1,32 @@
 package org.isf.opd.service;
 
+import java.util.GregorianCalendar;
 import java.util.List;
 
 import org.isf.opd.model.Opd;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
-import org.springframework.stereotype.Repository;
 
-@Repository
-public interface OpdIoOperationRepository extends JpaRepository<Opd, Integer>, OpdIoOperationRepositoryCustom {    
+public interface OpdIoOperationRepository extends JpaRepository<Opd, Integer>, OpdIoOperationRepositoryCustom {
 	
-	@Query(value = "SELECT * FROM OPD LEFT JOIN PATIENT ON OPD_PAT_ID = PAT_ID ORDER BY OPD_PROG_YEAR DESC", nativeQuery= true)
-    List<Opd> findAllByOrderByProgYearDesc();
+    @Query("select o from Opd o order by o.prog_year")
+	List<Opd> findAllOrderByProgYearDesc();
 	
-	@Query(value = "SELECT * FROM OPD LEFT JOIN PATIENT ON OPD_PAT_ID = PAT_ID WHERE OPD_PAT_ID = :code ORDER BY OPD_PROG_YEAR DESC", nativeQuery= true)
-    List<Opd> findAllWherePatIdByOrderByProgYearDesc(@Param("code") Integer code);
+	@Query("select o from Opd o where o.patient.code = :code order by o.prog_year")
+	List<Opd> findAllByPatient_CodeOrderByProgYearDesc(@Param("code") Integer code);
 	
-	@Query(value = "SELECT MAX(OPD_PROG_YEAR) FROM OPD", nativeQuery= true)
+	@Query("select max(o.prog_year) from Opd o")
     Integer findMaxProgYear();
 
-	@Query(value = "SELECT MAX(OPD_PROG_YEAR) FROM OPD WHERE YEAR(OPD_DATE) = :date", nativeQuery= true)
-    Integer findMaxProgYearWhereDate(@Param("date") Integer date);
+	@Query(value = "select max(o.prog_year) from Opd o where o.date >= :dateFrom and o.date < :dateTo")
+    Integer findMaxProgYearWhereDateBetween(@Param("dateFrom") GregorianCalendar dateFrom, @Param("dateTo") GregorianCalendar dateTo);
 
-	@Query(value = "SELECT * FROM OPD LEFT JOIN PATIENT ON OPD_PAT_ID = PAT_ID WHERE OPD_PAT_ID = ? ORDER BY OPD_DATE DESC LIMIT 1", nativeQuery= true)
-    List<Opd> findAllWherePatIdByOrderByDateDescLimit1(@Param("code") Integer code);
+    List<Opd> findTop1ByPatient_CodeOrderByDateDesc(Integer code);
 	
-	@Query(value = "SELECT * FROM OPD WHERE OPD_PROG_YEAR = :prog_year", nativeQuery= true)
-    List<Opd> findAllByProgYear(@Param("prog_year") Integer prog_year);
+	@Query("select o from Opd o where o.prog_year = :prog_year")
+    List<Opd> findByProgYear(@Param("prog_year") Integer prog_year);
 	
-	@Query(value = "SELECT * FROM OPD WHERE OPD_PROG_YEAR = :prog_year AND YEAR(OPD_DATE_VIS) = :year", nativeQuery= true)
-    List<Opd> findAllByProgYearWithinYear(@Param("prog_year") Integer prog_year, @Param("year") Integer year);
+	@Query(value = "select op from Opd op where op.prog_year = :prog_year and op.visitDate >= :dateVisitFrom and op.visitDate < :dateVisitTo")
+    List<Opd> findByProgYearAndVisitDateBetween(@Param("prog_year") Integer prog_year, @Param("dateVisitFrom") GregorianCalendar dateVisitFrom, @Param("dateVisitTo") GregorianCalendar dateVisitTo);
 }

--- a/src/org/isf/opd/service/OpdIoOperationRepositoryCustom.java
+++ b/src/org/isf/opd/service/OpdIoOperationRepositoryCustom.java
@@ -1,13 +1,15 @@
 package org.isf.opd.service;
 
 
+import org.isf.opd.model.Opd;
+
 import java.util.GregorianCalendar;
 import java.util.List;
 
 
 public interface OpdIoOperationRepositoryCustom {
 
-	List<Integer> findAllOpdWhereParams(String diseaseTypeCode, String diseaseCode, GregorianCalendar dateFrom,
-			GregorianCalendar dateTo, int ageFrom, int ageTo, char sex, char newPatient);
-	
+	List<Opd> findAllOpdWhereParams(String diseaseTypeCode, String diseaseCode, GregorianCalendar dateFrom,
+									GregorianCalendar dateTo, int ageFrom, int ageTo, char sex, char newPatient);
+
 }

--- a/src/org/isf/opd/service/OpdIoOperationRepositoryImpl.java
+++ b/src/org/isf/opd/service/OpdIoOperationRepositoryImpl.java
@@ -7,8 +7,13 @@ import java.util.List;
 
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
+import javax.persistence.TypedQuery;
+import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.CriteriaQuery;
+import javax.persistence.criteria.Root;
 
 import org.isf.generaldata.MessageBundle;
+import org.isf.opd.model.Opd;
 import org.springframework.transaction.annotation.Transactional;
 
 
@@ -18,10 +23,9 @@ public class OpdIoOperationRepositoryImpl implements OpdIoOperationRepositoryCus
 	@PersistenceContext
 	private EntityManager entityManager;
 
-	
 	@SuppressWarnings("unchecked")	
 	@Override
-	public List<Integer> findAllOpdWhereParams(
+	public List<Opd> findAllOpdWhereParams(
 			String diseaseTypeCode,
 			String diseaseCode, 
 			GregorianCalendar dateFrom,
@@ -30,16 +34,13 @@ public class OpdIoOperationRepositoryImpl implements OpdIoOperationRepositoryCus
 			int ageTo,
 			char sex,
 			char newPatient) {
-		return this.entityManager.
-				createNativeQuery(_getOpdQuery(
+		return _getOpdQuery(
 						diseaseTypeCode, diseaseCode, dateFrom, dateTo,
-						ageFrom, ageTo, sex, newPatient)).
+						ageFrom, ageTo, sex, newPatient).
 					getResultList();
 	}	
 
-		
-
-	public String _getOpdQuery(
+	private TypedQuery<Opd> _getOpdQuery(
 			String diseaseTypeCode,
 			String diseaseCode, 
 			GregorianCalendar dateFrom,
@@ -47,39 +48,41 @@ public class OpdIoOperationRepositoryImpl implements OpdIoOperationRepositoryCus
 			int ageFrom, 
 			int ageTo,
 			char sex,
-			char newPatient)
-	{	
-		String query = "SELECT OPD_ID FROM OPD LEFT JOIN PATIENT ON OPD_PAT_ID = PAT_ID LEFT JOIN DISEASE ON OPD_DIS_ID_A = DIS_ID_A LEFT JOIN DISEASETYPE ON DIS_DCL_ID_A = DCL_ID_A WHERE 1";
+			char newPatient) {
+		CriteriaBuilder cb = entityManager.getCriteriaBuilder();
+		CriteriaQuery<Opd> query = cb.createQuery(Opd.class);
+		Root<Opd> opd = query.from(Opd.class);
+
+		query.select(opd);
 		if (!(diseaseTypeCode.equals(MessageBundle.getMessage("angal.opd.alltype")))) {
-			query += " AND DIS_DCL_ID_A = \"" + diseaseTypeCode + "\"";
+			query.where(
+				cb.equal(opd.join("disease").join("diseaseType").get("code"), diseaseTypeCode)
+			);
 		}
 		if(!diseaseCode.equals(MessageBundle.getMessage("angal.opd.alldisease"))) {
-			query += " AND DIS_ID_A = \"" + diseaseCode + "\"";
+			query.where(
+				cb.equal(opd.join("disease").get("code"), diseaseCode)
+			);
 		}
 		if (ageFrom != 0 || ageTo != 0) {
-			query += " AND OPD_AGE BETWEEN \"" + ageFrom + "\" AND \"" + ageTo + "\"";
+			query.where(
+				cb.between(opd.<Comparable>get("age"), ageFrom, ageTo)
+			);
 		}
 		if (sex != 'A') {
-			query += " AND OPD_SEX =  \"" + sex + "\"";
+			query.where(
+				cb.equal(opd.get("sex"), sex)
+			);
 		}
 		if (newPatient != 'A') {
-			query += " AND OPD_NEW_PAT =  \"" + newPatient + "\"";
+			query.where(
+				cb.equal(opd.get("newPatient"), newPatient)
+			);
 		}
-		query += " AND OPD_DATE_VIS BETWEEN  \"" + _convertToSQLDateLimited(dateFrom) + "\" AND \"" + _convertToSQLDateLimited(dateTo) + "\"";
+		query.where(
+			cb.between(opd.<Comparable>get("visitDate"), dateFrom, dateTo)
+		);
 
-		return query;
-	}
-		
-	/**
-	 * return a String representing the date in format <code>yyyy-MM-dd</code>
-	 * 
-	 * @param date
-	 * @return the date in format <code>yyyy-MM-dd</code>
-	 */
-	private String _convertToSQLDateLimited(GregorianCalendar date) 
-	{
-		SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd");
-	
-		return sdf.format(date.getTime());
+		return entityManager.createQuery(query);
 	}
 }

--- a/src/org/isf/opd/service/OpdPatientMergedEventListener.java
+++ b/src/org/isf/opd/service/OpdPatientMergedEventListener.java
@@ -1,0 +1,28 @@
+package org.isf.opd.service;
+
+import org.isf.opd.model.Opd;
+import org.isf.patient.model.PatientMergedEvent;
+import org.isf.utils.exception.OHServiceException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Component
+public class OpdPatientMergedEventListener {
+	@Autowired
+	OpdIoOperations opdIoOperations;
+
+	@EventListener
+	@Transactional
+	public void handle(PatientMergedEvent patientMergedEvent) throws OHServiceException {
+		List<Opd> opds = opdIoOperations.getOpdList(patientMergedEvent.getObsoletePatient().getCode());
+		for(Opd opd : opds) {
+			opd.setPatient(patientMergedEvent.getMergedPatient());
+		}
+	}
+
+}

--- a/src/org/isf/opd/test/Tests.java
+++ b/src/org/isf/opd/test/Tests.java
@@ -1,9 +1,8 @@
 package org.isf.opd.test;
 
 
-import static org.junit.Assert.assertEquals;
-
 import java.util.ArrayList;
+import java.util.Calendar;
 import java.util.Date;
 
 import org.isf.disease.model.Disease;
@@ -28,6 +27,8 @@ import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringRunner;
+
+import static org.junit.Assert.*;
 
 @RunWith(SpringRunner.class)
 @ContextConfiguration(locations = { "classpath:applicationContext.xml" })
@@ -280,6 +281,72 @@ public class Tests
 			assertEquals(true, false);
 		}
 		
+		return;
+	}
+
+	@Test
+	public void testIoIsExistsOpdNumShouldReturnTrueWhenOpdWithGivenOPDProgressiveYearAndVisitYearExists() {
+		try	{
+			// given:
+			int code = _setupTestOpd(false);
+			Opd foundOpd = (Opd)jpa.find(Opd.class, code);
+
+			// when:
+			Boolean result = opdIoOperation.isExistOpdNum(foundOpd.getProgYear(), foundOpd.getVisitDate().get(Calendar.YEAR));
+
+			// then:
+			assertTrue(result);
+		}
+		catch (Exception e)
+		{
+			e.printStackTrace();
+			assertEquals(true, false);
+		}
+
+		return;
+	}
+
+	@Test
+	public void testIoIsExistsOpdNumShouldReturnTrueWhenOpdNumExistsAndVisitYearIsNotProvided()	{
+		try	{
+			// given:
+			int code = _setupTestOpd(false);
+			Opd foundOpd = (Opd)jpa.find(Opd.class, code);
+
+			// when:
+			Boolean result = opdIoOperation.isExistOpdNum(foundOpd.getProgYear(), 0);
+
+			// then:
+			assertTrue(result);
+		}
+		catch (Exception e)
+		{
+			e.printStackTrace();
+			assertEquals(true, false);
+		}
+
+		return;
+	}
+
+	@Test
+	public void testIoIsExistsOpdNumShouldReturnFalseWhenOpdNumExistsAndVisitYearIsIncorrect() {
+		try	{
+			// given:
+			int code = _setupTestOpd(false);
+			Opd foundOpd = (Opd)jpa.find(Opd.class, code);
+
+			// when:
+			Boolean result = opdIoOperation.isExistOpdNum(foundOpd.getProgYear(), 1488);
+
+			// then:
+			assertFalse(result);
+		}
+		catch (Exception e)
+		{
+			e.printStackTrace();
+			assertEquals(true, false);
+		}
+
 		return;
 	}
 

--- a/src/org/isf/operation/service/OperationIoOperationRepository.java
+++ b/src/org/isf/operation/service/OperationIoOperationRepository.java
@@ -1,20 +1,13 @@
 package org.isf.operation.service;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import org.isf.operation.model.Operation;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
-import org.springframework.stereotype.Repository;
 
-@Repository
+import java.util.List;
+
 public interface OperationIoOperationRepository extends JpaRepository<Operation, String> {
     List<Operation> findByOrderByDescriptionDesc();
 	List<Operation> findAllByDescriptionContainsOrderByDescriptionDesc(String type);
-   // @Query(value = "SELECT * FROM OPERATION WHERE OPE_DESC = :description AND OPE_OCL_ID_A = :type", nativeQuery= true)
-    Operation findOneByDescriptionAndType_Code(@Param("description") String description, @Param("type") String type);
-    
+    Operation findOneByDescriptionAndType_Code(String description, String type);
     Operation findByCode(String code);
 }

--- a/src/org/isf/operation/service/OperationIoOperationRepository.java
+++ b/src/org/isf/operation/service/OperationIoOperationRepository.java
@@ -1,6 +1,7 @@
 package org.isf.operation.service;
 
 import java.util.ArrayList;
+import java.util.List;
 
 import org.isf.operation.model.Operation;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -10,12 +11,10 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface OperationIoOperationRepository extends JpaRepository<Operation, String> {
-    @Query(value = "SELECT * FROM OPERATION JOIN OPERATIONTYPE ON OPE_OCL_ID_A = OCL_ID_A ORDER BY OPE_DESC", nativeQuery= true)
-    ArrayList<Operation> findAllWithoutDescription();
-    @Query(value = "SELECT * FROM OPERATION JOIN OPERATIONTYPE ON OPE_OCL_ID_A = OCL_ID_A WHERE OCL_DESC LIKE CONCAT('%', :type , '%') ORDER BY OPE_DESC", nativeQuery= true)
-    ArrayList<Operation> findAllByDescription(@Param("type") String type);
-    @Query(value = "SELECT * FROM OPERATION WHERE OPE_DESC = :description AND OPE_OCL_ID_A = :type", nativeQuery= true)
-    Operation findOneByDescriptionAndType(@Param("description") String description, @Param("type") String type);
+    List<Operation> findByOrderByDescriptionDesc();
+	List<Operation> findAllByDescriptionContainsOrderByDescriptionDesc(String type);
+   // @Query(value = "SELECT * FROM OPERATION WHERE OPE_DESC = :description AND OPE_OCL_ID_A = :type", nativeQuery= true)
+    Operation findOneByDescriptionAndType_Code(@Param("description") String description, @Param("type") String type);
     
     Operation findByCode(String code);
 }

--- a/src/org/isf/operation/service/OperationIoOperations.java
+++ b/src/org/isf/operation/service/OperationIoOperations.java
@@ -9,6 +9,7 @@ package org.isf.operation.service;
  -----------------------------------------------------------*/
 
 import java.util.ArrayList;
+import java.util.List;
 
 import org.isf.operation.model.Operation;
 import org.isf.opetype.model.OperationType;
@@ -39,27 +40,15 @@ public class OperationIoOperations {
 	 * @return the list of {@link Operation}s. It could be <code>empty</code> or <code>null</code>.
 	 * @throws OHServiceException 
 	 */
-	public ArrayList<Operation> getOperation(
-			String typeDescription) throws OHServiceException 
-	{
-    	ArrayList<Operation> operations = null;
-
-    	
-		if (typeDescription == null) 
-		{
-			operations = repository.findAllWithoutDescription();
-		}
-		else
-		{
-			operations = repository.findAllByDescription(typeDescription);
-		}	
-
-		return operations;
+	public ArrayList<Operation> getOperation(String typeDescription) throws OHServiceException {
+		return new ArrayList<Operation>(typeDescription == null ?
+			repository.findByOrderByDescriptionDesc() :
+			repository.findAllByDescriptionContainsOrderByDescriptionDesc(typeDescription));
 	}
-        
-        public Operation findByCode(String code) throws OHServiceException{
-            return repository.findByCode(code);
-        }
+
+	public Operation findByCode(String code) throws OHServiceException{
+    	return repository.findByCode(code);
+	}
 	
 	/**
 	 * insert an {@link Operation} in the DBs
@@ -68,16 +57,8 @@ public class OperationIoOperations {
 	 * @return <code>true</code> if the operation has been inserted, <code>false</code> otherwise.
 	 * @throws OHServiceException 
 	 */
-	public boolean newOperation(
-			Operation operation) throws OHServiceException
-	{
-		boolean result = true;
-	
-
-		Operation savedOperation = repository.save(operation);
-		result = (savedOperation != null);
-    	
-		return result;
+	public boolean newOperation(Operation operation) throws OHServiceException {
+		return repository.save(operation) != null;
 	}
 	
 	/** 
@@ -87,15 +68,8 @@ public class OperationIoOperations {
 	 * @return <code>true</code> if the item has been updated, <code>false</code> otherwise.
 	 * @throws OHServiceException 
 	 */
-	public boolean updateOperation(
-			Operation operation) throws OHServiceException
-	{
-		boolean result = true;
-	
-		Operation savedOperation = repository.save(operation);
-		result = (savedOperation != null);
-    	
-		return result;
+	public boolean updateOperation(Operation operation) throws OHServiceException {
+		return repository.save(operation) != null;
 	}
 	
 	/** 
@@ -104,15 +78,9 @@ public class OperationIoOperations {
 	 * @return <code>true</code> if the item has been updated, <code>false</code> otherwise.
 	 * @throws OHServiceException 
 	 */
-	public boolean deleteOperation(
-			Operation operation) throws OHServiceException
-	{
-		boolean result = true;
-	
-		
+	public boolean deleteOperation(Operation operation) throws OHServiceException {
 		repository.delete(operation);
-    	
-		return result;
+		return true;
 	}
 	
 	/**
@@ -121,15 +89,8 @@ public class OperationIoOperations {
 	 * @return <code>true</code> if the code is already in use, <code>false</code> otherwise.
 	 * @throws OHServiceException 
 	 */
-	public boolean isCodePresent(
-			String code) throws OHServiceException
-	{
-		boolean result = true;
-	
-		
-		result = repository.exists(code);
-		
-		return result;
+	public boolean isCodePresent(String code) throws OHServiceException {
+		return repository.exists(code);
 	}
 	
 	/**
@@ -140,20 +101,9 @@ public class OperationIoOperations {
 	 * @return <code>true</code> if the description is already in use, <code>false</code> otherwise.
 	 * @throws OHServiceException 
 	 */
-	public boolean isDescriptionPresent(
-			String description, 
-			String typeCode) throws OHServiceException
-	{
-		Operation foundOperation = repository.findOneByDescriptionAndType(description, typeCode);
-		boolean present = false;
-				
-			
-		if (foundOperation != null && foundOperation.getDescription().compareTo(description) == 0)
-		{
-			present = true;
-		}
-		
-		return present;
+	public boolean isDescriptionPresent(String description, String typeCode) throws OHServiceException {
+		Operation foundOperation = repository.findOneByDescriptionAndType_Code(description, typeCode);
+		return foundOperation != null && foundOperation.getDescription().compareTo(description) == 0;
 	}
 }
 

--- a/src/org/isf/operation/service/OperationRowIoOperationRepository.java
+++ b/src/org/isf/operation/service/OperationRowIoOperationRepository.java
@@ -19,12 +19,8 @@ import org.springframework.stereotype.Repository;
  */
 @Repository
 public interface OperationRowIoOperationRepository extends JpaRepository<OperationRow, String> {
-    	@Query(value = "SELECT * FROM OPERATIONROW ORDER BY OPER_OPDATE DESC", nativeQuery= true)
-        ArrayList<OperationRow> getOperationRow();
-        
+        ArrayList<OperationRow> findByOrderByOpDateDesc();
         ArrayList<OperationRow> findByAdmission(Admission adm);
-        
         OperationRow findById(int id);
-        
         ArrayList<OperationRow> findByOpd(Opd opd);
 }

--- a/src/org/isf/operation/service/OperationRowIoOperationRepository.java
+++ b/src/org/isf/operation/service/OperationRowIoOperationRepository.java
@@ -10,7 +10,6 @@ import org.isf.admission.model.Admission;
 import org.isf.opd.model.Opd;
 import org.isf.operation.model.OperationRow;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 /**

--- a/src/org/isf/operation/service/OperationRowIoOperations.java
+++ b/src/org/isf/operation/service/OperationRowIoOperations.java
@@ -29,7 +29,7 @@ public class OperationRowIoOperations {
     private OperationRowIoOperationRepository repository;
     
     public ArrayList<OperationRow> getOperationRow() throws OHServiceException{
-        return repository.getOperationRow();
+        return repository.findByOrderByOpDateDesc();
     }
 
     public List<OperationRow> getOperationRowByAdmission(Admission adm) throws OHServiceException{

--- a/src/org/isf/operation/test/Tests.java
+++ b/src/org/isf/operation/test/Tests.java
@@ -2,6 +2,7 @@ package org.isf.operation.test;
 
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 
 import java.util.ArrayList;
 
@@ -141,6 +142,33 @@ public class Tests
 			assertEquals(true, false);
 		}
 		
+		return;
+	}
+
+	@Test
+	public void testIoGetOperationsShouldFindOperationsWithoutProvidingDescription() throws OHException
+	{
+		String code = "";
+
+
+		try
+		{
+			// given:
+			code = _setupTestOperation(false);
+			Operation foundOperation = (Operation)jpa.find(Operation.class, code);
+
+			// when:
+			ArrayList<Operation> operations = operationIoOperations.getOperation(foundOperation.getDescription());
+
+			// then:
+			assertFalse(operations.isEmpty());
+		}
+		catch (Exception e)
+		{
+			e.printStackTrace();
+			assertEquals(true, false);
+		}
+
 		return;
 	}
 	

--- a/src/org/isf/patient/manager/PatientBrowserManager.java
+++ b/src/org/isf/patient/manager/PatientBrowserManager.java
@@ -193,7 +193,7 @@ public class PatientBrowserManager {
 	 * @throws OHServiceException 
 	 */
 	public ArrayList<Patient> getPatientWithHeightAndWeight(String regex) throws OHServiceException{
-        return ioOperations.getPatientsWithHeightAndWeight(regex);
+        return ioOperations.getPatientsByOneOfFieldsLike(regex);
 	}
 
 	/**

--- a/src/org/isf/patient/model/PatientMergedEvent.java
+++ b/src/org/isf/patient/model/PatientMergedEvent.java
@@ -1,0 +1,19 @@
+package org.isf.patient.model;
+
+public class PatientMergedEvent {
+	private final Patient obsoletePatient;
+	private final Patient mergedPatient;
+
+	public PatientMergedEvent(Patient obsoletePatient, Patient mergedPatient) {
+		this.obsoletePatient = obsoletePatient;
+		this.mergedPatient = mergedPatient;
+	}
+
+	public Patient getObsoletePatient() {
+		return obsoletePatient;
+	}
+
+	public Patient getMergedPatient() {
+		return mergedPatient;
+	}
+}

--- a/src/org/isf/patient/service/PatientIoOperationRepository.java
+++ b/src/org/isf/patient/service/PatientIoOperationRepository.java
@@ -1,7 +1,5 @@
 package org.isf.patient.service;
 
-import java.util.ArrayList;
-import java.util.Date;
 import java.util.List;
 
 import org.isf.patient.model.Patient;
@@ -27,44 +25,19 @@ public interface PatientIoOperationRepository extends JpaRepository<Patient, Int
 	@Query("select p from Patient p where p.code = :id and (p.deleted = :deletedStatus or p.deleted is null)")
 	List<Patient> findAllWhereIdAndDeleted(@Param("id") Integer id, @Param("deletedStatus") String deletedStatus);
     
-    List<Patient> findByCode(Integer id);
-    
     @Modifying
     @Transactional
     @Query(value = "UPDATE PATIENT SET PAT_DELETED = 'Y' WHERE PAT_ID = :id", nativeQuery = true)
     int updateDeleted(@Param("id") Integer id);
             
-    @Query(value = "SELECT * FROM PATIENT WHERE PAT_NAME = :name AND PAT_DELETED='N'", nativeQuery= true)
-    List<Patient> findAllWhereName(@Param("name") String name);
+    List<Patient> findByNameAndDeleted(String name, String deletedStatus);
 
-    @Query(value = "SELECT MAX(PAT_ID) FROM PATIENT", nativeQuery= true)
+    @Query(value = "select max(p.code) from Patient p")
     Integer findMaxCode();
  		
     @Modifying
     @Transactional
-    @Query(value = "UPDATE PATIENT SET PAT_DELETED = 'Y' WHERE PAT_ID = :id", nativeQuery= true)
+    @Query(value = "UPDATE Patient p SET p.deleted = 'Y' WHERE p.code = :id")
     int updateDelete(@Param("id") Integer id); 		
-    
-    @Modifying
-    @Transactional
-    @Query(value = "UPDATE PATIENT SET PAT_FNAME = :firstName, PAT_SNAME = :secondName, PAT_NAME  = :name, "
-    		+ "PAT_BDATE = :bdate, PAT_AGE = :age, PAT_AGETYPE = :ageType, PAT_SEX = :sex, PAT_ADDR = :address, PAT_CITY = :city, "
-    		+ "PAT_NEXT_KIN = :nextKin, PAT_TELE = :telephone, PAT_MOTH = :mother, PAT_MOTH_NAME = :motherName, "
-    		+ "PAT_FATH = :father, PAT_FATH_NAME = :fatherName, PAT_BTYPE = :bType, PAT_ESTA = :esta, PAT_PTOGE = :ptoge, "
-    		+ "PAT_NOTE = :note, PAT_TAXCODE = :taxCode, PAT_LOCK = :lock, PAT_PHOTO = :photo WHERE PAT_ID = :id", nativeQuery= true)
-    int updateLockByCode(
-    		@Param("firstName") String firstName, @Param("secondName") String secondName, @Param("name") String name,
-    		@Param("bdate") Date bdate, @Param("age") Integer age, @Param("ageType") String ageType, @Param("sex") char sex, @Param("address") String address, @Param("city") String city,
-    		@Param("nextKin") String nextKin, @Param("telephone") String telephone, @Param("mother") char mother, @Param("motherName") String motherName,
-    		@Param("father") char father, @Param("fatherName") String fatherName, @Param("bType") String bType, @Param("esta") char esta, @Param("ptoge") char ptoge,
-    		@Param("note") String note, @Param("taxCode") String taxCode, @Param("lock") Integer lock, @Param("photo") byte[] photo,
-    		@Param("id") Integer id); 
-    @Query(value = "SELECT * FROM PATIENT "
-    		+"LEFT JOIN (SELECT PEX_PAT_ID, PEX_HEIGHT AS PAT_HEIGHT, PEX_WEIGHT AS PAT_WEIGHT FROM PATIENTEXAMINATION GROUP BY PEX_PAT_ID ORDER BY PEX_DATE DESC) "
-    		+"AS HW ON PAT_ID = HW.PEX_PAT_ID WHERE (PAT_DELETED='N' or PAT_DELETED is null) "
-    		+"AND (PAT_AFFILIATED_PERSON < 1 OR PAT_AFFILIATED_PERSON is null) "
-    		+"AND (PAT_IS_HEAD_AFFILIATION = 1) "
-    		+"ORDER BY PAT_ID DESC", 
-    		nativeQuery= true)
-    ArrayList<Patient> getPatientsHeadWithHeightAndWeight();
+
 }

--- a/src/org/isf/patient/service/PatientIoOperationRepository.java
+++ b/src/org/isf/patient/service/PatientIoOperationRepository.java
@@ -17,26 +17,17 @@ import org.springframework.transaction.annotation.Transactional;
 @Repository
 public interface PatientIoOperationRepository extends JpaRepository<Patient, Integer>, PatientIoOperationRepositoryCustom {
     
-	@Query(value = "SELECT * FROM PATIENT WHERE (PAT_DELETED='N' OR PAT_DELETED IS NULL) ORDER BY PAT_ID", nativeQuery= true)
-    List<Patient> findAllWhereDeleted();
-
-	
-	@Query(value = "SELECT * FROM PATIENT WHERE (PAT_DELETED='N' OR PAT_DELETED IS NULL) ORDER BY PAT_NAME", nativeQuery= true)
-    List<Patient> findAllWhereDeletedOrderedByName();
-
-    @Query(value = "SELECT * FROM PATIENT WHERE (PAT_DELETED='N' OR PAT_DELETED IS NULL) ORDER BY PAT_NAME, ?#{#pageable}", nativeQuery= true)
-    List<Patient> findAllWhereDeleted(Pageable pageable);
+    List<Patient> findByDeletedOrDeletedIsNull(String deletionStatus);
 
     List<Patient> findAllByDeletedIsNullOrDeletedEqualsOrderByName(String patDeleted, Pageable pageable);
     
-    @Query(value = "SELECT * FROM PATIENT WHERE PAT_NAME = :name AND (PAT_DELETED='N' OR PAT_DELETED IS NULL) ORDER BY PAT_SNAME,PAT_FNAME", nativeQuery= true)
-    List<Patient> findAllWhereNameAndDeletedOrderedByName(@Param("name") String name);
+    @Query("select p from Patient p where p.name = :name and (p.deleted = :deletedStatus or p.deleted is null) order by p.secondName, p.firstName")
+	List<Patient> findByNameAndDeletedOrderByName(@Param("name") String name, @Param("deletedStatus") String deletedStatus);
 
-    @Query(value = "SELECT * FROM PATIENT WHERE PAT_ID = :id AND (PAT_DELETED='N' OR PAT_DELETED IS NULL)", nativeQuery= true)
-    List<Patient> findAllWhereIdAndDeleted(@Param("id") Integer id);
+	@Query("select p from Patient p where p.code = :id and (p.deleted = :deletedStatus or p.deleted is null)")
+	List<Patient> findAllWhereIdAndDeleted(@Param("id") Integer id, @Param("deletedStatus") String deletedStatus);
     
-    @Query(value = "SELECT * FROM PATIENT WHERE PAT_ID = :id", nativeQuery= true)
-    List<Patient> findAllWhereId(@Param("id") Integer id);
+    List<Patient> findByCode(Integer id);
     
     @Modifying
     @Transactional
@@ -48,51 +39,6 @@ public interface PatientIoOperationRepository extends JpaRepository<Patient, Int
 
     @Query(value = "SELECT MAX(PAT_ID) FROM PATIENT", nativeQuery= true)
     Integer findMaxCode();
-        
-    @Modifying
-    @Transactional
-    @Query(value = "UPDATE ADMISSION SET ADM_PAT_ID = :new_id WHERE ADM_PAT_ID = :old_id", nativeQuery= true)
-    int updateAdmission(@Param("new_id") Integer new_id, @Param("old_id") Integer old_id);
-
-    @Modifying
-    @Transactional
-    @Query(value = "UPDATE PATIENTEXAMINATION SET PEX_PAT_ID = :new_id WHERE PEX_PAT_ID = :old_id", nativeQuery= true)
-    int updateExamination(@Param("new_id") Integer new_id, @Param("old_id") Integer old_id);
-    
-    @Modifying
-    @Transactional
-    @Query(value = "UPDATE LABORATORY SET LAB_PAT_ID = :new_id, LAB_PAT_NAME = :name, LAB_AGE = :age, LAB_SEX = :sex WHERE LAB_PAT_ID = :old_id", nativeQuery= true)
-    int updateLaboratory(@Param("new_id") Integer new_id, @Param("name") String name, @Param("age") Integer age, @Param("sex") String sex, @Param("old_id") Integer old_id);
-
-    @Modifying
-    @Transactional
-    @Query(value = "UPDATE OPD SET OPD_PAT_ID = :new_id, OPD_AGE = :age, OPD_SEX = :sex WHERE OPD_PAT_ID = :old_id", nativeQuery= true)
-    int updateOpd(@Param("new_id") Integer new_id, @Param("age") Integer age, @Param("sex") String sex, @Param("old_id") Integer old_id);
-    
-    @Modifying
-    @Transactional
-    @Query(value = "UPDATE BILLS SET BLL_ID_PAT = :new_id, BLL_PAT_NAME = :name WHERE BLL_ID_PAT = :old_id", nativeQuery= true)
-    int updateBill(@Param("new_id") Integer new_id, @Param("name") String name, @Param("old_id") Integer old_id);
-	
-    @Modifying
-    @Transactional
-    @Query(value = "UPDATE MEDICALDSRSTOCKMOVWARD SET MMVN_PAT_ID = :new_id WHERE MMVN_PAT_ID = :old_id", nativeQuery= true)
-    int updateMedicalStock(@Param("new_id") Integer new_id, @Param("old_id") Integer old_id);
-    
-    @Modifying
-    @Transactional
-    @Query(value = "UPDATE THERAPIES SET THR_PAT_ID = :new_id WHERE THR_PAT_ID = :old_id", nativeQuery= true)
-    int updateTherapy(@Param("new_id") Integer new_id, @Param("old_id") Integer old_id);
-	
-    @Modifying
-    @Transactional
-    @Query(value = "UPDATE VISITS SET VST_PAT_ID = :new_id WHERE VST_PAT_ID = :old_id", nativeQuery= true)
-    int updateVisit(@Param("new_id") Integer new_id, @Param("old_id") Integer old_id);
-
-    @Modifying
-    @Transactional
-    @Query(value = "UPDATE PATIENTVACCINE SET PAV_PAT_ID = :new_id WHERE PAV_PAT_ID = :old_id", nativeQuery= true)
-    int updatePatientVaccine(@Param("new_id") Integer new_id, @Param("old_id") Integer old_id);
  		
     @Modifying
     @Transactional

--- a/src/org/isf/patient/service/PatientIoOperationRepository.java
+++ b/src/org/isf/patient/service/PatientIoOperationRepository.java
@@ -27,17 +27,12 @@ public interface PatientIoOperationRepository extends JpaRepository<Patient, Int
     
     @Modifying
     @Transactional
-    @Query(value = "UPDATE PATIENT SET PAT_DELETED = 'Y' WHERE PAT_ID = :id", nativeQuery = true)
+    @Query(value = "update Patient p set p.deleted = 'Y' where p.code = :id")
     int updateDeleted(@Param("id") Integer id);
             
     List<Patient> findByNameAndDeleted(String name, String deletedStatus);
 
     @Query(value = "select max(p.code) from Patient p")
     Integer findMaxCode();
- 		
-    @Modifying
-    @Transactional
-    @Query(value = "UPDATE Patient p SET p.deleted = 'Y' WHERE p.code = :id")
-    int updateDelete(@Param("id") Integer id); 		
 
 }

--- a/src/org/isf/patient/service/PatientIoOperationRepositoryCustom.java
+++ b/src/org/isf/patient/service/PatientIoOperationRepositoryCustom.java
@@ -1,11 +1,13 @@
 package org.isf.patient.service;
 
 
+import org.isf.patient.model.Patient;
+
 import java.util.List;
 
 
 public interface PatientIoOperationRepositoryCustom {
 
-	List<Integer> findAllByHeightAndWeight(String regex);
+	List<Patient> findByFieldsContainingWordsFromLiteral(String regex);
 	
 }

--- a/src/org/isf/patient/service/PatientIoOperationRepositoryImpl.java
+++ b/src/org/isf/patient/service/PatientIoOperationRepositoryImpl.java
@@ -5,7 +5,12 @@ import java.util.List;
 
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
+import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.CriteriaQuery;
+import javax.persistence.criteria.Predicate;
+import javax.persistence.criteria.Root;
 
+import org.isf.patient.model.Patient;
 import org.springframework.transaction.annotation.Transactional;
 
 
@@ -18,33 +23,23 @@ public class PatientIoOperationRepositoryImpl implements PatientIoOperationRepos
 	
 	@SuppressWarnings("unchecked")	
 	@Override
-	public List<Integer> findAllByHeightAndWeight(String regex) {
+	public List<Patient> findByFieldsContainingWordsFromLiteral(String literal) {
 		return this.entityManager.
-				createNativeQuery(_getPatientsWithHeightAndWeightQueryByRegex(regex)).
+				createQuery(buildSearchQuery(literal)).
 					getResultList();
 	}	
 
 	
-	private String _getPatientsWithHeightAndWeightQueryByRegex(
-			String regex) 
-	{
-		String[] words = _getPatientsWithHeightAndWeightRegex(regex);
-		String query = _getPatientsWithHeightAndWeightQuery(words);
-		
-		
-		return query;
+	private CriteriaQuery<Patient> buildSearchQuery(String regex) {
+		String[] words = getWordsToSearchForInPatientsRepository(regex);
+		return createQuerySearchingForPatientContainingGivenWordsInHisProperties(words);
 	}
 	
-	private String[] _getPatientsWithHeightAndWeightRegex(
-			String regex) 
-	{
+	private String[] getWordsToSearchForInPatientsRepository(String regex)	{
 		String string = null;
 		String[] words = new String[0];
-		
-		
-		if ((regex != null) 
-			&& (!regex.equals(""))) 
-		{
+
+		if ((regex != null) && (!regex.equals(""))) {
 			string = regex.trim().toLowerCase();
 			words = string.split(" ");
 		}
@@ -52,21 +47,32 @@ public class PatientIoOperationRepositoryImpl implements PatientIoOperationRepos
 		return words;
 	}
 		
-	private String _getPatientsWithHeightAndWeightQuery(
-			String[] words)
-	{
-		StringBuilder queryBld = new StringBuilder(
-				"SELECT PAT_ID FROM PATIENT LEFT JOIN (SELECT PEX_PAT_ID, PEX_HEIGHT AS PAT_HEIGHT, "
-				+ "PEX_WEIGHT AS PAT_WEIGHT FROM PATIENTEXAMINATION GROUP BY PEX_PAT_ID ORDER BY PEX_DATE DESC) "
-				+ "AS HW ON PAT_ID = HW.PEX_PAT_ID WHERE (PAT_DELETED='N' or PAT_DELETED is null) ");
+	private CriteriaQuery<Patient> createQuerySearchingForPatientContainingGivenWordsInHisProperties(String[] words)	{
+		CriteriaBuilder cb = entityManager.getCriteriaBuilder();
+		CriteriaQuery<Patient> query = cb.createQuery(Patient.class);
+		Root<Patient> patientRoot = query.from(Patient.class);
+		query.select(patientRoot);
 
+		for (String word : words) {
+			query.where(wordExistsInOneOfPatientFields(word, cb, patientRoot));
+		}
 
-        for (String word : words) {
-            queryBld.append("AND CONCAT_WS(PAT_ID, LOWER(PAT_SNAME), LOWER(PAT_FNAME), LOWER(PAT_NOTE), LOWER(PAT_TAXCODE)) ");
-            queryBld.append("LIKE CONCAT('%', \"" + word + "\" , '%') ");
-        }
-		queryBld.append(" ORDER BY PAT_ID DESC");
+		query.orderBy(cb.desc(patientRoot.get("code")));
 
-		return queryBld.toString();
+		return query;
+	}
+
+	private Predicate wordExistsInOneOfPatientFields(String word, CriteriaBuilder cb, Root<Patient> root) {
+		return cb.or(
+			cb.like(cb.lower(root.get("code").as(String.class)), like(word)),
+			cb.like(cb.lower(root.get("secondName").as(String.class)), like(word)),
+			cb.like(cb.lower(root.get("firstName").as(String.class)), like(word)),
+			cb.like(cb.lower(root.get("note").as(String.class)), like(word)),
+			cb.like(cb.lower(root.get("taxCode").as(String.class)), like(word))
+		);
+	}
+
+	private String like(String word) {
+		return "%" + word + "";
 	}
 }

--- a/src/org/isf/patient/service/PatientIoOperations.java
+++ b/src/org/isf/patient/service/PatientIoOperations.java
@@ -172,7 +172,7 @@ public class PatientIoOperations
 	 */
 	@Transactional
 	public boolean mergePatientHistory(Patient mergedPatient, Patient obsoletePatient) throws OHServiceException {
-		repository.updateDelete(obsoletePatient.getCode());
+		repository.updateDeleted(obsoletePatient.getCode());
 		applicationEventPublisher.publishEvent(new PatientMergedEvent(obsoletePatient, mergedPatient));
 		
 		return true;

--- a/src/org/isf/patient/service/PatientIoOperations.java
+++ b/src/org/isf/patient/service/PatientIoOperations.java
@@ -1,11 +1,5 @@
 package org.isf.patient.service;
 
-import java.awt.Graphics;
-import java.awt.Image;
-import java.awt.image.BufferedImage;
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-
 /*------------------------------------------
  * IoOperations - dB operations for the patient entity
  * -----------------------------------------
@@ -22,13 +16,11 @@ import java.io.IOException;
  *------------------------------------------*/
 
 import java.util.ArrayList;
-
-import javax.imageio.ImageIO;
+import java.util.List;
 
 import org.isf.patient.model.Patient;
 import org.isf.patient.model.PatientMergedEvent;
 import org.isf.utils.db.TranslateOHServiceException;
-import org.isf.utils.exception.OHException;
 import org.isf.utils.exception.OHServiceException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationEventPublisher;
@@ -54,14 +46,8 @@ public class PatientIoOperations
 	 * @return the list of patients
 	 * @throws OHServiceException
 	 */
-	public ArrayList<Patient> getPatients() throws OHServiceException 
-	{
-		ArrayList<Patient> pPatient = null;
-		
-		
-		pPatient = new ArrayList<Patient>(repository.findByDeletedOrDeletedIsNull(NOT_DELETED_STATUS));
-					
-		return pPatient;
+	public ArrayList<Patient> getPatients() throws OHServiceException {
+		return new ArrayList<Patient>(repository.findByDeletedOrDeletedIsNull(NOT_DELETED_STATUS));
 	}
 	
 	/**
@@ -70,14 +56,8 @@ public class PatientIoOperations
 	 * @return the list of patients
 	 * @throws OHServiceException
 	 */
-	public ArrayList<Patient> getPatients(Pageable pageable) throws OHServiceException 
-	{
-		ArrayList<Patient> pPatient = null;
-		
-		
-		pPatient = new ArrayList<Patient>(repository.findAllByDeletedIsNullOrDeletedEqualsOrderByName("N", pageable));
-					
-		return pPatient;
+	public ArrayList<Patient> getPatients(Pageable pageable) throws OHServiceException {
+		return new ArrayList<Patient>(repository.findAllByDeletedIsNullOrDeletedEqualsOrderByName("N", pageable));
 	}
 
 	/**
@@ -87,24 +67,8 @@ public class PatientIoOperations
 	 * @return the full list of Patients with Height and Weight
 	 * @throws OHServiceException
 	 */
-	public ArrayList<Patient> getPatientsWithHeightAndWeight(
-			String regex) throws OHServiceException 
-	{
-		ArrayList<Integer> pPatientCode = null;
-		ArrayList<Patient> pPatient = new ArrayList<Patient>();
-		
-		
-		pPatientCode = new ArrayList<Integer>(repository.findAllByHeightAndWeight(regex));			
-		for (int i=0; i<pPatientCode.size(); i++)
-		{
-			Integer code = pPatientCode.get(i);
-			Patient patient = repository.findOne(code);
-			
-			
-			pPatient.add(i, patient);
-		}
-					
-		return pPatient;
+	public ArrayList<Patient> getPatientsByOneOfFieldsLike(String regex) throws OHServiceException {
+		return new ArrayList<Patient>(repository.findByFieldsContainingWordsFromLiteral(regex));
 	}	
 
 	/**
@@ -114,20 +78,9 @@ public class PatientIoOperations
 	 * @return the Patient that match specified name
 	 * @throws OHServiceException
 	 */
-	public Patient getPatient(
-			String name) throws OHServiceException 
-	{
-		ArrayList<Patient> pPatient = null;
-		Patient patient = null;	
-		
-		
-		pPatient = new ArrayList<Patient>(repository.findByNameAndDeletedOrderByName(name, NOT_DELETED_STATUS));
-		if (pPatient.size() > 0)
-		{			
-			patient = pPatient.get(pPatient.size()-1);			
-		}
-					
-		return patient;
+	public Patient getPatient(String name) throws OHServiceException {
+		List<Patient> patients = repository.findByNameAndDeletedOrderByName(name, NOT_DELETED_STATUS);
+		return patients.size() > 0 ? patients.get(patients.size()-1) : null;
 	}
 
 	/**
@@ -137,20 +90,9 @@ public class PatientIoOperations
 	 * @return the Patient
 	 * @throws OHServiceException
 	 */
-	public Patient getPatient(
-			Integer code) throws OHServiceException 
-	{
-		ArrayList<Patient> pPatient = null;
-		Patient patient = null;	
-		
-		
-		pPatient = new ArrayList<Patient>(repository.findAllWhereIdAndDeleted(code, NOT_DELETED_STATUS));
-		if (pPatient.size() > 0)
-		{			
-			patient = pPatient.get(pPatient.size()-1);			
-		}
-					
-		return patient;
+	public Patient getPatient(Integer code) throws OHServiceException {
+		List<Patient> patients = repository.findAllWhereIdAndDeleted(code, NOT_DELETED_STATUS);
+		return patients.size() > 0 ? patients.get(patients.size()-1) : null;
 	}
 
 	/**
@@ -160,20 +102,8 @@ public class PatientIoOperations
 	 * @return the list of Patients
 	 * @throws OHServiceException
 	 */
-	public Patient getPatientAll(
-			Integer code) throws OHServiceException 
-	{
-		ArrayList<Patient> pPatient = null;
-		Patient patient = null;	
-		
-		
-		pPatient = new ArrayList<Patient>(repository.findByCode(code));
-		if (pPatient.size() > 0)
-		{			
-			patient = pPatient.get(pPatient.size()-1);			
-		}
-					
-		return patient;
+	public Patient getPatientAll(Integer code) throws OHServiceException {
+		return repository.findOne(code);
 	}
 
 	/**
@@ -183,16 +113,8 @@ public class PatientIoOperations
 	 * @return true - if the new Patient has been inserted
 	 * @throws OHServiceException
 	 */
-	public boolean newPatient(
-			Patient patient) throws OHServiceException 
-	{
-		boolean result = true;
-	
-
-		Patient patientVaccine = repository.save(patient);
-		result = (patientVaccine != null);
-		
-		return result;
+	public boolean newPatient(Patient patient) throws OHServiceException {
+		return repository.save(patient) != null;
 	}
 	
 	/**
@@ -203,54 +125,11 @@ public class PatientIoOperations
 	 * @return true - if the existing {@link Patient} has been updated
 	 * @throws OHServiceException
 	 */
-	public boolean updatePatient(
-			Patient patient) throws OHServiceException 
-	{
-		int lock = 0;
-		boolean result = false;
-				
-
-		if (repository.updateLockByCode(
-				patient.getFirstName(), patient.getSecondName(), patient.getName(),
-				patient.getBirthDate(), patient.getAge(), patient.getAgetype(), patient.getSex(), patient.getAddress(), patient.getCity(),
-				patient.getNextKin(), patient.getTelephone(), patient.getMother(), patient.getMother_name(),
-				patient.getFather(), patient.getFather_name(), patient.getBloodType(), patient.getHasInsurance(), patient.getParentTogether(),
-				patient.getNote(), patient.getTaxCode(), (lock + 1), _createPatientPhotoInputStream(patient.getPhoto()),
-				patient.getCode()) > 0)
-		{
-			result = true;
-		}
-	
-		return result;
+	public boolean updatePatient(Patient patient) throws OHServiceException {
+		repository.save(patient);
+		return true;
 	}
-	
-	private byte[] _createPatientPhotoInputStream(
-			Image anImage) 
-	{
-		byte[] byteArray = null;
-		
-		try {
-			// Paint the image onto the buffered image
-			BufferedImage bu = new BufferedImage(anImage.getWidth(null), anImage.getHeight(null), BufferedImage.TYPE_INT_RGB);
-			Graphics g = bu.createGraphics();
-			g.drawImage(anImage, 0, 0, null);
-			g.dispose();
-			// Create the ByteArrayOutputStream
-			ByteArrayOutputStream outStream = new ByteArrayOutputStream();
 
-			ImageIO.write(bu, "jpg", outStream);
-			
-			if (outStream != null) byteArray = outStream.toByteArray();
-			
-		} catch (IOException ioe) {
-			//TODO: handle exception
-		} catch (Exception ioe) {
-			//TODO: handle exception
-		}
-		
-		return byteArray;
-	}
-	
 	/**
 	 * method that logically delete a Patient (not physically deleted)
 	 * 
@@ -258,20 +137,8 @@ public class PatientIoOperations
 	 * @return true - if the Patient has been deleted (logically)
 	 * @throws OHServiceException
 	 */
-	public boolean deletePatient(
-			Patient patient) throws OHServiceException 
-	{
-		boolean result = false;
-		int updates = 0;
-		
-	
-		updates = repository.updateDeleted(patient.getCode());
-		if (updates > 0)
-		{
-			result = true;
-		} 
-		
-		return result;
+	public boolean deletePatient(Patient patient) throws OHServiceException {
+		return repository.updateDeleted(patient.getCode()) > 0;
 	}
 
 	/**
@@ -281,22 +148,8 @@ public class PatientIoOperations
 	 * @return true - if the patient is already present
 	 * @throws OHServiceException
 	 */
-	public boolean isPatientPresent(
-			String name) throws OHServiceException 
-	{
-		boolean result = false;
-		
-		
-		ArrayList<Patient> pPatient = null;
-		
-		
-		pPatient = new ArrayList<Patient>(repository.findAllWhereName(name));
-		if (pPatient.size() > 0)
-		{			
-			result = true;				
-		}
-					
-		return result;
+	public boolean isPatientPresent(String name) throws OHServiceException {
+		return repository.findByNameAndDeleted(name, NOT_DELETED_STATUS).size() > 0;
 	}
 
 	/**
@@ -305,11 +158,8 @@ public class PatientIoOperations
 	 * @return code
 	 * @throws OHServiceException
 	 */
-	public int getNextPatientCode() throws OHServiceException 
-	{
-		Integer code = repository.findMaxCode();
-
-		return (code + 1);
+	public int getNextPatientCode() throws OHServiceException {
+		return repository.findMaxCode() + 1;
 	}
 
 	/**
@@ -338,47 +188,5 @@ public class PatientIoOperations
 	public boolean isCodePresent(Integer code) throws OHServiceException {
 		return repository.exists(code);
 	}
-	/**
-	 * Get the patient list filter by head patient
-	 * @return patient list
-	 * @throws OHException
-	 */
-	
-	public ArrayList<Patient> getPatientsHeadWithHeightAndWeight() throws OHException {
-		
-		 ArrayList<Patient> pPatient = repository.getPatientsHeadWithHeightAndWeight();
-		
-		
-		// Recupera i pazienti arricchiti con Peso e Altezza
-		//StringBuilder queryBld = new StringBuilder(
-		//		"SELECT * FROM PATIENT LEFT JOIN (SELECT PEX_PAT_ID, PEX_HEIGHT AS PAT_HEIGHT, PEX_WEIGHT AS PAT_WEIGHT FROM PATIENTEXAMINATION GROUP BY PEX_PAT_ID ORDER BY PEX_DATE DESC) AS HW ON PAT_ID = HW.PEX_PAT_ID WHERE (PAT_DELETED='N' or PAT_DELETED is null) ");
 
-		/***** filter only head patient *****/
-		//queryBld.append(" AND (PAT_AFFILIATED_PERSON < 1 OR PAT_AFFILIATED_PERSON is null)");
-		//queryBld.append(" AND (PAT_IS_HEAD_AFFILIATION = 1)");
-		/*** *******/
-		/*queryBld.append(" ORDER BY PAT_ID DESC");
-		DbQueryLogger dbQuery = new DbQueryLogger();
-		try {
-			ResultSet resultSet = dbQuery.getDataWithParams(queryBld.toString(), params, true);
-			pPatient = new ArrayList<Patient>(resultSet.getFetchSize());
-			Patient patient;
-			while (resultSet.next()) {
-				patient = this.buildPatient(resultSet);
-				pPatient.add(patient);
-			}
-		} catch (SQLException e) {
-			throw new OHException(MessageBundle.getMessage("angal.sql.problemsoccurredwiththesqlistruction"), e);
-		}
-		// catch (IOException e) {
-		// throw new OHException(
-		// MessageBundle
-		// .getMessage("angal.sql.problemsoccurredwithserverconnection"),
-		// e);
-		// }
-		finally {
-			//dbQuery.releaseConnection();
-		} */
-		return pPatient;
-	}
 }

--- a/src/org/isf/patient/test/MergePatientTests.java
+++ b/src/org/isf/patient/test/MergePatientTests.java
@@ -1,26 +1,10 @@
 package org.isf.patient.test;
 
-import org.isf.accounting.test.TestBill;
-import org.isf.accounting.test.TestBillContext;
-import org.isf.admission.test.TestAdmission;
-import org.isf.admission.test.TestAdmissionContext;
 import org.isf.examination.model.PatientExamination;
 import org.isf.examination.test.TestPatientExamination;
 import org.isf.examination.test.TestPatientExaminationContext;
-import org.isf.lab.test.TestLaboratory;
-import org.isf.lab.test.TestLaboratoryContext;
-import org.isf.medicalstockward.test.TestMovementWard;
-import org.isf.medicalstockward.test.TestMovementWardContext;
-import org.isf.opd.test.TestOpd;
-import org.isf.opd.test.TestOpdContext;
 import org.isf.patient.model.Patient;
 import org.isf.patient.service.PatientIoOperations;
-import org.isf.patvac.test.TestPatientVaccine;
-import org.isf.patvac.test.TestPatientVaccineContext;
-import org.isf.priceslist.test.TestPriceList;
-import org.isf.priceslist.test.TestPriceListContext;
-import org.isf.therapy.test.TestTherapy;
-import org.isf.therapy.test.TestTherapyContext;
 import org.isf.utils.db.DbJpaUtil;
 import org.isf.utils.exception.OHException;
 import org.isf.utils.exception.OHServiceException;
@@ -34,6 +18,7 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringRunner;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 @RunWith(SpringRunner.class)
 @ContextConfiguration(locations = { "classpath:applicationContext.xml" })
@@ -41,26 +26,10 @@ public class MergePatientTests {
 	private static DbJpaUtil jpa;
 	private static TestPatient testPatient;
 	private static TestPatientContext testPatientContext;
-	private static TestAdmission testAdmission;
-	private static TestAdmissionContext testAdmissionContext;
 	private static TestPatientExamination testPatientExamination;
 	private static TestPatientExaminationContext testPatientExaminationContext;
-	private static TestLaboratory testLaboratory;
-	private static TestLaboratoryContext testLaboratoryContext;
-	private static TestOpd testOpd;
-	private static TestOpdContext testOpdContext;
-	private static TestBill testBill;
-	private static TestBillContext testBillContext;
-	private static TestPriceList testPriceList;
-	private static TestPriceListContext testPriceListContext;
-	private static TestMovementWard testMovementWard;
-	private static TestMovementWardContext testMovementWardContext;
-	private static TestTherapy testTherapy;
-	private static TestTherapyContext testTherapyContext;
 	private static TestVisit testVisit;
 	private static TestVisitContext testVisitContext;
-	private static TestPatientVaccine testPatientVaccine;
-	private static TestPatientVaccineContext testPatientVaccineContext;
 
 	@Autowired
 	PatientIoOperations patientIoOperation;
@@ -72,42 +41,21 @@ public class MergePatientTests {
 		jpa = new DbJpaUtil();
 		testPatient = new TestPatient();
 		testPatientContext = new TestPatientContext();
-		testAdmission = new TestAdmission();
-		testAdmissionContext = new TestAdmissionContext();
 		testPatientExamination = new TestPatientExamination();
 		testPatientExaminationContext = new TestPatientExaminationContext();
-		testLaboratory = new TestLaboratory();
-		testLaboratoryContext = new TestLaboratoryContext();
-		testOpd = new TestOpd();
-		testOpdContext = new TestOpdContext();
-		testBill = new TestBill();
-		testBillContext = new TestBillContext();
-		testPriceList = new TestPriceList();
-		testPriceListContext = new TestPriceListContext();
-		testMovementWard = new TestMovementWard();
-		testMovementWardContext = new TestMovementWardContext();
-		testTherapy = new TestTherapy();
-		testTherapyContext = new TestTherapyContext();
 		testVisit = new TestVisit();
 		testVisitContext = new TestVisitContext();
-		testPatientVaccine = new TestPatientVaccine();
-		testPatientVaccineContext = new TestPatientVaccineContext();
 	}
 
 	@Before
 	public void setUp() throws OHException {
 		jpa.open();
-
 		_saveContext();
-
-		return;
 	}
 
 	@After
-	public void tearDown() throws Exception
-	{
+	public void tearDown() throws Exception	{
 		_restoreContext();
-
 		jpa.flush();
 		jpa.close();
 
@@ -122,36 +70,15 @@ public class MergePatientTests {
 
 	private void _saveContext() throws OHException {
 		testPatientContext.saveAll(jpa);
-		//testAdmissionContext.saveAll(jpa);
 		testPatientExaminationContext.saveAll(jpa);
-		/*
-		testLaboratoryContext.saveAll(jpa);
-		testOpdContext.saveAll(jpa);
-		testBillContext.saveAll(jpa);
-		testPriceListContext.saveAll(jpa);
-		testMovementWardContext.saveAll(jpa);
-		testTherapyContext.saveAll(jpa);
-
-		 */
 		testVisitContext.saveAll(jpa);
-		//testPatientVaccineContext.saveAll(jpa);
 	}
 
 	private void _restoreContext() throws OHException {
 		testPatientContext.deleteNews(jpa);
-		//testAdmissionContext.deleteNews(jpa);
 		testPatientExaminationContext.deleteNews(jpa);
-		/*
-		testLaboratoryContext.deleteNews(jpa);
-		testOpdContext.deleteNews(jpa);
-		testBillContext.deleteNews(jpa);
-		testPriceListContext.deleteNews(jpa);
-		testMovementWardContext.deleteNews(jpa);
-		testTherapyContext.deleteNews(jpa);
-
-		 */
 		testVisitContext.deleteNews(jpa);
-		//testPatientVaccineContext.deleteNews(jpa);
+		testPatientMergedEventListener.setShouldFail(false);
 	}
 
 	public void testShouldRollbackWholeMergeWhenOneOperationFails() {
@@ -185,6 +112,38 @@ public class MergePatientTests {
 		}
 	}
 
+	@Test
+	public void testWholeMergeOperationShouldBeRolledBackWhenOneOfUpdateOperationsFails() throws OHException, OHServiceException {
+		try {
+			// given:
+			jpa.beginTransaction();
+			Patient mergedPatient = testPatient.setup(false);
+			jpa.persist(mergedPatient);
+			Patient obsoletePatient = testPatient.setup(false);
+			jpa.persist(obsoletePatient);
+			jpa.commitTransaction();
+			Visit visit = setupVisitAndAssignPatient(obsoletePatient);
+			PatientExamination patientExamination = setupPatientExaminationAndAssignPatient(obsoletePatient);
+			testPatientMergedEventListener.setShouldFail(true);
+
+			// when:
+			try {
+				patientIoOperation.mergePatientHistory(mergedPatient, obsoletePatient);
+			} catch (Exception e) {
+
+			}
+
+			// then:
+			assertThatObsoletePatientWasNotDeletedAndIsTheActiveOne(mergedPatient);
+			assertThatVisitIsStillAssignedToObsoletePatient(visit, obsoletePatient);
+			assertThatExaminationIsStillAssignedToObsoletePatient(patientExamination, obsoletePatient);
+			assertThatPatientMergedEventWasSent(mergedPatient, obsoletePatient);
+		} catch (Exception e) {
+			e.printStackTrace();
+			assertEquals(true, false);
+		}
+	}
+
 	private void assertThatObsoletePatientWasDeletedAndMergedIsTheActiveOne(Patient mergedPatient, Patient obsoletePatient) throws OHException {
 		Patient mergedPatientResult = (Patient) jpa.find(Patient.class, mergedPatient.getCode());
 		Patient obsoletePatientResult = (Patient) jpa.find(Patient.class, obsoletePatient.getCode());
@@ -192,14 +151,29 @@ public class MergePatientTests {
 		assertEquals("N", mergedPatientResult.getDeleted());
 	}
 
+	private void assertThatObsoletePatientWasNotDeletedAndIsTheActiveOne(Patient obsoletePatient) throws OHException {
+		Patient obsoletePatientResult = (Patient) jpa.find(Patient.class, obsoletePatient.getCode());
+		assertEquals("N", obsoletePatientResult.getDeleted());
+	}
+
 	private void assertThatVisitWasMovedFromObsoleteToMergedPatient(Visit visit, Patient mergedPatient) throws OHException {
 		Visit visitResult = (Visit) jpa.find(Visit.class, visit.getVisitID());
 		assertEquals(mergedPatient.getCode(), visitResult.getPatient().getCode());
 	}
 
+	private void assertThatVisitIsStillAssignedToObsoletePatient(Visit visit, Patient obsoletePatient) throws OHException {
+		Visit visitResult = (Visit) jpa.find(Visit.class, visit.getVisitID());
+		assertEquals(obsoletePatient.getCode(), visitResult.getPatient().getCode());
+	}
+
 	private void assertThatExaminationWasMovedFromObsoleteToMergedPatient(PatientExamination examination, Patient mergedPatient) throws OHException {
 		PatientExamination patientResult = (PatientExamination) jpa.find(PatientExamination.class, examination.getPex_ID());
 		assertEquals(mergedPatient.getCode(), patientResult.getPatient().getCode());
+	}
+
+	private void assertThatExaminationIsStillAssignedToObsoletePatient(PatientExamination patientExamination, Patient obsoletePatient) throws OHException {
+		PatientExamination patientResult = (PatientExamination) jpa.find(PatientExamination.class, patientExamination.getPex_ID());
+		assertEquals(obsoletePatient.getCode(), patientResult.getPatient().getCode());
 	}
 
 	private void assertThatPatientMergedEventWasSent(Patient mergedPatient, Patient obsoletePatient) {

--- a/src/org/isf/patient/test/MergePatientTests.java
+++ b/src/org/isf/patient/test/MergePatientTests.java
@@ -1,0 +1,225 @@
+package org.isf.patient.test;
+
+import org.isf.accounting.test.TestBill;
+import org.isf.accounting.test.TestBillContext;
+import org.isf.admission.test.TestAdmission;
+import org.isf.admission.test.TestAdmissionContext;
+import org.isf.examination.model.PatientExamination;
+import org.isf.examination.test.TestPatientExamination;
+import org.isf.examination.test.TestPatientExaminationContext;
+import org.isf.lab.test.TestLaboratory;
+import org.isf.lab.test.TestLaboratoryContext;
+import org.isf.medicalstockward.test.TestMovementWard;
+import org.isf.medicalstockward.test.TestMovementWardContext;
+import org.isf.opd.test.TestOpd;
+import org.isf.opd.test.TestOpdContext;
+import org.isf.patient.model.Patient;
+import org.isf.patient.service.PatientIoOperations;
+import org.isf.patvac.test.TestPatientVaccine;
+import org.isf.patvac.test.TestPatientVaccineContext;
+import org.isf.priceslist.test.TestPriceList;
+import org.isf.priceslist.test.TestPriceListContext;
+import org.isf.therapy.test.TestTherapy;
+import org.isf.therapy.test.TestTherapyContext;
+import org.isf.utils.db.DbJpaUtil;
+import org.isf.utils.exception.OHException;
+import org.isf.utils.exception.OHServiceException;
+import org.isf.visits.model.Visit;
+import org.isf.visits.test.TestVisit;
+import org.isf.visits.test.TestVisitContext;
+import org.junit.*;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(SpringRunner.class)
+@ContextConfiguration(locations = { "classpath:applicationContext.xml" })
+public class MergePatientTests {
+	private static DbJpaUtil jpa;
+	private static TestPatient testPatient;
+	private static TestPatientContext testPatientContext;
+	private static TestAdmission testAdmission;
+	private static TestAdmissionContext testAdmissionContext;
+	private static TestPatientExamination testPatientExamination;
+	private static TestPatientExaminationContext testPatientExaminationContext;
+	private static TestLaboratory testLaboratory;
+	private static TestLaboratoryContext testLaboratoryContext;
+	private static TestOpd testOpd;
+	private static TestOpdContext testOpdContext;
+	private static TestBill testBill;
+	private static TestBillContext testBillContext;
+	private static TestPriceList testPriceList;
+	private static TestPriceListContext testPriceListContext;
+	private static TestMovementWard testMovementWard;
+	private static TestMovementWardContext testMovementWardContext;
+	private static TestTherapy testTherapy;
+	private static TestTherapyContext testTherapyContext;
+	private static TestVisit testVisit;
+	private static TestVisitContext testVisitContext;
+	private static TestPatientVaccine testPatientVaccine;
+	private static TestPatientVaccineContext testPatientVaccineContext;
+
+	@Autowired
+	PatientIoOperations patientIoOperation;
+	@Autowired
+	TestPatientMergedEventListener testPatientMergedEventListener;
+
+	@BeforeClass
+	public static void setUpClass()	{
+		jpa = new DbJpaUtil();
+		testPatient = new TestPatient();
+		testPatientContext = new TestPatientContext();
+		testAdmission = new TestAdmission();
+		testAdmissionContext = new TestAdmissionContext();
+		testPatientExamination = new TestPatientExamination();
+		testPatientExaminationContext = new TestPatientExaminationContext();
+		testLaboratory = new TestLaboratory();
+		testLaboratoryContext = new TestLaboratoryContext();
+		testOpd = new TestOpd();
+		testOpdContext = new TestOpdContext();
+		testBill = new TestBill();
+		testBillContext = new TestBillContext();
+		testPriceList = new TestPriceList();
+		testPriceListContext = new TestPriceListContext();
+		testMovementWard = new TestMovementWard();
+		testMovementWardContext = new TestMovementWardContext();
+		testTherapy = new TestTherapy();
+		testTherapyContext = new TestTherapyContext();
+		testVisit = new TestVisit();
+		testVisitContext = new TestVisitContext();
+		testPatientVaccine = new TestPatientVaccine();
+		testPatientVaccineContext = new TestPatientVaccineContext();
+	}
+
+	@Before
+	public void setUp() throws OHException {
+		jpa.open();
+
+		_saveContext();
+
+		return;
+	}
+
+	@After
+	public void tearDown() throws Exception
+	{
+		_restoreContext();
+
+		jpa.flush();
+		jpa.close();
+
+		return;
+	}
+
+	@AfterClass
+	public static void tearDownClass() throws OHException
+	{
+		return;
+	}
+
+	private void _saveContext() throws OHException {
+		testPatientContext.saveAll(jpa);
+		//testAdmissionContext.saveAll(jpa);
+		testPatientExaminationContext.saveAll(jpa);
+		/*
+		testLaboratoryContext.saveAll(jpa);
+		testOpdContext.saveAll(jpa);
+		testBillContext.saveAll(jpa);
+		testPriceListContext.saveAll(jpa);
+		testMovementWardContext.saveAll(jpa);
+		testTherapyContext.saveAll(jpa);
+
+		 */
+		testVisitContext.saveAll(jpa);
+		//testPatientVaccineContext.saveAll(jpa);
+	}
+
+	private void _restoreContext() throws OHException {
+		testPatientContext.deleteNews(jpa);
+		//testAdmissionContext.deleteNews(jpa);
+		testPatientExaminationContext.deleteNews(jpa);
+		/*
+		testLaboratoryContext.deleteNews(jpa);
+		testOpdContext.deleteNews(jpa);
+		testBillContext.deleteNews(jpa);
+		testPriceListContext.deleteNews(jpa);
+		testMovementWardContext.deleteNews(jpa);
+		testTherapyContext.deleteNews(jpa);
+
+		 */
+		testVisitContext.deleteNews(jpa);
+		//testPatientVaccineContext.deleteNews(jpa);
+	}
+
+	public void testShouldRollbackWholeMergeWhenOneOperationFails() {
+
+	}
+
+	@Test
+	public void testMergePatientHistory() throws OHException, OHServiceException {
+		try {
+			// given:
+			jpa.beginTransaction();
+			Patient mergedPatient = testPatient.setup(false);
+			jpa.persist(mergedPatient);
+			Patient obsoletePatient = testPatient.setup(false);
+			jpa.persist(obsoletePatient);
+			jpa.commitTransaction();
+			Visit visit = setupVisitAndAssignPatient(obsoletePatient);
+			PatientExamination patientExamination = setupPatientExaminationAndAssignPatient(obsoletePatient);
+
+			// when:
+			patientIoOperation.mergePatientHistory(mergedPatient, obsoletePatient);
+
+			// then:
+			assertThatObsoletePatientWasDeletedAndMergedIsTheActiveOne(mergedPatient, obsoletePatient);
+			assertThatVisitWasMovedFromObsoleteToMergedPatient(visit, mergedPatient);
+			assertThatExaminationWasMovedFromObsoleteToMergedPatient(patientExamination, mergedPatient);
+			assertThatPatientMergedEventWasSent(mergedPatient, obsoletePatient);
+		} catch (Exception e) {
+			e.printStackTrace();
+			assertEquals(true, false);
+		}
+	}
+
+	private void assertThatObsoletePatientWasDeletedAndMergedIsTheActiveOne(Patient mergedPatient, Patient obsoletePatient) throws OHException {
+		Patient mergedPatientResult = (Patient) jpa.find(Patient.class, mergedPatient.getCode());
+		Patient obsoletePatientResult = (Patient) jpa.find(Patient.class, obsoletePatient.getCode());
+		assertEquals("Y", obsoletePatientResult.getDeleted());
+		assertEquals("N", mergedPatientResult.getDeleted());
+	}
+
+	private void assertThatVisitWasMovedFromObsoleteToMergedPatient(Visit visit, Patient mergedPatient) throws OHException {
+		Visit visitResult = (Visit) jpa.find(Visit.class, visit.getVisitID());
+		assertEquals(mergedPatient.getCode(), visitResult.getPatient().getCode());
+	}
+
+	private void assertThatExaminationWasMovedFromObsoleteToMergedPatient(PatientExamination examination, Patient mergedPatient) throws OHException {
+		PatientExamination patientResult = (PatientExamination) jpa.find(PatientExamination.class, examination.getPex_ID());
+		assertEquals(mergedPatient.getCode(), patientResult.getPatient().getCode());
+	}
+
+	private void assertThatPatientMergedEventWasSent(Patient mergedPatient, Patient obsoletePatient) {
+		assertEquals(mergedPatient.getCode(), testPatientMergedEventListener.getPatientMergedEvent().getMergedPatient().getCode());
+		assertEquals(obsoletePatient.getCode(), testPatientMergedEventListener.getPatientMergedEvent().getObsoletePatient().getCode());
+	}
+
+	private Visit setupVisitAndAssignPatient(Patient patient) throws OHException {
+		jpa.beginTransaction();
+		Visit visit = testVisit.setup(patient, false);
+		jpa.persist(visit);
+		jpa.commitTransaction();
+		return visit;
+	}
+
+	private PatientExamination setupPatientExaminationAndAssignPatient(Patient patient) throws OHException {
+		jpa.beginTransaction();
+		PatientExamination patientExamination = testPatientExamination.setup(patient, false);
+		jpa.persist(patientExamination);
+		jpa.commitTransaction();
+		return patientExamination;
+	}
+}

--- a/src/org/isf/patient/test/TestPatientMergedEventListener.java
+++ b/src/org/isf/patient/test/TestPatientMergedEventListener.java
@@ -12,10 +12,10 @@ public class TestPatientMergedEventListener {
 
 	@EventListener
 	public void handle(PatientMergedEvent patientMergedEvent) {
+		this.patientMergedEvent = patientMergedEvent;
 		if(shouldFail) {
 			throw new RuntimeException("failure testing");
 		}
-		this.patientMergedEvent = patientMergedEvent;
 	}
 
 	public PatientMergedEvent getPatientMergedEvent() {

--- a/src/org/isf/patient/test/TestPatientMergedEventListener.java
+++ b/src/org/isf/patient/test/TestPatientMergedEventListener.java
@@ -1,0 +1,29 @@
+package org.isf.patient.test;
+
+import org.isf.patient.model.PatientMergedEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+@Component
+public class TestPatientMergedEventListener {
+	private PatientMergedEvent patientMergedEvent;
+
+	private boolean shouldFail = false;
+
+	@EventListener
+	public void handle(PatientMergedEvent patientMergedEvent) {
+		if(shouldFail) {
+			throw new RuntimeException("failure testing");
+		}
+		this.patientMergedEvent = patientMergedEvent;
+	}
+
+	public PatientMergedEvent getPatientMergedEvent() {
+		return patientMergedEvent;
+	}
+
+	public void setShouldFail(boolean shouldFail) {
+		this.shouldFail = shouldFail;
+	}
+
+}

--- a/src/org/isf/patient/test/Tests.java
+++ b/src/org/isf/patient/test/Tests.java
@@ -7,8 +7,6 @@ import static org.junit.Assert.assertTrue;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.isf.admission.test.TestAdmission;
-import org.isf.admission.test.TestAdmissionContext;
 import org.isf.patient.model.Patient;
 import org.isf.patient.service.PatientIoOperations;
 import org.isf.utils.db.DbJpaUtil;
@@ -139,7 +137,7 @@ public class Tests
 		{		
 			_setupTestPatient(false);
 			// Pay attention that query return with PAT_ID descendant
-			ArrayList<Patient> patients = patientIoOperation.getPatientsWithHeightAndWeight(null);
+			ArrayList<Patient> patients = patientIoOperation.getPatientsByOneOfFieldsLike(null);
 
 			testPatient.check(patients.get(0));
 		} 
@@ -153,22 +151,98 @@ public class Tests
 	}
 	
 	@Test
-	public void testIoGetPatientsWithHeightAndWeightRegEx() 
-	{	
-		try 
-		{	
+	public void testIoGetPatientsByOneOfFieldsLikeFirstName() {
+		try {
+			// given:
 			Integer code = _setupTestPatient(false);
-			Patient foundPatient = (Patient)jpa.find(Patient.class, code); 
-			ArrayList<Patient> patients = patientIoOperation.getPatientsWithHeightAndWeight(foundPatient.getFirstName());
-			
+			Patient foundPatient = (Patient)jpa.find(Patient.class, code);
+
+			// when:
+			ArrayList<Patient> patients = patientIoOperation.getPatientsByOneOfFieldsLike(foundPatient.getFirstName());
+
+			// then:
 			testPatient.check(patients.get(0));
-		} 
-		catch (Exception e) 
-		{
+		} catch (Exception e) {
 			e.printStackTrace();		
 			assertEquals(true, false);
 		}
-		
+	}
+
+	@Test
+	public void testIoGetPatientsByOneOfFieldsLikeSecondName() {
+		try {
+			// given:
+			Integer code = _setupTestPatient(false);
+			Patient foundPatient = (Patient)jpa.find(Patient.class, code);
+
+			// when:
+			ArrayList<Patient> patients = patientIoOperation.getPatientsByOneOfFieldsLike(foundPatient.getSecondName());
+
+			// then:
+			testPatient.check(patients.get(0));
+		} catch (Exception e) {
+			e.printStackTrace();
+			assertEquals(true, false);
+		}
+	}
+
+	@Test
+	public void testIoGetPatientsByOneOfFieldsLikeNote() {
+		try {
+			// given:
+			Integer code = _setupTestPatient(false);
+			Patient foundPatient = (Patient)jpa.find(Patient.class, code);
+
+			// when:
+			ArrayList<Patient> patients = patientIoOperation.getPatientsByOneOfFieldsLike(foundPatient.getSecondName());
+
+			// then:
+			testPatient.check(patients.get(0));
+		}
+		catch (Exception e)
+		{
+			e.printStackTrace();
+			assertEquals(true, false);
+		}
+	}
+
+	@Test
+	public void testIoGetPatientsByOneOfFieldsLikeTaxCode()	{
+		try	{
+			// given:
+			Integer code = _setupTestPatient(false);
+			Patient foundPatient = (Patient)jpa.find(Patient.class, code);
+
+			// when:
+			ArrayList<Patient> patients = patientIoOperation.getPatientsByOneOfFieldsLike(foundPatient.getTaxCode());
+
+			// then:
+			testPatient.check(patients.get(0));
+		} catch (Exception e) {
+			e.printStackTrace();
+			assertEquals(true, false);
+		}
+
+		return;
+	}
+
+	@Test
+	public void testIoGetPatientsByOneOfFieldsLikeNotExistingStringShouldNotFindAnything()
+	{
+		try
+		{
+			Integer code = _setupTestPatient(false);
+			Patient foundPatient = (Patient)jpa.find(Patient.class, code);
+			ArrayList<Patient> patients = patientIoOperation.getPatientsByOneOfFieldsLike("dupa");
+
+			assertTrue(patients.isEmpty());
+		}
+		catch (Exception e)
+		{
+			e.printStackTrace();
+			assertEquals(true, false);
+		}
+
 		return;
 	}
 

--- a/src/org/isf/patvac/service/PatVacIoOperationRepository.java
+++ b/src/org/isf/patvac/service/PatVacIoOperationRepository.java
@@ -6,6 +6,8 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface PatVacIoOperationRepository extends JpaRepository<PatientVaccine, Integer>, PatVacIoOperationRepositoryCustom {
 
@@ -14,4 +16,6 @@ public interface PatVacIoOperationRepository extends JpaRepository<PatientVaccin
     
     @Query(value = "SELECT MAX(PAV_YPROG) FROM PATIENTVACCINE WHERE YEAR(PAV_DATE) = :year", nativeQuery= true)
     Integer findMaxCodeWhereVaccineDate(@Param("year") Integer year);
+
+    List<PatientVaccine> findByPatient_code(int patientId);
 }

--- a/src/org/isf/patvac/service/PatVacIoOperationRepository.java
+++ b/src/org/isf/patvac/service/PatVacIoOperationRepository.java
@@ -6,16 +6,17 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.GregorianCalendar;
 import java.util.List;
 
 @Repository
 public interface PatVacIoOperationRepository extends JpaRepository<PatientVaccine, Integer>, PatVacIoOperationRepositoryCustom {
 
-    @Query(value = "SELECT MAX(PAV_YPROG) FROM PATIENTVACCINE", nativeQuery= true)
+	@Query("select max(pv.progr) from PatientVaccine pv")
     Integer findMaxCode();
     
-    @Query(value = "SELECT MAX(PAV_YPROG) FROM PATIENTVACCINE WHERE YEAR(PAV_DATE) = :year", nativeQuery= true)
-    Integer findMaxCodeWhereVaccineDate(@Param("year") Integer year);
+	@Query("select max(pv.progr) from PatientVaccine pv where pv.vaccineDate >= :yearStart and pv.vaccineDate < :yearEnd")
+	Integer findMaxCodeWhereVaccineDate(@Param("yearStart") GregorianCalendar yearStart, @Param("yearEnd") GregorianCalendar yearEnd);
 
     List<PatientVaccine> findByPatient_code(int patientId);
 }

--- a/src/org/isf/patvac/service/PatVacIoOperationRepositoryCustom.java
+++ b/src/org/isf/patvac/service/PatVacIoOperationRepositoryCustom.java
@@ -1,12 +1,14 @@
 package org.isf.patvac.service;
 
 
+import org.isf.patvac.model.PatientVaccine;
+
 import java.util.GregorianCalendar;
 import java.util.List;
 
 
 public interface PatVacIoOperationRepositoryCustom {
 	
-	List<Integer> findAllByCodesAndDatesAndSexAndAges(String vaccineTypeCode, String vaccineCode,
-			GregorianCalendar dateFrom, GregorianCalendar dateTo, char sex, int ageFrom, int ageTo);	
+	List<PatientVaccine> findAllByCodesAndDatesAndSexAndAges(String vaccineTypeCode, String vaccineCode,
+															 GregorianCalendar dateFrom, GregorianCalendar dateTo, char sex, int ageFrom, int ageTo);
 }

--- a/src/org/isf/patvac/service/PatVacIoOperationRepositoryImpl.java
+++ b/src/org/isf/patvac/service/PatVacIoOperationRepositoryImpl.java
@@ -7,7 +7,11 @@ import java.util.List;
 
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
+import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.CriteriaQuery;
+import javax.persistence.criteria.Root;
 
+import org.isf.patvac.model.PatientVaccine;
 import org.springframework.transaction.annotation.Transactional;
 
 
@@ -20,7 +24,7 @@ public class PatVacIoOperationRepositoryImpl implements PatVacIoOperationReposit
 	
 	@SuppressWarnings("unchecked")	
 	@Override
-	public List<Integer> findAllByCodesAndDatesAndSexAndAges(
+	public List<PatientVaccine> findAllByCodesAndDatesAndSexAndAges(
 			String vaccineTypeCode, 
 			String vaccineCode, 
 			GregorianCalendar dateFrom, 
@@ -29,72 +33,57 @@ public class PatVacIoOperationRepositoryImpl implements PatVacIoOperationReposit
 			int ageFrom, 
 			int ageTo) {
 		return this.entityManager.
-				createNativeQuery(_getPatientVaccineQuery(
+				createQuery(_getPatientVaccineQuery(
 						vaccineTypeCode, vaccineCode, dateFrom, dateTo,
 						sex, ageFrom, ageTo)).
 					getResultList();
 	}	
 
-	
-	private String _getPatientVaccineQuery(
+	private CriteriaQuery<PatientVaccine> _getPatientVaccineQuery(
 			String vaccineTypeCode, 
 			String vaccineCode, 
 			GregorianCalendar dateFrom, 
 			GregorianCalendar dateTo, 
 			char sex, 
 			int ageFrom, 
-			int ageTo) 
-	{
-		StringBuilder query = new StringBuilder();
-		String clause = " WHERE";
-	
-		
-		query.append("SELECT PAV_ID"
-				+ " FROM PATIENTVACCINE JOIN VACCINE ON PAV_VAC_ID_A=VAC_ID_A"
-				+ " JOIN VACCINETYPE ON VAC_VACT_ID_A = VACT_ID_A"
-				+ " JOIN PATIENT ON PAV_PAT_ID = PAT_ID");
-		if (dateFrom != null || dateTo != null) {
-			if (dateFrom != null) {
-				query.append(clause).append(" DATE_FORMAT(PAV_DATE,'%Y-%m-%d') >= \"" + _convertToSQLDateLimited(dateFrom) + "\"");
-				clause = " AND";
-			}
-			if (dateTo != null) {
-				query.append(clause).append(" DATE_FORMAT(PAV_DATE,'%Y-%m-%d') <= \"" + _convertToSQLDateLimited(dateTo) + "\"");
-				clause = " AND";
-			}
+			int ageTo) {
+		CriteriaBuilder cb = entityManager.getCriteriaBuilder();
+		CriteriaQuery<PatientVaccine> query = cb.createQuery(PatientVaccine.class);
+		Root<PatientVaccine> pvRoot = query.from(PatientVaccine.class);
+
+		query.select(pvRoot);
+		if (dateFrom != null) {
+			query.where(
+				cb.greaterThanOrEqualTo(pvRoot.<Comparable>get("vaccineDate"), dateFrom)
+			);
+		}
+		if (dateTo != null) {
+			query.where(
+				cb.lessThanOrEqualTo(pvRoot.<Comparable>get("vaccineDate"), dateTo)
+			);
 		}
 		if (vaccineTypeCode != null) {
-			query.append(clause).append(" VACT_ID_A = \"" + vaccineTypeCode + "\"");
-			clause = " AND";
+			query.where(
+				cb.equal(pvRoot.join("vaccine").get("code"), vaccineTypeCode)
+			);
 		}
 		if (vaccineCode != null) {
-			query.append(clause).append(" VAC_ID_A = \"" + vaccineCode + "\"");
-			clause = " AND";
+			query.where(
+				cb.equal(pvRoot.join("vaccine").get("code"), vaccineCode)
+			);
 		}
 		if (sex != 'A') {
-			query.append(clause).append(" PAT_SEX = \"" + sex + "\"");
-			clause = " AND";
-		}		
+			query.where(
+				cb.equal(pvRoot.join("patient").get("sex"), sex)
+			);
+		}
 		if (ageFrom != 0 || ageTo != 0) {
-			query.append(clause).append(" PAT_AGE BETWEEN \"" + ageFrom + "\" AND \"" + ageTo + "\"");
-			clause = " AND";
-		}		
-		query.append(" ORDER BY PAV_DATE DESC, PAV_ID");
-		System.out.println(query.toString());
+			query.where(
+				cb.between(pvRoot.join("patient").<Comparable>get("age"), ageFrom, ageTo)
+			);
+		}
+		query.orderBy(cb.desc(pvRoot.get("vaccineDate")), cb.asc(pvRoot.get("code")));
 
-		return query.toString();
-	}
-	
-	/**
-	 * return a String representing the date in format <code>yyyy-MM-dd</code>
-	 * 
-	 * @param date
-	 * @return the date in format <code>yyyy-MM-dd</code>
-	 */
-	private String _convertToSQLDateLimited(GregorianCalendar date) 
-	{
-		SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd");
-	
-		return sdf.format(date.getTime());
+		return query;
 	}
 }

--- a/src/org/isf/patvac/service/PatVacIoOperations.java
+++ b/src/org/isf/patvac/service/PatVacIoOperations.java
@@ -16,6 +16,7 @@ import org.isf.patient.model.Patient;
 import org.isf.patvac.model.PatientVaccine;
 import org.isf.utils.db.TranslateOHServiceException;
 import org.isf.utils.exception.OHServiceException;
+import org.joda.time.DateTime;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -71,24 +72,9 @@ public class PatVacIoOperations {
 			GregorianCalendar dateTo, 
 			char sex, 
 			int ageFrom, 
-			int ageTo) throws OHServiceException 
-	{
-		ArrayList<Integer> pPatientVaccineCode = null;
-		ArrayList<PatientVaccine> pPatientVaccine = new ArrayList<PatientVaccine>();
-		
-		
-		pPatientVaccineCode = (ArrayList<Integer>) repository.findAllByCodesAndDatesAndSexAndAges(
-				vaccineTypeCode, vaccineCode, dateFrom, dateTo, sex, ageFrom, ageTo);
-		for (int i=0; i<pPatientVaccineCode.size(); i++)
-		{
-			Integer code = pPatientVaccineCode.get(i);
-			PatientVaccine patientVaccine = repository.findOne(code);
-			
-			
-			pPatientVaccine.add(i, patientVaccine);
-		}
-
-		return pPatientVaccine;
+			int ageTo) throws OHServiceException {
+		return new ArrayList<PatientVaccine>(repository.findAllByCodesAndDatesAndSexAndAges(
+				vaccineTypeCode, vaccineCode, dateFrom, dateTo, sex, ageFrom, ageTo));
 	}
 
 	public List<PatientVaccine> findForPatient(int patientCode) {
@@ -102,16 +88,8 @@ public class PatVacIoOperations {
 	 * @return <code>true</code> if the item has been inserted, <code>false</code> otherwise 
 	 * @throws OHServiceException 
 	 */
-	public boolean newPatientVaccine(
-			PatientVaccine patVac) throws OHServiceException 
-	{
-		boolean result = true;
-	
-
-		PatientVaccine savedVaccine = repository.save(patVac);
-		result = (savedVaccine != null);
-		
-		return result;
+	public boolean newPatientVaccine(PatientVaccine patVac) throws OHServiceException {
+		return repository.save(patVac) != null;
 	}
 
 	/**
@@ -121,16 +99,8 @@ public class PatVacIoOperations {
 	 * @return <code>true</code> if the item has been updated, <code>false</code> otherwise 
 	 * @throws OHServiceException 
 	 */
-	public boolean updatePatientVaccine(
-			PatientVaccine patVac) throws OHServiceException 
-	{
-		boolean result = true;
-	
-
-		PatientVaccine savedVaccine = repository.save(patVac);
-		result = (savedVaccine != null);
-		
-		return result;
+	public boolean updatePatientVaccine(PatientVaccine patVac) throws OHServiceException {
+		return repository.save(patVac) != null;
 	}
 
 	/**
@@ -140,15 +110,9 @@ public class PatVacIoOperations {
 	 * @return <code>true</code> if the item has been deleted, <code>false</code> otherwise 
 	 * @throws OHServiceException 
 	 */
-	public boolean deletePatientVaccine(
-			PatientVaccine patVac) throws OHServiceException 
-	{
-		boolean result = true;
-	
-		
+	public boolean deletePatientVaccine(PatientVaccine patVac) throws OHServiceException {
 		repository.delete(patVac);
-		
-		return result;	
+		return true;
 	}
 
 	/**
@@ -158,22 +122,12 @@ public class PatVacIoOperations {
 	 * @return <code>int</code> - the progressive number in the year
 	 * @throws OHServiceException 
 	 */
-	public int getProgYear(
-			int year) throws OHServiceException 
-	{
-		Integer progYear = 0;
+	public int getProgYear(int year) throws OHServiceException {
+		Integer progYear =year != 0 ?
+			repository.findMaxCodeWhereVaccineDate(getBeginningOfYear(year), getBeginningOfYear(year + 1)) :
+			repository.findMaxCode();
 
-		
-		if (year != 0) 
-		{
-			progYear = repository.findMaxCodeWhereVaccineDate(year);
-		}
-		else
-		{
-			progYear = repository.findMaxCode();
-		}
-		
-		return progYear == null ? new Integer(0) : progYear;
+		return progYear == null ? 0 : progYear;
 	}
 
 	/**
@@ -183,14 +137,11 @@ public class PatVacIoOperations {
 	 * @return <code>true</code> if the code is already in use, <code>false</code> otherwise
 	 * @throws OHServiceException 
 	 */
-	public boolean isCodePresent(
-			Integer code) throws OHServiceException
-	{
-		boolean result = true;
-	
-		
-		result = repository.exists(code);
-		
-		return result;	
+	public boolean isCodePresent(Integer code) throws OHServiceException {
+		return repository.exists(code);
+	}
+
+	private GregorianCalendar getBeginningOfYear(int year) {
+		return new DateTime().withYear(year).dayOfYear().withMinimumValue().withTimeAtStartOfDay().toGregorianCalendar();
 	}
 }

--- a/src/org/isf/patvac/service/PatVacIoOperations.java
+++ b/src/org/isf/patvac/service/PatVacIoOperations.java
@@ -10,7 +10,9 @@ package org.isf.patvac.service;
  *------------------------------------------*/
 import java.util.ArrayList;
 import java.util.GregorianCalendar;
+import java.util.List;
 
+import org.isf.patient.model.Patient;
 import org.isf.patvac.model.PatientVaccine;
 import org.isf.utils.db.TranslateOHServiceException;
 import org.isf.utils.exception.OHServiceException;
@@ -87,6 +89,10 @@ public class PatVacIoOperations {
 		}
 
 		return pPatientVaccine;
+	}
+
+	public List<PatientVaccine> findForPatient(int patientCode) {
+		return repository.findByPatient_code(patientCode);
 	}
 
 	/**

--- a/src/org/isf/patvac/service/VaccinePatientMergedEventListener.java
+++ b/src/org/isf/patvac/service/VaccinePatientMergedEventListener.java
@@ -1,0 +1,26 @@
+package org.isf.patvac.service;
+
+import org.isf.patient.model.PatientMergedEvent;
+import org.isf.patvac.model.PatientVaccine;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Component
+public class VaccinePatientMergedEventListener {
+	@Autowired
+	PatVacIoOperations patVacIoOperations;
+
+	@EventListener
+	@Transactional
+	public void handle(PatientMergedEvent patientMergedEvent) {
+		List<PatientVaccine> vaccines = patVacIoOperations.findForPatient(patientMergedEvent.getObsoletePatient().getCode());
+		for (PatientVaccine vaccine : vaccines) {
+			vaccine.setPatient(patientMergedEvent.getMergedPatient());
+		}
+	}
+
+}

--- a/src/org/isf/priceslist/service/PriceIoOperationRepository.java
+++ b/src/org/isf/priceslist/service/PriceIoOperationRepository.java
@@ -14,19 +14,10 @@ import org.springframework.transaction.annotation.Transactional;
 public interface PriceIoOperationRepository extends JpaRepository<Price, Integer> {
     List<Price> findAllByOrderByDescriptionAsc();
 	
-    @Query(value = "SELECT * FROM PRICES WHERE PRC_LST_ID = :id", nativeQuery= true)
-    List<Price> findAllWhereList(@Param("id") Integer id);
+    List<Price> findByList_id(Integer id);
 
     @Modifying
     @Transactional
-    @Query(value = "DELETE FROM PRICES WHERE PRC_LST_ID = :listId", nativeQuery= true)
-    void deleteWhereList(@Param("listId") Integer listId);
-    
-    @Modifying
-    @Transactional
-    @Query(value = "INSERT INTO PRICES (PRC_LST_ID, PRC_GRP, PRC_ITEM, PRC_DESC, PRC_PRICE) VALUES (:listId,:group,:item,:description,:price)", nativeQuery= true)
-    void insertPrice(
-            @Param("listId") Integer listId, @Param("group") String group, @Param("item") String item,
-            @Param("description") String description, @Param("price") Double price);
-    
+    @Query("delete from Price p where p.list.id = :listId")
+	void deleteByListId(@Param("listId") Integer listId);
 }

--- a/src/org/isf/priceslist/service/PriceListIoOperationRepository.java
+++ b/src/org/isf/priceslist/service/PriceListIoOperationRepository.java
@@ -10,23 +10,8 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Repository
 public interface PriceListIoOperationRepository extends JpaRepository<PriceList, Integer> {
-    
-	@Modifying
-    @Transactional
-    @Query(value = "INSERT INTO PRICELISTS (LST_CODE, LST_NAME, LST_DESC, LST_CURRENCY) VALUES (:code,:name,:description,:currency)", nativeQuery= true)
-    void insertPriceList(
-            @Param("code") String code, @Param("name") String name,
-            @Param("description") String description, @Param("currency") String currency);
-    
     @Modifying
     @Transactional
-    @Query(value = "UPDATE PRICELISTS SET LST_CODE = :code, LST_NAME = :name, LST_DESC = :description, LST_CURRENCY = :currency WHERE LST_ID = :id", nativeQuery= true)
-    int updatePriceList(
-            @Param("code") String code, @Param("name") String name,
-            @Param("description") String description, @Param("currency") String currency, @Param("id") Integer id);
-
-    @Modifying
-    @Transactional
-    @Query(value = "DELETE FROM PRICELISTS WHERE LST_ID = :id", nativeQuery= true)
-    void deleteWhereId(@Param("id") Integer id);
+    @Query(value = "DELETE FROM PriceList p WHERE p.id = :id")
+    void deleteById(@Param("id") Integer id);
 }

--- a/src/org/isf/priceslist/service/PricesListIoOperations.java
+++ b/src/org/isf/priceslist/service/PricesListIoOperations.java
@@ -60,12 +60,10 @@ public class PricesListIoOperations {
 	 * @return <code>true</code> if the list has been replaced, <code>false</code> otherwise
 	 * @throws OHServiceException 
 	 */
-	public boolean updatePrices(
-			PriceList list, 
-			ArrayList<Price> prices) throws OHServiceException {
+	public boolean updatePrices(PriceList list,	ArrayList<Price> prices) throws OHServiceException {
 		boolean result = true;
-		
-		
+
+
 		result = _deletePricesInsideList(list.getId());
 		
 		result &= _insertNewPricesInsideList(list, prices);
@@ -75,31 +73,19 @@ public class PricesListIoOperations {
 	
 	private boolean _deletePricesInsideList(
 			int id) throws OHServiceException 
-    {			
-		boolean result = true;
-
-		
-		priceRepository.deleteWhereList(id);
+    {
+		priceRepository.deleteByListId(id);
         				
-        return result;
+        return true;
     }
 	
-	private boolean _insertNewPricesInsideList(
-			PriceList list,
-			ArrayList<Price> prices) throws OHServiceException 
-    {	
-		boolean result = true;
-        		
-		
-		for (Price price : prices) 
-		{
-			priceRepository.insertPrice(
-					list.getId(), price.getGroup(), price.getItem(),
-					price.getDesc(),
-					price.getPrice());
+	private boolean _insertNewPricesInsideList(PriceList list, ArrayList<Price> prices) throws OHServiceException {
+		for (Price price : prices) {
+			price.setList(list);
+			priceRepository.save(price);
 		}
 		
-        return result;
+        return true;
     }
 
 	/**
@@ -109,14 +95,8 @@ public class PricesListIoOperations {
 	 * @return <code>true</code> if the list has been inserted, <code>false</code> otherwise
 	 * @throws OHServiceException 
 	 */
-	public boolean newList(
-			PriceList list) throws OHServiceException {
-		boolean result = true;
-        		
-		
-		repository.insertPriceList(list.getCode(), list.getName(), list.getDescription(), list.getCurrency());
-		
-		return result;
+	public boolean newList(PriceList list) throws OHServiceException {
+		return repository.save(list) != null;
 	}
 	
 	/**
@@ -126,17 +106,8 @@ public class PricesListIoOperations {
 	 * @return <code>true</code> if the list has been updated, <code>false</code> otherwise
 	 * @throws OHServiceException 
 	 */
-	public boolean updateList(
-			PriceList list) throws OHServiceException {
-		boolean result = false;
-        				
-
-		if (repository.updatePriceList(list.getCode(), list.getName(), list.getDescription(), list.getCurrency(), list.getId()) > 0)
-		{
-			result = true;
-		}		
-		
-		return result;
+	public boolean updateList(PriceList list) throws OHServiceException {
+		return repository.save(list) != null;
 	}
 	
 	/**
@@ -164,7 +135,7 @@ public class PricesListIoOperations {
 		boolean result = true;
 		
 		
-		repository.deleteWhereId(id);
+		repository.deleteById(id);
 		
         return result;
     }
@@ -187,7 +158,7 @@ public class PricesListIoOperations {
 		boolean result = true; 			
 
 		
-		List<Price> Prices = (List<Price>)priceRepository.findAllWhereList(list.getId());
+		List<Price> Prices = (List<Price>)priceRepository.findByList_id(list.getId());
 		for (Price price: Prices) 
 		{    
 			Price newPrice = new Price();

--- a/src/org/isf/test/Tests.java
+++ b/src/org/isf/test/Tests.java
@@ -32,6 +32,7 @@ import org.junit.runners.Suite.SuiteClasses;
 	org.isf.operation.test.Tests.class,
 	org.isf.opetype.test.Tests.class,	
 	org.isf.patient.test.Tests.class,
+	org.isf.patient.test.MergePatientTests.class,
 	org.isf.patvac.test.Tests.class,
 	org.isf.pregtreattype.test.Tests.class,	
 	org.isf.priceslist.test.Tests.class,

--- a/src/org/isf/therapy/service/TherapyPatientMergedEventListener.java
+++ b/src/org/isf/therapy/service/TherapyPatientMergedEventListener.java
@@ -1,0 +1,28 @@
+package org.isf.therapy.service;
+
+import org.isf.patient.model.PatientMergedEvent;
+import org.isf.therapy.model.TherapyRow;
+import org.isf.utils.exception.OHServiceException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Component
+public class TherapyPatientMergedEventListener {
+	@Autowired
+	TherapyIoOperations therapyIoOperations;
+
+	@EventListener
+	@Transactional
+	public void handle(PatientMergedEvent patientMergedEvent) throws OHServiceException {
+		List<TherapyRow> therapyRows = therapyIoOperations.getTherapyRows(patientMergedEvent.getObsoletePatient().getCode());
+		for (TherapyRow therapyRow : therapyRows) {
+			therapyRow.setPatID(patientMergedEvent.getMergedPatient());
+		}
+	}
+
+}

--- a/src/org/isf/therapy/test/Tests.java
+++ b/src/org/isf/therapy/test/Tests.java
@@ -12,6 +12,7 @@ import org.isf.medtype.model.MedicalType;
 import org.isf.medtype.test.TestMedicalType;
 import org.isf.medtype.test.TestMedicalTypeContext;
 import org.isf.patient.model.Patient;
+import org.isf.patient.model.PatientMergedEvent;
 import org.isf.patient.test.TestPatient;
 import org.isf.patient.test.TestPatientContext;
 import org.isf.therapy.model.TherapyRow;
@@ -25,6 +26,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringRunner;
 
@@ -44,6 +46,8 @@ public class Tests
 
     @Autowired
     private TherapyIoOperations therapyIoOperation;
+    @Autowired
+    private ApplicationEventPublisher applicationEventPublisher;
 	
 	@BeforeClass
     public static void setUpClass()  
@@ -233,6 +237,36 @@ public class Tests
 		}
 		
 		return;
+	}
+
+	@Test
+	public void testListenerShouldUpdatePatientToMergedWhenPatientMergedEventArrive() {
+		try {
+			// given:
+			int id = _setupTestTherapyRow(false);
+			TherapyRow found = (TherapyRow) jpa.find(TherapyRow.class, id);
+			Patient obsoletePatient = found.getPatID();
+			Patient mergedPatient = _setupTestPatient(false);
+
+			// when:
+			applicationEventPublisher.publishEvent(new PatientMergedEvent(obsoletePatient, mergedPatient));
+
+			// then:
+			TherapyRow result = (TherapyRow)jpa.find(TherapyRow.class, id);
+			assertEquals(mergedPatient.getCode(), result.getPatID().getCode());
+		} catch (Exception e) {
+			e.printStackTrace();
+			assertEquals(true, false);
+		}
+	}
+
+	private Patient _setupTestPatient(boolean usingSet) throws OHException	{
+		jpa.beginTransaction();
+		Patient patient = testPatient.setup(usingSet);
+		jpa.persist(patient);
+		jpa.commitTransaction();
+
+		return patient;
 	}
 		
 	

--- a/src/org/isf/visits/service/VisitsPatientMergedEventListener.java
+++ b/src/org/isf/visits/service/VisitsPatientMergedEventListener.java
@@ -1,0 +1,26 @@
+package org.isf.visits.service;
+
+import org.isf.patient.model.PatientMergedEvent;
+import org.isf.utils.exception.OHServiceException;
+import org.isf.visits.model.Visit;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Component
+public class VisitsPatientMergedEventListener {
+	@Autowired
+	VisitsIoOperations visitsIoOperations;
+
+	@EventListener
+	public void handle(PatientMergedEvent patientMergedEvent) throws OHServiceException {
+		List<Visit> visits = visitsIoOperations.getVisits(patientMergedEvent.getObsoletePatient().getCode());
+		for(Visit visit : visits) {
+			visit.setPatient(patientMergedEvent.getMergedPatient());
+		}
+	}
+
+}


### PR DESCRIPTION
1. ApplicationEventPublisher was introduced into PationIoOperations. It publishes event that patient was merged. 
2. Than other modules that contain reference to patient in their repositories has event listeners for PatientMerged event.
3. When they get notified they update references to Patient (changes obsolete patient into merged one)

Everything happens within the same transaction so if some part of merging fails whole operation is rolled back.

Test cases were introduced both in Patient and Patient connected modules. In Patient we check only if Patient entity was updated and if correct event was emmited. Than in each dependent module there is a test which checks if when event arrives patient reference will be updated.

https://www.baeldung.com/spring-events