### PR TITLE
Remove redundant public for interface methods

### DIFF
--- a/src/main/java/org/isf/dicom/manager/DicomManagerInterface.java
+++ b/src/main/java/org/isf/dicom/manager/DicomManagerInterface.java
@@ -43,7 +43,7 @@ public interface DicomManagerInterface
      * @return true if file exist
       * @throws OHServiceException 
      */
-	boolean exist(int patientID, String seriesNumber) throws OHServiceException;
+    boolean exist(int patientID, String seriesNumber) throws OHServiceException;
 
     /**
      * Load the Detail of DICOM
@@ -53,7 +53,7 @@ public interface DicomManagerInterface
      * @return FileDicom
      * @throws OHServiceException 
      */
-	FileDicom loadDetails(Long idFile, int patientID, String seriesNumber) throws OHServiceException;
+    FileDicom loadDetails(Long idFile, int patientID, String seriesNumber) throws OHServiceException;
 
     /**
      * Load detail
@@ -63,7 +63,7 @@ public interface DicomManagerInterface
      * @return FileDicom
      * @throws OHServiceException 
      */
-	FileDicom loadDetails(long idFile, int patientID, String seriesNumber) throws OHServiceException;
+    FileDicom loadDetails(long idFile, int patientID, String seriesNumber) throws OHServiceException;
 
     /**
      * load metadata from DICOM files of the patient
@@ -71,12 +71,12 @@ public interface DicomManagerInterface
      * @return
      * @throws OHServiceException 
      */
-	FileDicom[] loadPatientFiles(int patientID) throws OHServiceException;
+    FileDicom[] loadPatientFiles(int patientID) throws OHServiceException;
 
     /**
      * save the DICOM file and metadata
      * @param dicom
      * @throws OHServiceException 
      */
-	void saveFile(FileDicom dicom) throws OHServiceException;
+    void saveFile(FileDicom dicom) throws OHServiceException;
 }

--- a/src/main/java/org/isf/dicom/manager/DicomManagerInterface.java
+++ b/src/main/java/org/isf/dicom/manager/DicomManagerInterface.java
@@ -43,7 +43,7 @@ public interface DicomManagerInterface
      * @return true if file exist
       * @throws OHServiceException 
      */
-    boolean exist(int patientID, String seriesNumber) throws OHServiceException;
+     boolean exist(int patientID, String seriesNumber) throws OHServiceException;
 
     /**
      * Load the Detail of DICOM

--- a/src/main/java/org/isf/dicom/manager/DicomManagerInterface.java
+++ b/src/main/java/org/isf/dicom/manager/DicomManagerInterface.java
@@ -17,7 +17,7 @@ public interface DicomManagerInterface
      * @return
      * @throws OHServiceException 
      */
-    public Long[] getSerieDetail(int patientID, String seriesNumber) throws OHServiceException;
+	Long[] getSerieDetail(int patientID, String seriesNumber) throws OHServiceException;
 
     /**
      * Delete series 
@@ -34,7 +34,7 @@ public interface DicomManagerInterface
     * @return true if file exist
      * @throws OHServiceException 
     */
-    public boolean exist(FileDicom dicom) throws OHServiceException;
+	boolean exist(FileDicom dicom) throws OHServiceException;
     
     /**
      * Check if dicom is loaded
@@ -43,7 +43,7 @@ public interface DicomManagerInterface
      * @return true if file exist
       * @throws OHServiceException 
      */
-     public boolean exist(int patientID, String seriesNumber) throws OHServiceException;
+	boolean exist(int patientID, String seriesNumber) throws OHServiceException;
 
     /**
      * Load the Detail of DICOM
@@ -53,7 +53,7 @@ public interface DicomManagerInterface
      * @return FileDicom
      * @throws OHServiceException 
      */
-    public FileDicom loadDetails(Long idFile, int patientID, String seriesNumber) throws OHServiceException;
+	FileDicom loadDetails(Long idFile, int patientID, String seriesNumber) throws OHServiceException;
 
     /**
      * Load detail
@@ -63,7 +63,7 @@ public interface DicomManagerInterface
      * @return FileDicom
      * @throws OHServiceException 
      */
-    public FileDicom loadDetails(long idFile, int patientID, String seriesNumber) throws OHServiceException;
+	FileDicom loadDetails(long idFile, int patientID, String seriesNumber) throws OHServiceException;
 
     /**
      * load metadata from DICOM files of the patient
@@ -71,12 +71,12 @@ public interface DicomManagerInterface
      * @return
      * @throws OHServiceException 
      */
-    public FileDicom[] loadPatientFiles(int patientID) throws OHServiceException;
+	FileDicom[] loadPatientFiles(int patientID) throws OHServiceException;
 
     /**
      * save the DICOM file and metadata
      * @param dicom
      * @throws OHServiceException 
      */
-    public void saveFile(FileDicom dicom) throws OHServiceException;
+	void saveFile(FileDicom dicom) throws OHServiceException;
 }

