### PR TITLE
Remove unused (?) dependency clibwrapper_jiio that causes build failure

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -359,11 +359,6 @@
          <artifactId>spring-aspects</artifactId>
          <version>${spring.framework.version}</version>
 	    </dependency>
-	    <dependency>
-		    <groupId>com.sun</groupId>
-		    <artifactId>clibwrapper_jiio</artifactId>
-		    <version>1.1</version>
-		</dependency>
 		<dependency>
 		    <groupId>com.sun.media</groupId>
 		    <artifactId>jai_imageio</artifactId>


### PR DESCRIPTION
I could not build the repository locally, after cleaning the Maven cache, because that library can't be retrieved (not even from other repositories that I found on mvnrepository.com). So I removed it, and everything seems to be building fine now (unless this will cause some runtime error, but I wouldn't expect so judging by the scope of the dependency).

Edit: this looks related to a discussion I was not aware of in OP-140: https://openhospital.atlassian.net/browse/OP-140
Feel free to close this if it's not the right way to solve the issue.
cc: @giuseppesorge 