### PR TITLE
Remove redundant public for interface methods

### DIFF
--- a/src/main/java/org/isf/dicom/manager/DicomManagerInterface.java
+++ b/src/main/java/org/isf/dicom/manager/DicomManagerInterface.java
@@ -5,78 +5,87 @@ import org.isf.utils.exception.OHServiceException;
 
 /**
  * Interface for definitions IO for Dicom acquired files
+ *
  * @author Pietro Castellucci
- * @version 1.0.0 
+ * @version 1.0.0
  */
-public interface DicomManagerInterface 
-{   
-    /**
-     * Load a list of idfile for series
-     * @param patientID, the patient id
-     * @param seriesNumber, the series number
-     * @return
-     * @throws OHServiceException 
-     */
-    public Long[] getSerieDetail(int patientID, String seriesNumber) throws OHServiceException;
+public interface DicomManagerInterface {
 
-    /**
-     * Delete series 
-     * @param patientID, the id of patient
-     * @param seriesNumber, the series number to delete
-     * @return true if success
-     * @throws OHServiceException 
-     */
-    boolean deleteSerie(int patientID, String seriesNumber) throws OHServiceException ;
-    
-    /**
-    * Check if dicom is loaded
-    * @param dicom, the detail of dicom
-    * @return true if file exist
-     * @throws OHServiceException 
-    */
-    public boolean exist(FileDicom dicom) throws OHServiceException;
-    
-    /**
-     * Check if dicom is loaded
-     * @param patientID, the id of patient
-     * @param seriesNumber, the series number
-     * @return true if file exist
-      * @throws OHServiceException 
-     */
-     public boolean exist(int patientID, String seriesNumber) throws OHServiceException;
+	/**
+	 * Load a list of idfile for series
+	 *
+	 * @param patientID, the patient id
+	 * @param seriesNumber, the series number
+	 * @return
+	 * @throws OHServiceException
+	 */
+	Long[] getSerieDetail(int patientID, String seriesNumber) throws OHServiceException;
 
-    /**
-     * Load the Detail of DICOM
-     * @param idFile
-     * @param patientID
-     * @param seriesNumber
-     * @return FileDicom
-     * @throws OHServiceException 
-     */
-    public FileDicom loadDetails(Long idFile, int patientID, String seriesNumber) throws OHServiceException;
+	/**
+	 * Delete series
+	 *
+	 * @param patientID, the id of patient
+	 * @param seriesNumber, the series number to delete
+	 * @return true if success
+	 * @throws OHServiceException
+	 */
+	boolean deleteSerie(int patientID, String seriesNumber) throws OHServiceException;
 
-    /**
-     * Load detail
-     * @param idFile
-     * @param patientID
-     * @param seriesNumber
-     * @return FileDicom
-     * @throws OHServiceException 
-     */
-    public FileDicom loadDetails(long idFile, int patientID, String seriesNumber) throws OHServiceException;
+	/**
+	 * Check if dicom is loaded
+	 *
+	 * @param dicom, the detail of dicom
+	 * @return true if file exist
+	 * @throws OHServiceException
+	 */
+	boolean exist(FileDicom dicom) throws OHServiceException;
 
-    /**
-     * load metadata from DICOM files of the patient
-     * @param patientID
-     * @return
-     * @throws OHServiceException 
-     */
-    public FileDicom[] loadPatientFiles(int patientID) throws OHServiceException;
+	/**
+	 * Check if dicom is loaded
+	 *
+	 * @param patientID, the id of patient
+	 * @param seriesNumber, the series number
+	 * @return true if file exist
+	 * @throws OHServiceException
+	 */
+	boolean exist(int patientID, String seriesNumber) throws OHServiceException;
 
-    /**
-     * save the DICOM file and metadata
-     * @param dicom
-     * @throws OHServiceException 
-     */
-    public void saveFile(FileDicom dicom) throws OHServiceException;
+	/**
+	 * Load the Detail of DICOM
+	 *
+	 * @param idFile
+	 * @param patientID
+	 * @param seriesNumber
+	 * @return FileDicom
+	 * @throws OHServiceException
+	 */
+	FileDicom loadDetails(Long idFile, int patientID, String seriesNumber) throws OHServiceException;
+
+	/**
+	 * Load detail
+	 *
+	 * @param idFile
+	 * @param patientID
+	 * @param seriesNumber
+	 * @return FileDicom
+	 * @throws OHServiceException
+	 */
+	FileDicom loadDetails(long idFile, int patientID, String seriesNumber) throws OHServiceException;
+
+	/**
+	 * Load metadata from DICOM files of the patient
+	 *
+	 * @param patientID
+	 * @return
+	 * @throws OHServiceException
+	 */
+	FileDicom[] loadPatientFiles(int patientID) throws OHServiceException;
+
+	/**
+	 * Save the DICOM file and metadata
+	 *
+	 * @param dicom
+	 * @throws OHServiceException
+	 */
+	void saveFile(FileDicom dicom) throws OHServiceException;
 }

--- a/src/main/java/org/isf/medicalstock/service/LotIoOperationRepository.java
+++ b/src/main/java/org/isf/medicalstock/service/LotIoOperationRepository.java
@@ -10,13 +10,14 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface LotIoOperationRepository extends JpaRepository<Lot, String> {
+
 	@Query("select l from Lot l left join l.movements m where m.medical.code = :medical group by l.code")
 	List<Lot> findByMovements_MedicalOrderByDueDate(@Param("medical") int medicalCode);
 
 	@Query(value = "select LT_ID_A,LT_PREP_DATE,LT_DUE_DATE,LT_COST,"
-		+ "SUM(IF(MMVT_TYPE LIKE '%+%',MMV_QTY,-MMV_QTY)) as quantity from "
-		+ "((MEDICALDSRLOT join MEDICALDSRSTOCKMOV on MMV_LT_ID_A=LT_ID_A) join MEDICALDSR on MMV_MDSR_ID=MDSR_ID)"
-		+ " join MEDICALDSRSTOCKMOVTYPE on MMV_MMVT_ID_A=MMVT_ID_A "
-		+ "where LT_ID_A=:code group by LT_ID_A order by LT_DUE_DATE", nativeQuery= true)
-	public List<Object[]> findAllWhereLot(@Param("code") String code);
+			+ "SUM(IF(MMVT_TYPE LIKE '%+%',MMV_QTY,-MMV_QTY)) as quantity from "
+			+ "((MEDICALDSRLOT join MEDICALDSRSTOCKMOV on MMV_LT_ID_A=LT_ID_A) join MEDICALDSR on MMV_MDSR_ID=MDSR_ID)"
+			+ " join MEDICALDSRSTOCKMOVTYPE on MMV_MMVT_ID_A=MMVT_ID_A "
+			+ "where LT_ID_A=:code group by LT_ID_A order by LT_DUE_DATE", nativeQuery = true)
+	List<Object[]> findAllWhereLot(@Param("code") String code);
 }