--- a/src/main/java/org/isf/dicom/manager/DicomManagerInterface.java
+++ b/src/main/java/org/isf/dicom/manager/DicomManagerInterface.java
@@ -17,7 +17,7 @@ public interface DicomManagerInterface
      * @return
      * @throws OHServiceException 
      */
-	Long[] getSerieDetail(int patientID, String seriesNumber) throws OHServiceException;
+    Long[] getSerieDetail(int patientID, String seriesNumber) throws OHServiceException;
 
     /**
      * Delete series 

--- a/src/main/java/org/isf/dicom/manager/DicomManagerInterface.java
+++ b/src/main/java/org/isf/dicom/manager/DicomManagerInterface.java
@@ -34,7 +34,7 @@ public interface DicomManagerInterface
     * @return true if file exist
      * @throws OHServiceException 
     */
-	boolean exist(FileDicom dicom) throws OHServiceException;
+    boolean exist(FileDicom dicom) throws OHServiceException;
     
     /**
      * Check if dicom is loaded

--- a/src/main/java/org/isf/medicalstock/service/LotIoOperationRepository.java
+++ b/src/main/java/org/isf/medicalstock/service/LotIoOperationRepository.java
@@ -19,5 +19,5 @@ public interface LotIoOperationRepository extends JpaRepository<Lot, String> {
 		+ "((MEDICALDSRLOT join MEDICALDSRSTOCKMOV on MMV_LT_ID_A=LT_ID_A) join MEDICALDSR on MMV_MDSR_ID=MDSR_ID)"
 		+ " join MEDICALDSRSTOCKMOVTYPE on MMV_MMVT_ID_A=MMVT_ID_A "
 		+ "where LT_ID_A=:code group by LT_ID_A order by LT_DUE_DATE", nativeQuery= true)
-    List<Object[]> findAllWhereLot(@Param("code") String code);
+	List<Object[]> findAllWhereLot(@Param("code") String code);
 }

--- a/src/main/java/org/isf/medicalstock/service/LotIoOperationRepository.java
+++ b/src/main/java/org/isf/medicalstock/service/LotIoOperationRepository.java
@@ -19,5 +19,5 @@ public interface LotIoOperationRepository extends JpaRepository<Lot, String> {
 		+ "((MEDICALDSRLOT join MEDICALDSRSTOCKMOV on MMV_LT_ID_A=LT_ID_A) join MEDICALDSR on MMV_MDSR_ID=MDSR_ID)"
 		+ " join MEDICALDSRSTOCKMOVTYPE on MMV_MMVT_ID_A=MMVT_ID_A "
 		+ "where LT_ID_A=:code group by LT_ID_A order by LT_DUE_DATE", nativeQuery= true)
-	public List<Object[]> findAllWhereLot(@Param("code") String code);
+    List<Object[]> findAllWhereLot(@Param("code") String code);
 }

--- a/src/main/java/org/isf/medicalstockward/service/MedicalStockWardIoOperationRepository.java
+++ b/src/main/java/org/isf/medicalstockward/service/MedicalStockWardIoOperationRepository.java
@@ -15,7 +15,7 @@ import org.springframework.transaction.annotation.Transactional;
 public interface MedicalStockWardIoOperationRepository extends JpaRepository<MedicalWard, String>, MedicalStockWardIoOperationRepositoryCustom {
 
     @Query(value = "SELECT * FROM MEDICALDSRWARD WHERE MDSRWRD_WRD_ID_A = :ward AND MDSRWRD_MDSR_ID = :medical AND MDSRWRD_LT_ID_A = :lot", nativeQuery= true)
-    public MedicalWard findOneWhereCodeAndMedicalAndLot(@Param("ward") String ward, @Param("medical") int medical, @Param("lot") String lot);
+    MedicalWard findOneWhereCodeAndMedicalAndLot(@Param("ward") String ward, @Param("medical") int medical, @Param("lot") String lot);
 
     @Query(value = "select medWard from MedicalWard medWard where medWard.id.ward.code=:ward " +
 			"and medWard.id.medical.code=:medical")
@@ -32,7 +32,7 @@ public interface MedicalStockWardIoOperationRepository extends JpaRepository<Med
     @Modifying
     @Transactional
     @Query(value = "UPDATE MEDICALDSRWARD SET MDSRWRD_IN_QTI = MDSRWRD_IN_QTI + :quantity WHERE MDSRWRD_WRD_ID_A = :ward AND MDSRWRD_MDSR_ID = :medical AND MDSRWRD_LT_ID_A = :lot", nativeQuery= true)
-    public void updateInQuantity(@Param("quantity") Double quantity, @Param("ward") String ward, @Param("medical") int medical, @Param("lot") String lot);
+    void updateInQuantity(@Param("quantity") Double quantity, @Param("ward") String ward, @Param("medical") int medical, @Param("lot") String lot);
 
     @Query(value = "update MedicalWard set in_quantity=in_quantity+:quantity where id.ward.code=:ward and id.medical.code=:medical")
     void updateInQuantity(@Param("quantity") Double quantity, @Param("ward") String ward, @Param("medical") int medical);
@@ -40,13 +40,13 @@ public interface MedicalStockWardIoOperationRepository extends JpaRepository<Med
     @Modifying
     @Transactional
     @Query(value = "UPDATE MEDICALDSRWARD SET MDSRWRD_OUT_QTI = MDSRWRD_OUT_QTI + :quantity WHERE MDSRWRD_WRD_ID_A = :ward AND MDSRWRD_MDSR_ID = :medical AND MDSRWRD_LT_ID_A = :lot ", nativeQuery= true)
-    public void updateOutQuantity(@Param("quantity") Double quantity, @Param("ward") String ward, @Param("medical") int medical, @Param("lot") String lot);
+    void updateOutQuantity(@Param("quantity") Double quantity, @Param("ward") String ward, @Param("medical") int medical, @Param("lot") String lot);
 
     @Modifying
     @Transactional
     @Query(value = "INSERT INTO MEDICALDSRWARD (MDSRWRD_WRD_ID_A, MDSRWRD_MDSR_ID, MDSRWRD_IN_QTI, MDSRWRD_OUT_QTI, MDSRWRD_LT_ID_A) " +
     		"VALUES (?, ?, ?, '0', ?)", nativeQuery= true)
-    public void insertMedicalWard(@Param("ward") String ward, @Param("medical") int medical, @Param("quantity") Double quantity, @Param("lot") String lot );
+    void insertMedicalWard(@Param("ward") String ward, @Param("medical") int medical, @Param("quantity") Double quantity, @Param("lot") String lot);
 
     @Query(value = "SELECT * FROM MEDICALDSRWARD WHERE MDSRWRD_WRD_ID_A = :ward", nativeQuery= true)
 	List<MedicalWard> findAllWhereWard(@Param("ward") char wardId);

--- a/src/main/java/org/isf/visits/service/VisitsIoOperationRepository.java
+++ b/src/main/java/org/isf/visits/service/VisitsIoOperationRepository.java
@@ -21,7 +21,7 @@ public interface VisitsIoOperationRepository extends JpaRepository<Visit, Intege
 	List<Visit> findAllWhereWardByOrderPatientAndDateAsc(@Param("wardId") String wardId);
 
 	@Query(value = "SELECT * FROM VISITS WHERE VST_WARD_ID = :ward ORDER BY VST_DATE", nativeQuery= true)
-        List<Visit> findAllWhereWardByOrderDateAsc(@Param("ward") String ward);
+	List<Visit> findAllWhereWardByOrderDateAsc(@Param("ward") String ward);
 
 	@Query(value = "SELECT * FROM VISITS WHERE VST_PAT_ID = :patient ORDER BY VST_PAT_ID, VST_DATE", nativeQuery= true)
 	List<Visit> findAllWherePatientByOrderPatientAndDateAsc(@Param("patient") Integer patient);

--- a/src/main/java/org/isf/visits/service/VisitsIoOperationRepository.java
+++ b/src/main/java/org/isf/visits/service/VisitsIoOperationRepository.java
@@ -21,7 +21,7 @@ public interface VisitsIoOperationRepository extends JpaRepository<Visit, Intege
 	List<Visit> findAllWhereWardByOrderPatientAndDateAsc(@Param("wardId") String wardId);
 
 	@Query(value = "SELECT * FROM VISITS WHERE VST_WARD_ID = :ward ORDER BY VST_DATE", nativeQuery= true)
-    List<Visit> findAllWhereWardByOrderDateAsc(@Param("ward") String ward);
+        List<Visit> findAllWhereWardByOrderDateAsc(@Param("ward") String ward);
 
 	@Query(value = "SELECT * FROM VISITS WHERE VST_PAT_ID = :patient ORDER BY VST_PAT_ID, VST_DATE", nativeQuery= true)
 	List<Visit> findAllWherePatientByOrderPatientAndDateAsc(@Param("patient") Integer patient);

--- a/src/main/java/org/isf/visits/service/VisitsIoOperationRepository.java
+++ b/src/main/java/org/isf/visits/service/VisitsIoOperationRepository.java
@@ -21,7 +21,7 @@ public interface VisitsIoOperationRepository extends JpaRepository<Visit, Intege
 	List<Visit> findAllWhereWardByOrderPatientAndDateAsc(@Param("wardId") String wardId);
 
 	@Query(value = "SELECT * FROM VISITS WHERE VST_WARD_ID = :ward ORDER BY VST_DATE", nativeQuery= true)
-	public List<Visit> findAllWhereWardByOrderDateAsc(@Param("ward") String ward);
+    List<Visit> findAllWhereWardByOrderDateAsc(@Param("ward") String ward);
 
 	@Query(value = "SELECT * FROM VISITS WHERE VST_PAT_ID = :patient ORDER BY VST_PAT_ID, VST_DATE", nativeQuery= true)
 	List<Visit> findAllWherePatientByOrderPatientAndDateAsc(@Param("patient") Integer patient);


### PR DESCRIPTION
Removed redundant `public` modifier for interface methods.  Note some of the file already had some methods without the `public` so this makes things consistent.