### PR TITLE
Remove docker step from github CI

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -12,8 +12,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Start the database container
-      run: docker-compose up -d
     - name: Set up JDK 1.8
       uses: actions/setup-java@v1
       with:


### PR DESCRIPTION
Since tests are now performed against an in-memory db (#132 ), we can get rid of the docker-compose step in the CI.