### PR TITLE
Add maven license plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -117,7 +117,35 @@
 					<finalName>OpenHospital20/bin/OH-core</finalName>
 				</configuration>
 			</plugin>
-
+			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>license-maven-plugin</artifactId>
+				<version>2.0.0</version>
+				<configuration>
+					<verbose>false</verbose>
+					<addSvnKeyWords>true</addSvnKeyWords>
+				</configuration>
+				<executions>
+					<execution>
+						<id>first</id>
+						<goals>
+							<goal>update-file-header</goal>
+						</goals>
+						<phase>process-sources</phase>
+						<configuration>
+							<licenseName>gpl_v3</licenseName>
+							<inceptionYear>2006</inceptionYear>
+							<organizationName>Informatici Senza Frontiere</organizationName>
+							<projectName>OpenHospital</projectName>
+							<addJavaLicenseAfterPackage>false</addJavaLicenseAfterPackage>
+							<roots>
+								<root>src/main/java</root>
+								<root>src/test</root>
+							</roots>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
 		</plugins>
 	</build>
 


### PR DESCRIPTION
Per comment in this [PR](https://github.com/informatici/openhospital-gui/pull/195#discussion_r472464238), here is an example of using the Maven license plugin with associated changes to the `pom.xml` file.

![License](https://user-images.githubusercontent.com/1105445/90624360-d5dcd000-e1e5-11ea-8d0f-356b064620cc.jpg)

To modify the java source files run this command: `mvn process-sources`.

If this PR is OK I can add it to the other repositories.

We will most likely need to review each file to ensure there aren't other bogus headers from the original implementation but it is a start.