### PR TITLE
Revert "Bump jasperreports from 3.0.0 to 3.5.3"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -160,7 +160,7 @@
 					<groupId>commons-logging</groupId>
 				</exclusion>
 			</exclusions>
-			<version>3.5.3</version>
+			<version>3.0.0</version>
 		</dependency>
 		<dependency>
 			<groupId>com.lowagie</groupId>


### PR DESCRIPTION
Temporarily reverts informatici/openhospital-core#123, as we need to solve some incompatibility issues with Jasper before bumping its version (https://openhospital.atlassian.net/browse/OP-104) or migrate to the rebranded library (https://mvnrepository.com/artifact/net.sf.jasperreports/jasperreports ).