--- a/src/main/java/org/isf/medicalstockward/service/MedicalStockWardIoOperationRepository.java
+++ b/src/main/java/org/isf/medicalstockward/service/MedicalStockWardIoOperationRepository.java
@@ -14,47 +14,47 @@ import org.springframework.transaction.annotation.Transactional;
 @Repository
 public interface MedicalStockWardIoOperationRepository extends JpaRepository<MedicalWard, String>, MedicalStockWardIoOperationRepositoryCustom {
 
-    @Query(value = "SELECT * FROM MEDICALDSRWARD WHERE MDSRWRD_WRD_ID_A = :ward AND MDSRWRD_MDSR_ID = :medical AND MDSRWRD_LT_ID_A = :lot", nativeQuery= true)
-    public MedicalWard findOneWhereCodeAndMedicalAndLot(@Param("ward") String ward, @Param("medical") int medical, @Param("lot") String lot);
+	@Query(value = "SELECT * FROM MEDICALDSRWARD WHERE MDSRWRD_WRD_ID_A = :ward AND MDSRWRD_MDSR_ID = :medical AND MDSRWRD_LT_ID_A = :lot", nativeQuery = true)
+	MedicalWard findOneWhereCodeAndMedicalAndLot(@Param("ward") String ward, @Param("medical") int medical, @Param("lot") String lot);
 
-    @Query(value = "select medWard from MedicalWard medWard where medWard.id.ward.code=:ward " +
+	@Query(value = "select medWard from MedicalWard medWard where medWard.id.ward.code=:ward " +
 			"and medWard.id.medical.code=:medical")
-    MedicalWard findOneWhereCodeAndMedical(@Param("ward") String ward, @Param("medical") int medical);
+	MedicalWard findOneWhereCodeAndMedical(@Param("ward") String ward, @Param("medical") int medical);
 
-    @Query(value = "select sum(medWard.in_quantity-medWard.out_quantity) from MedicalWard medWard " +
+	@Query(value = "select sum(medWard.in_quantity-medWard.out_quantity) from MedicalWard medWard " +
 			"where medWard.id.medical.code=:medical")
-    Double findQuantityInWardWhereMedical(@Param("medical") int medical);
+	Double findQuantityInWardWhereMedical(@Param("medical") int medical);
 
-    @Query(value = "select sum(medWard.in_quantity-medWard.out_quantity) from MedicalWard medWard " +
+	@Query(value = "select sum(medWard.in_quantity-medWard.out_quantity) from MedicalWard medWard " +
 			"where medWard.id.medical.code=:medical and medWard.id.ward.code=:ward")
-    Double findQuantityInWardWhereMedicalAndWard(@Param("medical") int medical, @Param("ward") String ward);
+	Double findQuantityInWardWhereMedicalAndWard(@Param("medical") int medical, @Param("ward") String ward);
 
-    @Modifying
-    @Transactional
-    @Query(value = "UPDATE MEDICALDSRWARD SET MDSRWRD_IN_QTI = MDSRWRD_IN_QTI + :quantity WHERE MDSRWRD_WRD_ID_A = :ward AND MDSRWRD_MDSR_ID = :medical AND MDSRWRD_LT_ID_A = :lot", nativeQuery= true)
-    public void updateInQuantity(@Param("quantity") Double quantity, @Param("ward") String ward, @Param("medical") int medical, @Param("lot") String lot);
+	@Modifying
+	@Transactional
+	@Query(value = "UPDATE MEDICALDSRWARD SET MDSRWRD_IN_QTI = MDSRWRD_IN_QTI + :quantity WHERE MDSRWRD_WRD_ID_A = :ward AND MDSRWRD_MDSR_ID = :medical AND MDSRWRD_LT_ID_A = :lot", nativeQuery = true)
+	void updateInQuantity(@Param("quantity") Double quantity, @Param("ward") String ward, @Param("medical") int medical, @Param("lot") String lot);
 
-    @Query(value = "update MedicalWard set in_quantity=in_quantity+:quantity where id.ward.code=:ward and id.medical.code=:medical")
-    void updateInQuantity(@Param("quantity") Double quantity, @Param("ward") String ward, @Param("medical") int medical);
+	@Query(value = "update MedicalWard set in_quantity=in_quantity+:quantity where id.ward.code=:ward and id.medical.code=:medical")
+	void updateInQuantity(@Param("quantity") Double quantity, @Param("ward") String ward, @Param("medical") int medical);
 
-    @Modifying
-    @Transactional
-    @Query(value = "UPDATE MEDICALDSRWARD SET MDSRWRD_OUT_QTI = MDSRWRD_OUT_QTI + :quantity WHERE MDSRWRD_WRD_ID_A = :ward AND MDSRWRD_MDSR_ID = :medical AND MDSRWRD_LT_ID_A = :lot ", nativeQuery= true)
-    public void updateOutQuantity(@Param("quantity") Double quantity, @Param("ward") String ward, @Param("medical") int medical, @Param("lot") String lot);
+	@Modifying
+	@Transactional
+	@Query(value = "UPDATE MEDICALDSRWARD SET MDSRWRD_OUT_QTI = MDSRWRD_OUT_QTI + :quantity WHERE MDSRWRD_WRD_ID_A = :ward AND MDSRWRD_MDSR_ID = :medical AND MDSRWRD_LT_ID_A = :lot ", nativeQuery = true)
+	void updateOutQuantity(@Param("quantity") Double quantity, @Param("ward") String ward, @Param("medical") int medical, @Param("lot") String lot);
 
-    @Modifying
-    @Transactional
-    @Query(value = "INSERT INTO MEDICALDSRWARD (MDSRWRD_WRD_ID_A, MDSRWRD_MDSR_ID, MDSRWRD_IN_QTI, MDSRWRD_OUT_QTI, MDSRWRD_LT_ID_A) " +
-    		"VALUES (?, ?, ?, '0', ?)", nativeQuery= true)
-    public void insertMedicalWard(@Param("ward") String ward, @Param("medical") int medical, @Param("quantity") Double quantity, @Param("lot") String lot );
+	@Modifying
+	@Transactional
+	@Query(value = "INSERT INTO MEDICALDSRWARD (MDSRWRD_WRD_ID_A, MDSRWRD_MDSR_ID, MDSRWRD_IN_QTI, MDSRWRD_OUT_QTI, MDSRWRD_LT_ID_A) " +
+			"VALUES (?, ?, ?, '0', ?)", nativeQuery = true)
+	void insertMedicalWard(@Param("ward") String ward, @Param("medical") int medical, @Param("quantity") Double quantity, @Param("lot") String lot);
 
-    @Query(value = "SELECT * FROM MEDICALDSRWARD WHERE MDSRWRD_WRD_ID_A = :ward", nativeQuery= true)
+	@Query(value = "SELECT * FROM MEDICALDSRWARD WHERE MDSRWRD_WRD_ID_A = :ward", nativeQuery = true)
 	List<MedicalWard> findAllWhereWard(@Param("ward") char wardId);
 
-    @Query(value = "update MedicalWard set out_quantity=out_quantity+:quantity where id.ward.code=:ward and id.medical.code=:medical")
+	@Query(value = "update MedicalWard set out_quantity=out_quantity+:quantity where id.ward.code=:ward and id.medical.code=:medical")
 	void updateOutQuantity(@Param("quantity") Double quantity, @Param("ward") String ward, @Param("medical") int medical);
 
-    @Query(value = "select medWard from MedicalWard medWard where medWard.id.ward.code=:ward")
-    List<MedicalWard> findAllWhereWard(@Param("ward") String wordCode);
+	@Query(value = "select medWard from MedicalWard medWard where medWard.id.ward.code=:ward")
+	List<MedicalWard> findAllWhereWard(@Param("ward") String wordCode);
 
 }

--- a/src/main/java/org/isf/visits/service/VisitsIoOperationRepository.java
+++ b/src/main/java/org/isf/visits/service/VisitsIoOperationRepository.java
@@ -11,18 +11,21 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface VisitsIoOperationRepository extends JpaRepository<Visit, Integer> {
-    List<Visit> findAllByOrderByPatient_CodeAscDateAsc();
-    List<Visit> findAllByPatient_CodeOrderByPatient_CodeAscDateAsc(@Param("patient") Integer patient);
-    @Modifying
-    void deleteByPatient_Code(@Param("patient") Integer patient);
 
-	@Query(value = "SELECT * FROM VISITS WHERE VST_WRD_ID_A = :wardId ORDER BY VST_PAT_ID, VST_DATE", nativeQuery= true)
+	List<Visit> findAllByOrderByPatient_CodeAscDateAsc();
+
+	List<Visit> findAllByPatient_CodeOrderByPatient_CodeAscDateAsc(@Param("patient") Integer patient);
+
+	@Modifying
+	void deleteByPatient_Code(@Param("patient") Integer patient);
+
+	@Query(value = "SELECT * FROM VISITS WHERE VST_WRD_ID_A = :wardId ORDER BY VST_PAT_ID, VST_DATE", nativeQuery = true)
 	List<Visit> findAllWhereWardByOrderPatientAndDateAsc(@Param("wardId") String wardId);
 
-	@Query(value = "SELECT * FROM VISITS WHERE VST_WARD_ID = :ward ORDER BY VST_DATE", nativeQuery= true)
-	public List<Visit> findAllWhereWardByOrderDateAsc(@Param("ward") String ward);
+	@Query(value = "SELECT * FROM VISITS WHERE VST_WARD_ID = :ward ORDER BY VST_DATE", nativeQuery = true)
+	List<Visit> findAllWhereWardByOrderDateAsc(@Param("ward") String ward);
 
-	@Query(value = "SELECT * FROM VISITS WHERE VST_PAT_ID = :patient ORDER BY VST_PAT_ID, VST_DATE", nativeQuery= true)
+	@Query(value = "SELECT * FROM VISITS WHERE VST_PAT_ID = :patient ORDER BY VST_PAT_ID, VST_DATE", nativeQuery = true)
 	List<Visit> findAllWherePatientByOrderPatientAndDateAsc(@Param("patient") Integer patient);
 
 }


### PR DESCRIPTION
This replaces this [PR](https://github.com/informatici/openhospital-core/pull/135).

Removed redundant public modifier for interface methods. Note some of the file already had some methods without the public so this makes things consistent.

Even though it looks like a lot of changes it really isn't as the files each were a mixture of spaces and tabs and I reformatted them all to tabs before applying the change.