### PR TITLE
Simplify assertions

### DIFF
--- a/src/test/java/org/isf/accounting/test/Tests.java
+++ b/src/test/java/org/isf/accounting/test/Tests.java
@@ -1,7 +1,9 @@
 package org.isf.accounting.test;
 
-
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.util.ArrayList;
 import java.util.GregorianCalendar;
@@ -126,7 +128,7 @@ public class Tests
 		catch (Exception e) 
 		{
 			e.printStackTrace();	
-			assertEquals(true, false);
+			fail();
 		}
 				
 		return;
@@ -146,7 +148,7 @@ public class Tests
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -166,7 +168,7 @@ public class Tests
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 				
 		return;
@@ -186,7 +188,7 @@ public class Tests
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -206,7 +208,7 @@ public class Tests
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 				
 		return;
@@ -226,7 +228,7 @@ public class Tests
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -248,7 +250,7 @@ public class Tests
 			assertEquals(mergedPatient.getCode(), resultBill.getPatient().getCode());
 		} catch (Exception e) {
 			e.printStackTrace();
-			assertEquals(true, false);
+			fail();
 		}
 	}
 
@@ -263,13 +265,13 @@ public class Tests
 			id = _setupTestBill(false);
 			Bill foundBill = (Bill)jpa.find(Bill.class, id); 
 			ArrayList<Bill> bills = accountingIoOperation.getPendingBills(0);
-			
-			assertEquals(true, bills.contains(foundBill));
+
+			assertTrue(bills.contains(foundBill));
 		} 
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}	
 				
 		return;
@@ -292,7 +294,7 @@ public class Tests
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 				
 		return;
@@ -309,13 +311,13 @@ public class Tests
 			id = _setupTestBill(false);
 			Bill foundBill = (Bill)jpa.find(Bill.class, id); 
 			ArrayList<Bill> bills = accountingIoOperation.getBills();
-			
-			assertEquals(true, bills.contains(foundBill));
+
+			assertTrue(bills.contains(foundBill));
 		} 
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 				
 		return;
@@ -338,7 +340,7 @@ public class Tests
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 				
 		return;
@@ -356,13 +358,13 @@ public class Tests
 			id = _setupTestBillPayments(false);
 			BillPayments foundBillPayment = (BillPayments)jpa.find(BillPayments.class, id); 
 			userIds = accountingIoOperation.getUsers();
-			
-			assertEquals(true, userIds.contains(foundBillPayment.getUser()));
+
+			assertTrue(userIds.contains(foundBillPayment.getUser()));
 		} 
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 				
 		return;
@@ -377,13 +379,13 @@ public class Tests
 			
 			BillItems foundBillItem = (BillItems)jpa.find(BillItems.class, billItemID); 
 			ArrayList<BillItems> billItems = accountingIoOperation.getItems(foundBillItem.getBill().getId());
-			
-			assertEquals(true, billItems.contains(foundBillItem));
+
+			assertTrue(billItems.contains(foundBillItem));
 		} 
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 				
 		return;
@@ -406,7 +408,7 @@ public class Tests
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 				
 		return;
@@ -425,13 +427,13 @@ public class Tests
 			GregorianCalendar dateFrom = new GregorianCalendar(4, 3, 2);
 			GregorianCalendar dateTo = new GregorianCalendar();
 			ArrayList<BillPayments> billPayments = accountingIoOperation.getPayments(dateFrom, dateTo);
-			
-			assertEquals(true, billPayments.contains(foundBillPayment));
+
+			assertTrue(billPayments.contains(foundBillPayment));
 		} 
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 				
 		return;
@@ -454,7 +456,7 @@ public class Tests
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 				
 		return;
@@ -484,7 +486,7 @@ public class Tests
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 						
 		return;
@@ -509,14 +511,14 @@ public class Tests
 			billItems.add(insertBillItem);	
 			result = accountingIoOperation.newBillItems(bill, billItems);
 			
-			BillItems foundBillItems = (BillItems)jpa.find(BillItems.class, insertId); 		
-			assertEquals(true, result);				
+			BillItems foundBillItems = (BillItems)jpa.find(BillItems.class, insertId);
+			assertTrue(result);
 			assertEquals(bill.getId(), foundBillItems.getBill().getId());		
 		} 
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -541,14 +543,14 @@ public class Tests
 			billPayments.add(insertBillPayment);	
 			result = accountingIoOperation.newBillPayments(bill, billPayments);
 			
-			BillPayments foundBillPayments = (BillPayments)jpa.find(BillPayments.class, insertId); 		
-			assertEquals(true, result);				
+			BillPayments foundBillPayments = (BillPayments)jpa.find(BillPayments.class, insertId);
+			assertTrue(result);
 			assertEquals(bill.getId(), foundBillPayments.getBill().getId());		
 		} 
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}	
 		
 		return;
@@ -573,7 +575,7 @@ public class Tests
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 						
 		return;
@@ -591,13 +593,13 @@ public class Tests
 			Bill bill = (Bill)jpa.find(Bill.class, id); 
 			
 			boolean result = accountingIoOperation.deleteBill(bill);
-			 		
-			assertEquals(true, result);
+
+			assertTrue(result);
 		} 
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 						
 		return;
@@ -616,13 +618,13 @@ public class Tests
 			GregorianCalendar dateFrom = new GregorianCalendar(4, 3, 2);
 			GregorianCalendar dateTo = new GregorianCalendar();
 			ArrayList<Bill> bills = accountingIoOperation.getBills(dateFrom, dateTo);
-			
-			assertEquals(true, bills.contains(foundBill));
+
+			assertTrue(bills.contains(foundBill));
 		} 
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 				
 		return;
@@ -642,32 +644,32 @@ public class Tests
 			Bill foundBill = (Bill)jpa.find(Bill.class, id); 
 			
 			ArrayList<Bill> bills = accountingIoOperation.getBills(dateFrom, dateTo);
-			assertEquals(true, bills.contains(foundBill));
+			assertTrue(bills.contains(foundBill));
 			
 			bills = accountingIoOperation.getBills(new GregorianCalendar(10, 0, 1), dateFrom);
-			assertEquals(false, bills.contains(foundBill));
+			assertFalse(bills.contains(foundBill));
 			
 			bills = accountingIoOperation.getBills(dateTo, new GregorianCalendar(11, 0, 1));
-			assertEquals(false, bills.contains(foundBill));
+			assertFalse(bills.contains(foundBill));
 			
 			id = _setupTestBillItems(false);
 			BillItems foundBillItem = (BillItems)jpa.find(BillItems.class, id);
 			foundBill = (Bill)jpa.find(Bill.class, foundBillItem.getBill().getId());
 			
 			bills = accountingIoOperation.getBills(dateFrom, dateTo, foundBillItem);
-			assertEquals(true, bills.contains(foundBill));
+			assertTrue(bills.contains(foundBill));
 			
 			id = _setupTestBillItems(true);
 			foundBillItem = (BillItems)jpa.find(BillItems.class, id);
 			
 			bills = accountingIoOperation.getBills(dateFrom, dateTo, foundBillItem);
-			assertEquals(true, bills.contains(foundBill));
+			assertTrue(bills.contains(foundBill));
 			
 		} 
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 				
 		return;
@@ -693,7 +695,7 @@ public class Tests
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 				
 		return;
@@ -720,7 +722,7 @@ public class Tests
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 				
 		return;
@@ -731,7 +733,7 @@ public class Tests
 		int id = _setupTestBillItems(false);
 		BillItems foundBillItem = (BillItems)jpa.find(BillItems.class, id);
 		List<BillItems> billItems = accountingIoOperation.getDistictsBillItems();
-		assertEquals(true, billItems.contains(foundBillItem));
+		assertTrue(billItems.contains(foundBillItem));
 	}
 
 	private void _saveContext() throws OHException 

--- a/src/test/java/org/isf/admission/test/Tests.java
+++ b/src/test/java/org/isf/admission/test/Tests.java
@@ -1,7 +1,13 @@
 package org.isf.admission.test;
 
-
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.GregorianCalendar;
 
 import org.isf.admission.model.Admission;
 import org.isf.admission.model.AdmittedPatient;
@@ -52,12 +58,6 @@ import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringRunner;
-
-import java.util.ArrayList;
-import java.util.Calendar;
-import java.util.GregorianCalendar;
-
-import static org.junit.Assert.assertEquals;
 
 @RunWith(SpringRunner.class)
 @ContextConfiguration(locations = { "classpath:applicationContext.xml" })
@@ -191,7 +191,7 @@ public class Tests
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 				
 		return;
@@ -211,7 +211,7 @@ public class Tests
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -460,7 +460,7 @@ public class Tests
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 	
 		return;
@@ -482,7 +482,7 @@ public class Tests
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 	
 		return;
@@ -505,7 +505,7 @@ public class Tests
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 	
 		return;
@@ -559,14 +559,14 @@ public class Tests
 					diseaseOut2, diseaseOut3, operation, dischargeType, pregTreatmentType, 
 					deliveryType, deliveryResult, true);
 			result = admissionIoOperation.newAdmission(admission);
-					
-					assertEquals(true, result);
-					_checkAdmissionIntoDb(admission.getId());
+
+			assertTrue(result);
+			_checkAdmissionIntoDb(admission.getId());
 		} 
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -626,7 +626,7 @@ public class Tests
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -646,15 +646,15 @@ public class Tests
 			jpa.flush();
 			foundAdmission.setNote("Update");
 			result = admissionIoOperation.updateAdmission(foundAdmission);
-			Admission updateAdmission = (Admission)jpa.find(Admission.class, id); 
-			
-			assertEquals(true, result);
+			Admission updateAdmission = (Admission)jpa.find(Admission.class, id);
+
+			assertTrue(result);
 			assertEquals("Update", updateAdmission.getNote());
 		} 
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -677,7 +677,7 @@ public class Tests
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -700,7 +700,7 @@ public class Tests
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -724,7 +724,7 @@ public class Tests
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 	
 		return;
@@ -743,13 +743,13 @@ public class Tests
 			Admission foundAdmission = (Admission)jpa.find(Admission.class, id);
 			jpa.flush();
 			result = admissionIoOperation.setDeleted(foundAdmission.getId());
-			
-			assertEquals(true, result);
+
+			assertTrue(result);
 		} 
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 
 		return;
@@ -773,7 +773,7 @@ public class Tests
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 
 		return;
@@ -791,14 +791,14 @@ public class Tests
 			id = _setupTestAdmission(false);
 			Admission foundAdmission = (Admission)jpa.find(Admission.class, id);  
 			result = admissionIoOperation.deletePatientPhoto(foundAdmission.getPatient().getCode());
-			
-			assertEquals(true, result);
-			assertEquals(null, foundAdmission.getPatient().getPatientProfilePhoto().getPhoto());
+
+			assertTrue(result);
+			assertNull(foundAdmission.getPatient().getPatientProfilePhoto().getPhoto());
 		} 
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 
 		return;

--- a/src/test/java/org/isf/admtype/test/Tests.java
+++ b/src/test/java/org/isf/admtype/test/Tests.java
@@ -1,7 +1,9 @@
 package org.isf.admtype.test;
 
-
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.util.ArrayList;
 
@@ -86,7 +88,7 @@ public class Tests
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 				
 		return;
@@ -106,7 +108,7 @@ public class Tests
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -126,7 +128,7 @@ public class Tests
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -146,15 +148,15 @@ public class Tests
 			jpa.flush();
 			foundAdmissionType.setDescription("Update");
 			result = admissionTypeIoOperation.updateAdmissionType(foundAdmissionType);
-			AdmissionType updateAdmissionType = (AdmissionType)jpa.find(AdmissionType.class, code); 
-			
-			assertEquals(true, result);
+			AdmissionType updateAdmissionType = (AdmissionType)jpa.find(AdmissionType.class, code);
+
+			assertTrue(result);
 			assertEquals("Update", updateAdmissionType.getDescription());
 		} 
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -170,14 +172,14 @@ public class Tests
 		{		
 			AdmissionType admissionType = testAdmissionType.setup(true);
 			result = admissionTypeIoOperation.newAdmissionType(admissionType);
-			
-			assertEquals(true, result);
+
+			assertTrue(result);
 			_checkAdmissionTypeIntoDb(admissionType.getCode());
 		} 
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -198,10 +200,10 @@ public class Tests
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
-		
-		assertEquals(true, result);
+
+		assertTrue(result);
 		
 		return;
 	}
@@ -218,15 +220,15 @@ public class Tests
 			code = _setupTestAdmissionType(false);
 			AdmissionType foundAdmissionType = (AdmissionType)jpa.find(AdmissionType.class, code); 
 			result = admissionTypeIoOperation.deleteAdmissionType(foundAdmissionType);
-			
-			assertEquals(true, result);
+
+			assertTrue(result);
 			result = admissionTypeIoOperation.isCodePresent(code);
-			assertEquals(false, result);			
+			assertFalse(result);
 		} 
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;

--- a/src/test/java/org/isf/agetype/test/Tests.java
+++ b/src/test/java/org/isf/agetype/test/Tests.java
@@ -1,6 +1,8 @@
 package org.isf.agetype.test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.util.ArrayList;
 
@@ -85,7 +87,7 @@ public class Tests
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 				
 		return;
@@ -105,7 +107,7 @@ public class Tests
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -128,7 +130,7 @@ public class Tests
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -150,16 +152,16 @@ public class Tests
 			ArrayList<AgeType> ageTypes = new ArrayList<AgeType>();
 			ageTypes.add(foundAgeType);
 			result = ageTypeIoOperations.updateAgeType(ageTypes);
-			AgeType updateAgeType = (AgeType)jpa.find(AgeType.class, code); 
-			
-			assertEquals(true, result);
+			AgeType updateAgeType = (AgeType)jpa.find(AgeType.class, code);
+
+			assertTrue(result);
 			assertEquals(4, updateAgeType.getFrom());
 			assertEquals(40, updateAgeType.getTo());
 		} 
 		catch (Exception e) 
 		{
 			e.printStackTrace();
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -183,7 +185,7 @@ public class Tests
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;

--- a/src/test/java/org/isf/dicom/test/Tests.java
+++ b/src/test/java/org/isf/dicom/test/Tests.java
@@ -2,6 +2,9 @@ package org.isf.dicom.test;
 
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import org.isf.dicom.model.FileDicom;
 import org.isf.dicom.service.DicomIoOperations;
@@ -93,7 +96,7 @@ public class Tests
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 				
 		return;
@@ -114,7 +117,7 @@ public class Tests
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -138,7 +141,7 @@ public class Tests
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -157,15 +160,15 @@ public class Tests
 			code = _setupTestFileDicom(false);
 			FileDicom foundFileDicom = (FileDicom)jpa.find(FileDicom.class, code); 
 			result = dicomIoOperation.deleteSerie(foundFileDicom.getPatId(), foundFileDicom.getDicomSeriesNumber());
-			
-			assertEquals(true, result);
-			result = dicomIoOperation.isCodePresent(code);			
-			assertEquals(false, result);
+
+			assertTrue(result);
+			result = dicomIoOperation.isCodePresent(code);
+			assertFalse(result);
 		} 
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -191,7 +194,7 @@ public class Tests
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -220,12 +223,12 @@ public class Tests
 			FileDicom foundFileDicom = (FileDicom)jpa.find(FileDicom.class, code); 
 			result = dicomIoOperation.exist(foundFileDicom);
 
-			assertEquals(true, result);
+			assertTrue(result);
 		} 
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		
@@ -252,7 +255,7 @@ public class Tests
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;

--- a/src/test/java/org/isf/dicomtype/test/Tests.java
+++ b/src/test/java/org/isf/dicomtype/test/Tests.java
@@ -1,10 +1,9 @@
 package org.isf.dicomtype.test;
 
+import static org.junit.Assert.fail;
 
-import static org.junit.Assert.assertEquals;
-
-import org.isf.dicomtype.model.DicomType;
 import org.isf.dicom.service.DicomIoOperations;
+import org.isf.dicomtype.model.DicomType;
 import org.isf.utils.db.DbJpaUtil;
 import org.isf.utils.exception.OHException;
 import org.junit.After;
@@ -83,7 +82,7 @@ public class Tests
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 				
 		return;
@@ -104,7 +103,7 @@ public class Tests
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;

--- a/src/test/java/org/isf/disctype/test/Tests.java
+++ b/src/test/java/org/isf/disctype/test/Tests.java
@@ -2,6 +2,9 @@ package org.isf.disctype.test;
 
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.util.ArrayList;
 
@@ -84,7 +87,7 @@ public class Tests
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 				
 		return;
@@ -104,7 +107,7 @@ public class Tests
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -127,7 +130,7 @@ public class Tests
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -143,14 +146,14 @@ public class Tests
 		{		
 			DischargeType dischargeType = testDischargeType.setup(true);
 			result = dischargeTypeIoOperation.newDischargeType(dischargeType);
-			
-			assertEquals(true, result);
+
+			assertTrue(result);
 			_checkDischargeTypeIntoDb(dischargeType.getCode());
 		} 
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -167,13 +170,13 @@ public class Tests
 		{		
 			code = _setupTestDischargeType(false);
 			result = dischargeTypeIoOperation.isCodePresent(code);
-			
-			assertEquals(true, result);
+
+			assertTrue(result);
 		} 
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -191,15 +194,15 @@ public class Tests
 			code = _setupTestDischargeType(false);
 			DischargeType foundDischargeType = (DischargeType)jpa.find(DischargeType.class, code); 
 			result = dischargeTypeIoOperation.deleteDischargeType(foundDischargeType);
-			
-			assertEquals(true, result);
-			result = dischargeTypeIoOperation.isCodePresent(code);			
-			assertEquals(false, result);
+
+			assertTrue(result);
+			result = dischargeTypeIoOperation.isCodePresent(code);
+			assertFalse(result);
 		} 
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -218,15 +221,15 @@ public class Tests
 			DischargeType foundDischargeType = (DischargeType)jpa.find(DischargeType.class, code); 
 			foundDischargeType.setDescription("Update");
 			result = dischargeTypeIoOperation.updateDischargeType(foundDischargeType);
-			DischargeType updateDischargeType = (DischargeType)jpa.find(DischargeType.class, code); 
-			
-			assertEquals(true, result);
+			DischargeType updateDischargeType = (DischargeType)jpa.find(DischargeType.class, code);
+
+			assertTrue(result);
 			assertEquals("Update", updateDischargeType.getDescription());
 		} 
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;

--- a/src/test/java/org/isf/disease/test/Tests.java
+++ b/src/test/java/org/isf/disease/test/Tests.java
@@ -2,6 +2,9 @@ package org.isf.disease.test;
 
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.util.ArrayList;
 
@@ -96,7 +99,7 @@ public class Tests
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 				
 		return;
@@ -116,7 +119,7 @@ public class Tests
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -138,7 +141,7 @@ public class Tests
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -156,31 +159,31 @@ public class Tests
 			Disease foundDisease = (Disease)jpa.find(Disease.class, code); 
 
 			ArrayList<Disease> diseases = diseaseIoOperation.getDiseases(foundDisease.getType().getCode(), false, false, false);
-			assertEquals(true, diseases.contains(foundDisease));
+			assertTrue(diseases.contains(foundDisease));
 			
 			diseases = diseaseIoOperation.getDiseases(foundDisease.getType().getCode(), true, false, false);
-			assertEquals(false, diseases.contains(foundDisease));
+			assertFalse(diseases.contains(foundDisease));
 			foundDisease.setOpdInclude(true);
 			jpa.beginTransaction();	
 			jpa.persist(foundDisease);
 			jpa.commitTransaction();
 			diseases = diseaseIoOperation.getDiseases(foundDisease.getType().getCode(), true, false, false);
-			assertEquals(true, diseases.contains(foundDisease));
+			assertTrue(diseases.contains(foundDisease));
 
 			foundDisease = (Disease)jpa.find(Disease.class, code);
 			diseases = diseaseIoOperation.getDiseases(foundDisease.getType().getCode(), true, true, false);
-			assertEquals(false, diseases.contains(foundDisease));
+			assertFalse(diseases.contains(foundDisease));
 			foundDisease.setOpdInclude(true);
 			foundDisease.setIpdInInclude(true);
 			jpa.beginTransaction();	
 			jpa.persist(foundDisease);
 			jpa.commitTransaction();
 			diseases = diseaseIoOperation.getDiseases(foundDisease.getType().getCode(), true, true, false);
-			assertEquals(true, diseases.contains(foundDisease));
+			assertTrue(diseases.contains(foundDisease));
 
 			foundDisease = (Disease)jpa.find(Disease.class, code);
 			diseases = diseaseIoOperation.getDiseases(foundDisease.getType().getCode(), true, true, true);
-			assertEquals(false, diseases.contains(foundDisease));
+			assertFalse(diseases.contains(foundDisease));
 			foundDisease.setOpdInclude(true);
 			foundDisease.setIpdInInclude(true);
 			foundDisease.setIpdOutInclude(true);
@@ -188,22 +191,22 @@ public class Tests
 			jpa.persist(foundDisease);
 			jpa.commitTransaction();
 			diseases = diseaseIoOperation.getDiseases(foundDisease.getType().getCode(), true, true, true);
-			assertEquals(true, diseases.contains(foundDisease));
+			assertTrue(diseases.contains(foundDisease));
 			
 			diseases = diseaseIoOperation.getDiseases(foundDisease.getType().getCode(), false, true, true);
-			assertEquals(true, diseases.contains(foundDisease));
+			assertTrue(diseases.contains(foundDisease));
 			
 			diseases = diseaseIoOperation.getDiseases(foundDisease.getType().getCode(), false, false, true);
-			assertEquals(true, diseases.contains(foundDisease));
+			assertTrue(diseases.contains(foundDisease));
 			
 			diseases = diseaseIoOperation.getDiseases(foundDisease.getType().getCode(), false, true, false);
-			assertEquals(true, diseases.contains(foundDisease));
+			assertTrue(diseases.contains(foundDisease));
 			
 		} 
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -225,14 +228,14 @@ public class Tests
 			jpa.persist(diseaseType);
 			jpa.commitTransaction();
 			result = diseaseIoOperation.newDisease(disease);
-			
-			assertEquals(true, result);
+
+			assertTrue(result);
 			_checkDiseaseIntoDb(disease.getCode());
 		} 
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -253,15 +256,15 @@ public class Tests
  			foundDisease.setDescription("Update");
  			result = diseaseIoOperation.updateDisease(foundDisease);
 			jpa.open();
- 			Disease updateDisease = (Disease)jpa.find(Disease.class, code); 
-			
-			assertEquals(true, result);
+ 			Disease updateDisease = (Disease)jpa.find(Disease.class, code);
+
+			assertTrue(result);
 			assertEquals("Update", updateDisease.getDescription());
 		} 
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -281,14 +284,14 @@ public class Tests
 			jpa.flush();
 			result = diseaseIoOperation.deleteDisease(foundDisease);
 			jpa.open();
- 			assertEquals(true, result);
- 			assertEquals(false, foundDisease.getIpdInInclude());
- 			assertEquals(false, foundDisease.getIpdOutInclude());
+			assertTrue(result);
+			assertFalse(foundDisease.getIpdInInclude());
+			assertFalse(foundDisease.getIpdOutInclude());
 		} 
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -308,15 +311,15 @@ public class Tests
 			jpa.flush();
 			result = diseaseIoOperation.deleteDisease(foundDisease);
 			jpa.open();
-			assertEquals(true, result);
-			assertEquals(false, foundDisease.getIpdInInclude());
-			assertEquals(false, foundDisease.getIpdOutInclude());
-			assertEquals(false, foundDisease.getOpdInclude());
+			assertTrue(result);
+			assertFalse(foundDisease.getIpdInInclude());
+			assertFalse(foundDisease.getIpdOutInclude());
+			assertFalse(foundDisease.getOpdInclude());
 		} 
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -333,13 +336,13 @@ public class Tests
 		{		
 			code = _setupTestDisease(false);
 			result = diseaseIoOperation.isCodePresent(code);
-			
-			assertEquals(true, result);
+
+			assertTrue(result);
 		} 
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -357,13 +360,13 @@ public class Tests
 			code = _setupTestDisease(false);
 			Disease foundDisease = (Disease)jpa.find(Disease.class, code); 
 			result = diseaseIoOperation.isDescriptionPresent(foundDisease.getDescription(), foundDisease.getType().getCode());
-			
-			assertEquals(true, result);
+
+			assertTrue(result);
 		} 
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;

--- a/src/test/java/org/isf/distype/test/Tests.java
+++ b/src/test/java/org/isf/distype/test/Tests.java
@@ -2,6 +2,9 @@ package org.isf.distype.test;
 
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.util.ArrayList;
 
@@ -85,7 +88,7 @@ public class Tests
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 				
 		return;
@@ -105,7 +108,7 @@ public class Tests
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -122,13 +125,13 @@ public class Tests
 			code = _setupTestDiseaseType(false);
 			DiseaseType foundDiseaseType = (DiseaseType)jpa.find(DiseaseType.class, code); 
 			ArrayList<DiseaseType> diseaseTypes = diseaseTypeIoOperation.getDiseaseTypes();
-			
-			assertEquals(diseaseTypes.contains(foundDiseaseType), true);
+
+			assertTrue(diseaseTypes.contains(foundDiseaseType));
 		} 
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -148,15 +151,15 @@ public class Tests
 			jpa.flush();
 			foundDiseaseType.setDescription("Update");
 			result = diseaseTypeIoOperation.updateDiseaseType(foundDiseaseType);
-			DiseaseType updateDiseaseType = (DiseaseType)jpa.find(DiseaseType.class, code); 
-			
-			assertEquals(true, result);
+			DiseaseType updateDiseaseType = (DiseaseType)jpa.find(DiseaseType.class, code);
+
+			assertTrue(result);
 			assertEquals("Update", updateDiseaseType.getDescription());
 		} 
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -172,14 +175,14 @@ public class Tests
 		{		
 			DiseaseType diseaseType = testDiseaseType.setup(true);
 			result = diseaseTypeIoOperation.newDiseaseType(diseaseType);
-			
-			assertEquals(true, result);
+
+			assertTrue(result);
 			_checkDiseaseTypeIntoDb(diseaseType.getCode());
 		} 
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -196,13 +199,13 @@ public class Tests
 		{		
 			code = _setupTestDiseaseType(false);
 			result = diseaseTypeIoOperation.isCodePresent(code);
-			
-			assertEquals(true, result);
+
+			assertTrue(result);
 		} 
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -221,13 +224,13 @@ public class Tests
 			DiseaseType foundDiseaseType = (DiseaseType)jpa.find(DiseaseType.class, code); 
 			result = diseaseTypeIoOperation.deleteDiseaseType(foundDiseaseType);
 
-			result = diseaseTypeIoOperation.isCodePresent(code);			
-			assertEquals(false, result);
+			result = diseaseTypeIoOperation.isCodePresent(code);
+			assertFalse(result);
 		} 
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;

--- a/src/test/java/org/isf/dlvrrestype/test/Tests.java
+++ b/src/test/java/org/isf/dlvrrestype/test/Tests.java
@@ -2,6 +2,9 @@ package org.isf.dlvrrestype.test;
 
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import org.isf.dlvrrestype.model.DeliveryResultType;
 import org.isf.dlvrrestype.service.DeliveryResultTypeIoOperation;
@@ -84,7 +87,7 @@ public class Tests
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 				
 		return;
@@ -104,7 +107,7 @@ public class Tests
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -125,7 +128,7 @@ public class Tests
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -144,15 +147,15 @@ public class Tests
 			DeliveryResultType foundDeliveryResultType = (DeliveryResultType)jpa.find(DeliveryResultType.class, code); 
 			foundDeliveryResultType.setDescription("Update");
 			result = deliveryResultTypeIoOperation.updateDeliveryResultType(foundDeliveryResultType);
-			DeliveryResultType updateDeliveryResultType = (DeliveryResultType)jpa.find(DeliveryResultType.class, code); 
-			
-			assertEquals(true, result);
+			DeliveryResultType updateDeliveryResultType = (DeliveryResultType)jpa.find(DeliveryResultType.class, code);
+
+			assertTrue(result);
 			assertEquals("Update", updateDeliveryResultType.getDescription());
 		} 
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -168,14 +171,14 @@ public class Tests
 		{		
 			DeliveryResultType deliveryResultType = testDeliveryResultType.setup(true);
 			result = deliveryResultTypeIoOperation.newDeliveryResultType(deliveryResultType);
-			
-			assertEquals(true, result);
+
+			assertTrue(result);
 			_checkDeliveryResultTypeIntoDb(deliveryResultType.getCode());
 		} 
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -192,13 +195,13 @@ public class Tests
 		{		
 			code = _setupTestDeliveryResultType(false);
 			result = deliveryResultTypeIoOperation.isCodePresent(code);
-			
-			assertEquals(true, result);
+
+			assertTrue(result);
 		} 
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -217,13 +220,13 @@ public class Tests
 			DeliveryResultType foundDeliveryResultType = (DeliveryResultType)jpa.find(DeliveryResultType.class, code); 
 			result = deliveryResultTypeIoOperation.deleteDeliveryResultType(foundDeliveryResultType);
 			
-			result = deliveryResultTypeIoOperation.isCodePresent(code);			
-			assertEquals(false, result);
+			result = deliveryResultTypeIoOperation.isCodePresent(code);
+			assertFalse(result);
 		} 
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;

--- a/src/test/java/org/isf/dlvrtype/test/Tests.java
+++ b/src/test/java/org/isf/dlvrtype/test/Tests.java
@@ -2,6 +2,9 @@ package org.isf.dlvrtype.test;
 
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.util.ArrayList;
 
@@ -87,7 +90,7 @@ public class Tests
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 				
 		return;
@@ -107,7 +110,7 @@ public class Tests
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -127,7 +130,7 @@ public class Tests
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -147,15 +150,15 @@ public class Tests
 			jpa.flush();
 			foundDeliveryType.setDescription("Update");
 			result = deliveryTypeIoOperation.updateDeliveryType(foundDeliveryType);
-			DeliveryType updateDeliveryType = (DeliveryType)jpa.find(DeliveryType.class, code); 
-			
-			assertEquals(true, result);
+			DeliveryType updateDeliveryType = (DeliveryType)jpa.find(DeliveryType.class, code);
+
+			assertTrue(result);
 			assertEquals("Update", updateDeliveryType.getDescription());
 		} 
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -171,14 +174,14 @@ public class Tests
 		{		
 			DeliveryType deliveryType = testDeliveryType.setup(true);
 			result = deliveryTypeIoOperation.newDeliveryType(deliveryType);
-			
-			assertEquals(true, result);
+
+			assertTrue(result);
 			_checkDeliveryTypeIntoDb(deliveryType.getCode());
 		} 
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -195,13 +198,13 @@ public class Tests
 		{		
 			code = _setupTestDeliveryType(false);
 			result = deliveryTypeIoOperation.isCodePresent(code);
-			
-			assertEquals(true, result);
+
+			assertTrue(result);
 		} 
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -219,14 +222,14 @@ public class Tests
 			code = _setupTestDeliveryType(false);
 			DeliveryType foundDeliveryType = (DeliveryType)jpa.find(DeliveryType.class, code); 
 			result = deliveryTypeIoOperation.deleteDeliveryType(foundDeliveryType);
-			assertEquals(true, result);
+			assertTrue(result);
 			result = deliveryTypeIoOperation.isCodePresent(code);
-			assertEquals(false, result);
+			assertFalse(result);
 		} 
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;

--- a/src/test/java/org/isf/exa/test/Tests.java
+++ b/src/test/java/org/isf/exa/test/Tests.java
@@ -2,6 +2,9 @@ package org.isf.exa.test;
 
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -106,7 +109,7 @@ public class Tests
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 				
 		return;
@@ -126,7 +129,7 @@ public class Tests
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -146,7 +149,7 @@ public class Tests
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 				
 		return;
@@ -166,7 +169,7 @@ public class Tests
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -189,7 +192,7 @@ public class Tests
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -212,7 +215,7 @@ public class Tests
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -229,13 +232,13 @@ public class Tests
 			code = _setupTestExamType(false);
 			ExamType foundExamType = (ExamType)jpa.find(ExamType.class, code); 
 			ArrayList<ExamType> examTypes = examIoOperation.getExamType();
-			
-			assertEquals(examTypes.contains(foundExamType), true);
+
+			assertTrue(examTypes.contains(foundExamType));
 		} 
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -258,14 +261,14 @@ public class Tests
 			jpa.persist(exam);
 			jpa.commitTransaction();
 			result = examIoOperation.newExamRow(examRow);
-			
-			assertEquals(true, result);
+
+			assertTrue(result);
 			_checkExamRowIntoDb(examRow.getCode());
 		} 
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -287,14 +290,14 @@ public class Tests
 			jpa.commitTransaction();
 			Exam exam = testExam.setup(examType, 1, false);
 			result = examIoOperation.newExam(exam);
-			
-			assertEquals(true, result);
+
+			assertTrue(result);
 			_checkExamIntoDb(exam.getCode());
 		} 
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -314,15 +317,15 @@ public class Tests
 			jpa.flush();
 			foundExam.setDescription("Update");
 			result = examIoOperation.updateExam(foundExam);
-			Exam updateExam = (Exam)jpa.find(Exam.class, code); 
-			
-			assertEquals(true, result);
+			Exam updateExam = (Exam)jpa.find(Exam.class, code);
+
+			assertTrue(result);
 			assertEquals("Update", updateExam.getDescription());
 		} 
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -341,14 +344,14 @@ public class Tests
 			Exam foundExam = (Exam)jpa.find(Exam.class, code); 
 			result = examIoOperation.deleteExam(foundExam);
 
-			assertEquals(true, result);
-			result = examIoOperation.isCodePresent(code);			
-			assertEquals(false, result);
+			assertTrue(result);
+			result = examIoOperation.isCodePresent(code);
+			assertFalse(result);
 		} 
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -366,15 +369,15 @@ public class Tests
 			code = _setupTestExamRow(false);
 			ExamRow foundExamRow = (ExamRow)jpa.find(ExamRow.class, code); 
 			result = examIoOperation.deleteExamRow(foundExamRow);
-			
-			assertEquals(true, result);
-			result = examIoOperation.isRowPresent(code);			
-			assertEquals(false, result);
+
+			assertTrue(result);
+			result = examIoOperation.isRowPresent(code);
+			assertFalse(result);
 		} 
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -396,13 +399,13 @@ public class Tests
 			jpa.persist(exam);
 			jpa.commitTransaction();
 			result = examIoOperation.isKeyPresent(exam);
-			
-			assertEquals(true, result);
+
+			assertTrue(result);
 		} 
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;

--- a/src/test/java/org/isf/examination/test/Tests.java
+++ b/src/test/java/org/isf/examination/test/Tests.java
@@ -2,6 +2,7 @@ package org.isf.examination.test;
 
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 import java.util.ArrayList;
 
@@ -98,7 +99,7 @@ public class Tests
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 				
 		return;
@@ -118,7 +119,7 @@ public class Tests
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -140,7 +141,7 @@ public class Tests
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 				
 		return;
@@ -164,7 +165,7 @@ public class Tests
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 				
 		return;
@@ -186,7 +187,7 @@ public class Tests
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 				
 		return;
@@ -210,7 +211,7 @@ public class Tests
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -234,7 +235,7 @@ public class Tests
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -258,7 +259,7 @@ public class Tests
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -280,7 +281,7 @@ public class Tests
 			assertEquals(mergedPatient.getCode(), result.getPatient().getCode());
 		} catch (Exception e) {
 			e.printStackTrace();
-			assertEquals(true, false);
+			fail();
 		}
 	}
 

--- a/src/test/java/org/isf/exatype/test/Tests.java
+++ b/src/test/java/org/isf/exatype/test/Tests.java
@@ -2,6 +2,9 @@ package org.isf.exatype.test;
 
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.util.ArrayList;
 
@@ -87,7 +90,7 @@ public class Tests
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 				
 		return;
@@ -107,7 +110,7 @@ public class Tests
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -124,13 +127,13 @@ public class Tests
 			code = _setupTestExamType(false);
 			ExamType foundExamType = (ExamType)jpa.find(ExamType.class, code); 
 			ArrayList<ExamType> examTypes = examTypeIoOperation.getExamType();
-			
-			assertEquals(examTypes.contains(foundExamType), true);
+
+			assertTrue(examTypes.contains(foundExamType));
 		} 
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -149,15 +152,15 @@ public class Tests
 			ExamType foundExamType = (ExamType)jpa.find(ExamType.class, code); 
 			foundExamType.setDescription("Update");
 			result = examTypeIoOperation.updateExamType(foundExamType);
-			ExamType updateExamType = (ExamType)jpa.find(ExamType.class, code); 
-			
-			assertEquals(true, result);
+			ExamType updateExamType = (ExamType)jpa.find(ExamType.class, code);
+
+			assertTrue(result);
 			assertEquals("Update", updateExamType.getDescription());
 		} 
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -173,14 +176,14 @@ public class Tests
 		{		
 			ExamType examType = testExamType.setup(true);
 			result = examTypeIoOperation.newExamType(examType);
-			
-			assertEquals(true, result);
+
+			assertTrue(result);
 			_checkExamTypeIntoDb(examType.getCode());
 		} 
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -197,13 +200,13 @@ public class Tests
 		{		
 			code = _setupTestExamType(false);
 			result = examTypeIoOperation.isCodePresent(code);
-			
-			assertEquals(true, result);
+
+			assertTrue(result);
 		} 
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -221,15 +224,15 @@ public class Tests
 			code = _setupTestExamType(false);
 			ExamType foundExamType = (ExamType)jpa.find(ExamType.class, code); 
 			result = examTypeIoOperation.deleteExamType(foundExamType);
-			assertEquals(true, result);
+			assertTrue(result);
 
 			result = examTypeIoOperation.isCodePresent(code);
-			assertEquals(false, result);
+			assertFalse(result);
 		} 
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;

--- a/src/test/java/org/isf/hospital/test/Tests.java
+++ b/src/test/java/org/isf/hospital/test/Tests.java
@@ -2,6 +2,8 @@ package org.isf.hospital.test;
 
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import org.isf.hospital.model.Hospital;
 import org.isf.hospital.service.HospitalIoOperations;
@@ -83,7 +85,7 @@ public class Tests
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 				
 		return;
@@ -105,7 +107,7 @@ public class Tests
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -127,13 +129,13 @@ public class Tests
 			result = hospitalIoOperation.updateHospital(foundHospital);
 			Hospital updateHospital = (Hospital)jpa.find(Hospital.class, code);
 
-			assertEquals(true, result);
+			assertTrue(result);
 			assertEquals("Update", updateHospital.getDescription());
 		}
 		catch (Exception e)
 		{
 			e.printStackTrace();
-			assertEquals(true, false);
+			fail();
 		}
 
 		return;

--- a/src/test/java/org/isf/lab/test/Tests.java
+++ b/src/test/java/org/isf/lab/test/Tests.java
@@ -1,6 +1,10 @@
 package org.isf.lab.test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.util.ArrayList;
 
@@ -123,7 +127,7 @@ public class Tests {
 			_checkLaboratoryIntoDb(code);
 		} catch (Exception e) {
 			e.printStackTrace();
-			assertEquals(true, false);
+			fail();
 		}
 
 		return;
@@ -138,7 +142,7 @@ public class Tests {
 			_checkLaboratoryIntoDb(code);
 		} catch (Exception e) {
 			e.printStackTrace();
-			assertEquals(true, false);
+			fail();
 		}
 
 		return;
@@ -153,7 +157,7 @@ public class Tests {
 			_checkLaboratoryRowIntoDb(code);
 		} catch (Exception e) {
 			e.printStackTrace();
-			assertEquals(true, false);
+			fail();
 		}
 
 		return;
@@ -168,7 +172,7 @@ public class Tests {
 			_checkLaboratoryRowIntoDb(code);
 		} catch (Exception e) {
 			e.printStackTrace();
-			assertEquals(true, false);
+			fail();
 		}
 
 		return;
@@ -183,10 +187,10 @@ public class Tests {
 			LaboratoryRow foundLaboratoryRow = (LaboratoryRow) jpa.find(LaboratoryRow.class, id);
 			ArrayList<LaboratoryRow> laboratoryRows = labIoOperation.getLabRow(foundLaboratoryRow.getLabId().getCode());
 
-			assertEquals(true, laboratoryRows.contains(foundLaboratoryRow));
+			assertTrue(laboratoryRows.contains(foundLaboratoryRow));
 		} catch (Exception e) {
 			e.printStackTrace();
-			assertEquals(true, false);
+			fail();
 		}
 
 		return;
@@ -205,7 +209,7 @@ public class Tests {
 			assertEquals(foundLaboratory.getCode(), laboratories.get(0).getCode());
 		} catch (Exception e) {
 			e.printStackTrace();
-			assertEquals(true, false);
+			fail();
 		}
 
 		return;
@@ -225,7 +229,7 @@ public class Tests {
 			assertEquals(foundLaboratory.getCode(), laboratories.get(0).getCode());
 		} catch (Exception e) {
 			e.printStackTrace();
-			assertEquals(true, false);
+			fail();
 		}
 
 		return;
@@ -243,7 +247,7 @@ public class Tests {
 			assertEquals(foundLaboratoryRow.getLabId().getCode(), laboratories.get(0).getCode());
 		} catch (Exception e) {
 			e.printStackTrace();
-			assertEquals(true, false);
+			fail();
 		}
 
 		return;
@@ -261,7 +265,7 @@ public class Tests {
 			assertEquals(foundLaboratory.getCode(), laboratories.get(0).getCode());
 		} catch (Exception e) {
 			e.printStackTrace();
-			assertEquals(true, false);
+			fail();
 		}
 		return;
 	}
@@ -283,7 +287,7 @@ public class Tests {
 			assertEquals(foundLaboratory.getCode(), laboratories.get(0).getCode());
 		} catch (Exception e) {
 			e.printStackTrace();
-			assertEquals(true, false);
+			fail();
 		}
 		return;
 	}
@@ -303,7 +307,7 @@ public class Tests {
 			assertEquals(foundLaboratory.getCode(), laboratories.get(0).getCode());
 		} catch (Exception e) {
 			e.printStackTrace();
-			assertEquals(true, false);
+			fail();
 		}
 		return;
 	}
@@ -325,11 +329,11 @@ public class Tests {
 			Laboratory laboratory = testLaboratory.setup(exam, patient, false);
 			result = labIoOperation.newLabFirstProcedure(laboratory);
 
-			assertEquals(true, result);
+			assertTrue(result);
 			_checkLaboratoryIntoDb(laboratory.getCode());
 		} catch (Exception e) {
 			e.printStackTrace();
-			assertEquals(true, false);
+			fail();
 		}
 
 		return;
@@ -354,11 +358,11 @@ public class Tests {
 			labRow.add("TestLabRow");
 			result = labIoOperation.newLabSecondProcedure(laboratory, labRow);
 
-			assertEquals(true, result);
+			assertTrue(result);
 			_checkLaboratoryIntoDb(laboratory.getCode());
 		} catch (Exception e) {
 			e.printStackTrace();
-			assertEquals(true, false);
+			fail();
 		}
 
 		return;
@@ -385,20 +389,20 @@ public class Tests {
 			labRow.add("TestLabRowTestLabRowTestLabRowTestLabRowTestLabRowTestLabRow"); // Causing rollback
 			result = labIoOperation.newLabSecondProcedure(laboratory, labRow);
 
-			assertEquals(true, result);
+			assertTrue(result);
 			_checkLaboratoryIntoDb(laboratory.getCode());
 		} catch (OHServiceException e) {
 			logger.debug("==> Voluntary Exception: " + e);
 			try {
 				Laboratory foundlaboratory = (Laboratory) jpa.find(Laboratory.class, laboratory.getCode());
-				assertEquals(null, foundlaboratory);
+				assertNull(foundlaboratory);
 			} catch (Exception e1) {
 				logger.debug("==> Test Exception: " + e);
-				assertEquals(true, false);
+				fail();
 			}
 		} catch (Exception e) {
 			logger.debug("==> Test Exception: " + e);
-			assertEquals(true, false);
+			fail();
 		}
 
 		return;
@@ -440,7 +444,7 @@ public class Tests {
 			labManager.setIoOperations(labIoOperation);
 			result = labManager.newLaboratory(laboratories, labRowList);
 
-			assertEquals(true, result);
+			assertTrue(result);
 			_checkLaboratoryIntoDb(laboratory.getCode());
 		} catch (OHServiceException e) {
 			logger.debug("==> Voluntary Exception: ");
@@ -448,7 +452,7 @@ public class Tests {
 				logger.debug("    " + error.getMessage());
 		} catch (Exception e) {
 			logger.debug("==> Test Exception: " + e);
-			assertEquals(true, false);
+			fail();
 		}
 		return;
 	}
@@ -466,11 +470,11 @@ public class Tests {
 			result = labIoOperation.updateLabFirstProcedure(foundlaboratory);
 			Laboratory updateLaboratory = (Laboratory) jpa.find(Laboratory.class, code);
 
-			assertEquals(true, result);
+			assertTrue(result);
 			assertEquals("Update", updateLaboratory.getNote());
 		} catch (Exception e) {
 			e.printStackTrace();
-			assertEquals(true, false);
+			fail();
 		}
 
 		return;
@@ -489,11 +493,11 @@ public class Tests {
 			result = labIoOperation.updateLabSecondProcedure(foundLaboratoryRow.getLabId(), labRow);
 			LaboratoryRow updateLaboratoryRow = (LaboratoryRow) jpa.find(LaboratoryRow.class, (code + 1));
 
-			assertEquals(true, result);
+			assertTrue(result);
 			assertEquals("Update", updateLaboratoryRow.getDescription());
 		} catch (Exception e) {
 			e.printStackTrace();
-			assertEquals(true, false);
+			fail();
 		}
 
 		return;
@@ -509,16 +513,16 @@ public class Tests {
 			Laboratory foundLaboratory = (Laboratory) jpa.find(Laboratory.class, code);
 			result = labIoOperation.deleteLaboratory(foundLaboratory);
 
-			assertEquals(true, result);
+			assertTrue(result);
 			result = labIoOperation.isCodePresent(code);
-			assertEquals(false, result);
+			assertFalse(result);
 		} catch (OHServiceException e) {
 			logger.debug("==> Test Exception: " + e);
 			e.printStackTrace();
-			assertEquals(true, false);
+			fail();
 		} catch (Exception e) {
 			e.printStackTrace();
-			assertEquals(true, false);
+			fail();
 		}
 
 		return;
@@ -543,7 +547,7 @@ public class Tests {
 			assertEquals(String.valueOf(mergedPatient.getSex()), result.getSex());
 		} catch (Exception e) {
 			e.printStackTrace();
-			assertEquals(true, false);
+			fail();
 		}
 	}
 

--- a/src/test/java/org/isf/malnutrition/test/Tests.java
+++ b/src/test/java/org/isf/malnutrition/test/Tests.java
@@ -2,6 +2,10 @@ package org.isf.malnutrition.test;
 
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.util.ArrayList;
 
@@ -193,7 +197,7 @@ public class Tests
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 				
 		return;
@@ -213,7 +217,7 @@ public class Tests
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -236,7 +240,7 @@ public class Tests
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -259,7 +263,7 @@ public class Tests
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -280,15 +284,14 @@ public class Tests
 			foundMalnutrition.setHeight(200);
 			result = malnutritionIoOperation.updateMalnutrition(foundMalnutrition);
 			Malnutrition updateMalnutrition = (Malnutrition)jpa.find(Malnutrition.class, code);
-			
-			
-			assertEquals(true, (result != null));
+
+			assertNotNull(result);
 			assertEquals(200.0, updateMalnutrition.getHeight(), 0.000001d);
 		} 
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -343,14 +346,14 @@ public class Tests
 						
 			Malnutrition malnutrition = testMalnutrition.setup(admission, true);
 			result = malnutritionIoOperation.newMalnutrition(malnutrition);
-			
-			assertEquals(true, result);
+
+			assertTrue(result);
 			_checkMalnutritionIntoDb(malnutrition.getCode());
 		} 
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -370,15 +373,15 @@ public class Tests
 			jpa.flush();
 			
 			result = malnutritionIoOperation.deleteMalnutrition(foundMalnutrition);
-			
-			assertEquals(true, result);
-			result = malnutritionIoOperation.isCodePresent(code);			
-			assertEquals(false, result);
+
+			assertTrue(result);
+			result = malnutritionIoOperation.isCodePresent(code);
+			assertFalse(result);
 		} 
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;

--- a/src/test/java/org/isf/medicals/test/Tests.java
+++ b/src/test/java/org/isf/medicals/test/Tests.java
@@ -2,6 +2,9 @@ package org.isf.medicals.test;
 
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.util.ArrayList;
 
@@ -139,7 +142,7 @@ public class Tests
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 				
 		return;
@@ -159,7 +162,7 @@ public class Tests
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -182,7 +185,7 @@ public class Tests
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -205,7 +208,7 @@ public class Tests
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -228,7 +231,7 @@ public class Tests
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -246,13 +249,13 @@ public class Tests
 			code = _setupTestMedical(false);
 			Medical foundMedical = (Medical)jpa.find(Medical.class, code); 
 			result = medicalsIoOperations.medicalExists(foundMedical, false);
-			
-			assertEquals(true, result);
+
+			assertTrue(result);
 		} 
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -272,15 +275,15 @@ public class Tests
 			jpa.flush();
 			foundMedical.setDescription("Update");
 			result = medicalsIoOperations.updateMedical(foundMedical);
-			Medical updateMedical = (Medical)jpa.find(Medical.class, code); 
-			
-			assertEquals(true, result);
+			Medical updateMedical = (Medical)jpa.find(Medical.class, code);
+
+			assertTrue(result);
 			assertEquals("Update", updateMedical.getDescription());
 		} 
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -300,14 +303,14 @@ public class Tests
 			jpa.commitTransaction();			
 			Medical medical = testMedical.setup(medicalType, true);
 			result = medicalsIoOperations.newMedical(medical);
-			
-			assertEquals(true, result);
+
+			assertTrue(result);
 			_checkMedicalIntoDb(medical.getCode());
 		} 
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -325,16 +328,16 @@ public class Tests
 			code = _setupTestMedical(false);
 			Medical foundMedical = (Medical)jpa.find(Medical.class, code); 
 			result = medicalsIoOperations.deleteMedical(foundMedical);
-			
-			assertEquals(true, result);
+
+			assertTrue(result);
 			Medical deletedMedical = (Medical)jpa.find(Medical.class, code); 
-			result = medicalsIoOperations.medicalExists(deletedMedical,true);			
-			assertEquals(false, result);
+			result = medicalsIoOperations.medicalExists(deletedMedical,true);
+			assertFalse(result);
 		} 
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -352,13 +355,13 @@ public class Tests
 			code = _setupTestMovement(false);
 			Movement foundMovement = (Movement)jpa.find(Movement.class, code); 
 			result = medicalsIoOperations.isMedicalReferencedInStockMovement(foundMovement.getMedical().getCode());
-			
-			assertEquals(true, result);
+
+			assertTrue(result);
 		} 
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;

--- a/src/test/java/org/isf/medicalstock/test/Tests.java
+++ b/src/test/java/org/isf/medicalstock/test/Tests.java
@@ -3,6 +3,7 @@ package org.isf.medicalstock.test;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.util.ArrayList;
 import java.util.Calendar;
@@ -144,7 +145,7 @@ public class Tests
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 				
 		return;
@@ -164,7 +165,7 @@ public class Tests
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -184,7 +185,7 @@ public class Tests
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 				
 		return;
@@ -204,7 +205,7 @@ public class Tests
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -227,7 +228,7 @@ public class Tests
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -250,7 +251,7 @@ public class Tests
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -268,12 +269,12 @@ public class Tests
 			Movement foundMovement = (Movement)jpa.find(Movement.class, code); 
 			boolean result = medicalStockIoOperation.newAutomaticDischargingMovement(foundMovement);
 
-			assertEquals(true, result);
+			assertTrue(result);
 		} 
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -324,7 +325,7 @@ public class Tests
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -342,12 +343,12 @@ public class Tests
 			Movement foundMovement = (Movement)jpa.find(Movement.class, code); 
 			boolean result = medicalStockIoOperation.newMovement(foundMovement);
 
-			assertEquals(true, result);
+			assertTrue(result);
 		} 
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -365,12 +366,12 @@ public class Tests
 			Movement foundMovement = (Movement)jpa.find(Movement.class, code); 
 			boolean result = medicalStockIoOperation.prepareChargingMovement(foundMovement);
 
-			assertEquals(true, result);
+			assertTrue(result);
 		} 
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -388,12 +389,12 @@ public class Tests
 			Movement foundMovement = (Movement)jpa.find(Movement.class, code); 
 			boolean result = medicalStockIoOperation.prepareDischargingMovement(foundMovement);
 
-			assertEquals(true, result);
+			assertTrue(result);
 		} 
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -410,13 +411,13 @@ public class Tests
 		{		
 			code = _setupTestLot(false);
 			result = medicalStockIoOperation.lotExists(code);
-			
-			assertEquals(true, result);
+
+			assertTrue(result);
 		} 
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -440,7 +441,7 @@ public class Tests
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -469,7 +470,7 @@ public class Tests
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -505,7 +506,7 @@ public class Tests
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -541,7 +542,7 @@ public class Tests
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -565,7 +566,7 @@ public class Tests
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -583,12 +584,12 @@ public class Tests
 			Movement foundMovement = (Movement)jpa.find(Movement.class, code); 
 			boolean result = medicalStockIoOperation.refNoExists(foundMovement.getRefNo());
 
-			assertEquals(true, result);
+			assertTrue(result);
 		} 
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -611,7 +612,7 @@ public class Tests
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;

--- a/src/test/java/org/isf/medicalstockward/test/Tests.java
+++ b/src/test/java/org/isf/medicalstockward/test/Tests.java
@@ -2,6 +2,8 @@ package org.isf.medicalstockward.test;
 
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.util.ArrayList;
 import java.util.Calendar;
@@ -168,7 +170,7 @@ public class Tests
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 				
 		return;
@@ -188,7 +190,7 @@ public class Tests
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -208,7 +210,7 @@ public class Tests
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 				
 		return;
@@ -228,7 +230,7 @@ public class Tests
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -257,7 +259,7 @@ public class Tests
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -300,7 +302,7 @@ public class Tests
 		} 
 		catch (Exception e) 
 		{
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -343,7 +345,7 @@ public class Tests
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -362,15 +364,15 @@ public class Tests
 			MovementWard foundMovementWard = (MovementWard)jpa.find(MovementWard.class, code); 
 			foundMovementWard.setDescription("Update");
 			result = medicalIoOperation.updateMovementWard(foundMovementWard);
-			MovementWard updateMovementWard = (MovementWard)jpa.find(MovementWard.class, code); 
-			
-			assertEquals(true, result);
+			MovementWard updateMovementWard = (MovementWard)jpa.find(MovementWard.class, code);
+
+			assertTrue(result);
 			assertEquals("Update", updateMovementWard.getDescription());
 		} 
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -388,13 +390,13 @@ public class Tests
 			code = _setupTestMovementWard(false);
 			MovementWard foundMovementWard = (MovementWard)jpa.find(MovementWard.class, code); 
 			result = medicalIoOperation.deleteMovementWard(foundMovementWard);
-			
-			assertEquals(true, result);
+
+			assertTrue(result);
 		} 
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -416,7 +418,7 @@ public class Tests
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -438,7 +440,7 @@ public class Tests
 			assertEquals(mergedPatient.getCode(), result.getPatient().getCode());
 		} catch (Exception e) {
 			e.printStackTrace();
-			assertEquals(true, false);
+			fail();
 		}
 	}
 

--- a/src/test/java/org/isf/medstockmovtype/test/Tests.java
+++ b/src/test/java/org/isf/medstockmovtype/test/Tests.java
@@ -2,6 +2,9 @@ package org.isf.medstockmovtype.test;
 
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.util.ArrayList;
 
@@ -83,7 +86,7 @@ public class Tests
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 				
 		return;
@@ -103,7 +106,7 @@ public class Tests
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -126,7 +129,7 @@ public class Tests
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -145,15 +148,15 @@ public class Tests
 			MovementType foundMovementType = (MovementType)jpa.find(MovementType.class, code); 
 			foundMovementType.setDescription("Update");
 			result = medicalStockMovementTypeIoOperation.updateMedicaldsrstockmovType(foundMovementType);
-			MovementType updateMovementType = (MovementType)jpa.find(MovementType.class, code); 
-			
-			assertEquals(true, result);
+			MovementType updateMovementType = (MovementType)jpa.find(MovementType.class, code);
+
+			assertTrue(result);
 			assertEquals("Update", updateMovementType.getDescription());
 		} 
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -169,14 +172,14 @@ public class Tests
 		{		
 			MovementType movementType = testMovementType.setup(true);
 			result = medicalStockMovementTypeIoOperation.newMedicaldsrstockmovType(movementType);
-			
-			assertEquals(true, result);
+
+			assertTrue(result);
 			_checkMovementTypeIntoDb(movementType.getCode());
 		} 
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -193,13 +196,13 @@ public class Tests
 		{		
 			code = _setupTestMovementType(false);
 			result = medicalStockMovementTypeIoOperation.isCodePresent(code);
-			
-			assertEquals(true, result);
+
+			assertTrue(result);
 		} 
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -217,15 +220,15 @@ public class Tests
 			code = _setupTestMovementType(false);
 			MovementType foundMovementType = (MovementType)jpa.find(MovementType.class, code); 
 			result = medicalStockMovementTypeIoOperation.deleteMedicaldsrstockmovType(foundMovementType);
-			
-			assertEquals(true, result);
-			result = medicalStockMovementTypeIoOperation.isCodePresent(code);			
-			assertEquals(false, result);
+
+			assertTrue(result);
+			result = medicalStockMovementTypeIoOperation.isCodePresent(code);
+			assertFalse(result);
 		} 
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;

--- a/src/test/java/org/isf/medtype/test/Tests.java
+++ b/src/test/java/org/isf/medtype/test/Tests.java
@@ -2,6 +2,9 @@ package org.isf.medtype.test;
 
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.util.ArrayList;
 
@@ -82,7 +85,7 @@ public class Tests
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 				
 		return;
@@ -102,7 +105,7 @@ public class Tests
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -125,7 +128,7 @@ public class Tests
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -144,15 +147,15 @@ public class Tests
 			MedicalType foundMedicalType = (MedicalType)jpa.find(MedicalType.class, code); 
 			foundMedicalType.setDescription("Update");
 			result = medicalTypeIoOperation.updateMedicalType(foundMedicalType);
-			MedicalType updateMedicalType = (MedicalType)jpa.find(MedicalType.class, code); 
-			
-			assertEquals(true, result);
+			MedicalType updateMedicalType = (MedicalType)jpa.find(MedicalType.class, code);
+
+			assertTrue(result);
 			assertEquals("Update", updateMedicalType.getDescription());
 		} 
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -168,14 +171,14 @@ public class Tests
 		{		
 			MedicalType medicalType = testMedicalType.setup(true);
 			result = medicalTypeIoOperation.newMedicalType(medicalType);
-			
-			assertEquals(true, result);
+
+			assertTrue(result);
 			_checkMedicalTypeIntoDb(medicalType.getCode());
 		} 
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -192,16 +195,16 @@ public class Tests
 		{		
 			code = _setupTestMedicalType(false);
 			result = medicalTypeIoOperation.isCodePresent(code);
-			
-			assertEquals(true, result);
+
+			assertTrue(result);
 		} 
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
-		
-		assertEquals(true, result);
+
+		assertTrue(result);
 		
 		return;
 	}
@@ -218,15 +221,15 @@ public class Tests
 			code = _setupTestMedicalType(false);
 			MedicalType foundMedicalType = (MedicalType)jpa.find(MedicalType.class, code); 
 			result = medicalTypeIoOperation.deleteMedicalType(foundMedicalType);
-			
-			assertEquals(true, result);
+
+			assertTrue(result);
 			result = medicalTypeIoOperation.isCodePresent(code);
-			assertEquals(false, result);
+			assertFalse(result);
 		} 
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;

--- a/src/test/java/org/isf/menu/test/Tests.java
+++ b/src/test/java/org/isf/menu/test/Tests.java
@@ -2,6 +2,8 @@ package org.isf.menu.test;
 
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.util.ArrayList;
 
@@ -98,7 +100,7 @@ public class Tests
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 				
 		return;
@@ -118,7 +120,7 @@ public class Tests
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -138,7 +140,7 @@ public class Tests
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 				
 		return;
@@ -158,7 +160,7 @@ public class Tests
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -178,7 +180,7 @@ public class Tests
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 				
 		return;
@@ -198,7 +200,7 @@ public class Tests
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -219,7 +221,7 @@ public class Tests
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 				
 		return;
@@ -239,7 +241,7 @@ public class Tests
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -262,7 +264,7 @@ public class Tests
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -285,7 +287,7 @@ public class Tests
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -308,7 +310,7 @@ public class Tests
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -331,7 +333,7 @@ public class Tests
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -348,13 +350,13 @@ public class Tests
 		{		
 			code = _setupTestUser(false);
 			result = menuIoOperation.isUserNamePresent(code);
-			
-			assertEquals(true, result);
+
+			assertTrue(result);
 		} 
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -371,13 +373,13 @@ public class Tests
 		{		
 			code = _setupTestUserGroup(false);
 			result = menuIoOperation.isGroupNamePresent(code);
-			
-			assertEquals(true, result);
+
+			assertTrue(result);
 		} 
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -398,14 +400,14 @@ public class Tests
 			jpa.persist(userGroup);
 			jpa.commitTransaction();
 			result = menuIoOperation.newUser(user);
-			
-			assertEquals(true, result);
+
+			assertTrue(result);
 			_checkUserIntoDb(user.getUserName());
 		} 
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -424,15 +426,15 @@ public class Tests
 			User foundUser = (User)jpa.find(User.class, code); 
 			foundUser.setDesc("Update");
 			result = menuIoOperation.updateUser(foundUser);
-			User updateUser = (User)jpa.find(User.class, code); 
-			
-			assertEquals(true, result);
+			User updateUser = (User)jpa.find(User.class, code);
+
+			assertTrue(result);
 			assertEquals("Update", updateUser.getDesc());
 		} 
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -451,15 +453,15 @@ public class Tests
 			User foundUser = (User)jpa.find(User.class, code); 
 			foundUser.setPasswd("Update");
 			result = menuIoOperation.updatePassword(foundUser);
-			User updateDisease = (User)jpa.find(User.class, code); 
-			
-			assertEquals(true, result);
+			User updateDisease = (User)jpa.find(User.class, code);
+
+			assertTrue(result);
 			assertEquals("Update", updateDisease.getPasswd());
 		} 
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -477,13 +479,13 @@ public class Tests
 			code = _setupTestUser(false);
 			User foundUser = (User)jpa.find(User.class, code); 
 			result = menuIoOperation.deleteUser(foundUser);
-			
-			assertEquals(true, result);
+
+			assertTrue(result);
 		} 
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -512,7 +514,7 @@ public class Tests
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -541,7 +543,7 @@ public class Tests
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -551,7 +553,7 @@ public class Tests
 	public void testIoSetGroupMenu() 
 	{
 		//TODO: Do unit test checking insert
-		assertEquals(true, true);	
+		assertTrue(true);
 		
 		return;
 	}
@@ -568,13 +570,13 @@ public class Tests
 			code = _setupTestUserGroup(false);
 			UserGroup foundUserGroup = (UserGroup)jpa.find(UserGroup.class, code); 
 			result = menuIoOperation.deleteGroup(foundUserGroup);
-			
-			assertEquals(true, result);			
+
+			assertTrue(result);
 		} 
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -590,14 +592,14 @@ public class Tests
 		{						
 			UserGroup userGroup= testUserGroup.setup(false);
 			result = menuIoOperation.newUserGroup(userGroup);
-			
-			assertEquals(true, result);
+
+			assertTrue(result);
 			_checkUserGroupIntoDb(userGroup.getCode());
 		} 
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -616,15 +618,15 @@ public class Tests
 			UserGroup foundUserGroup = (UserGroup)jpa.find(UserGroup.class, code); 
 			foundUserGroup.setDesc("Update");
             result = menuIoOperation.updateUserGroup(foundUserGroup);
-			UserGroup updateUserGroup = (UserGroup)jpa.find(UserGroup.class, code); 
-			
-			assertEquals(true, result);
+			UserGroup updateUserGroup = (UserGroup)jpa.find(UserGroup.class, code);
+
+			assertTrue(result);
 			assertEquals("Update", updateUserGroup.getDesc());
 		} 
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;

--- a/src/test/java/org/isf/opd/test/Tests.java
+++ b/src/test/java/org/isf/opd/test/Tests.java
@@ -119,7 +119,7 @@ public class Tests
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 				
 		return;
@@ -139,7 +139,7 @@ public class Tests
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -170,7 +170,7 @@ public class Tests
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -196,14 +196,14 @@ public class Tests
 			Opd opd = testOpd.setup(patient, disease, false);
 	    	opd.setDate(new Date());
 			result = opdIoOperation.newOpd(opd);
-			
-			assertEquals(true, result);
+
+			assertTrue(result);
 			_checkOpdIntoDb(opd.getCode());
 		} 
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -224,15 +224,15 @@ public class Tests
 			foundOpd.setNote("Update");
 			result = opdIoOperation.updateOpd(foundOpd);
 			jpa.open();
-			Opd updateOpd = (Opd)jpa.find(Opd.class, code); 
-			
-			assertEquals(true, (result != null));
+			Opd updateOpd = (Opd)jpa.find(Opd.class, code);
+
+			assertNotNull(result);
 			assertEquals("Update", updateOpd.getNote());
 		} 
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -251,14 +251,14 @@ public class Tests
 			Opd foundOpd = (Opd)jpa.find(Opd.class, code); 
 			result = opdIoOperation.deleteOpd(foundOpd);
 
-			assertEquals(true, result);
-			result = opdIoOperation.isCodePresent(code);			
-			assertEquals(false, result);
+			assertTrue(result);
+			result = opdIoOperation.isCodePresent(code);
+			assertFalse(result);
 		} 
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -282,7 +282,7 @@ public class Tests
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -304,7 +304,7 @@ public class Tests
 		catch (Exception e)
 		{
 			e.printStackTrace();
-			assertEquals(true, false);
+			fail();
 		}
 
 		return;
@@ -326,7 +326,7 @@ public class Tests
 		catch (Exception e)
 		{
 			e.printStackTrace();
-			assertEquals(true, false);
+			fail();
 		}
 
 		return;
@@ -348,7 +348,7 @@ public class Tests
 		catch (Exception e)
 		{
 			e.printStackTrace();
-			assertEquals(true, false);
+			fail();
 		}
 
 		return;
@@ -371,7 +371,7 @@ public class Tests
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -393,7 +393,7 @@ public class Tests
 			assertEquals(mergedPatient.getCode(), result.getPatient().getCode());
 		} catch (Exception e) {
 			e.printStackTrace();
-			assertEquals(true, false);
+			fail();
 		}
 	}
 

--- a/src/test/java/org/isf/operation/test/Tests.java
+++ b/src/test/java/org/isf/operation/test/Tests.java
@@ -3,6 +3,8 @@ package org.isf.operation.test;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.util.ArrayList;
 
@@ -96,7 +98,7 @@ public class Tests
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 				
 		return;
@@ -116,7 +118,7 @@ public class Tests
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -139,7 +141,7 @@ public class Tests
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -166,7 +168,7 @@ public class Tests
 		catch (Exception e)
 		{
 			e.printStackTrace();
-			assertEquals(true, false);
+			fail();
 		}
 
 		return;
@@ -186,14 +188,14 @@ public class Tests
 			jpa.persist(operationType);
 			jpa.commitTransaction();
 			result = operationIoOperations.newOperation(operation);
-			
-			assertEquals(true, result);
+
+			assertTrue(result);
 			_checkOperationIntoDb(operation.getCode());
 		} 
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -213,16 +215,16 @@ public class Tests
 			int lock = foundOperation.getLock();
 			foundOperation.setDescription("Update");
 			result = operationIoOperations.updateOperation(foundOperation);
-			Operation updateOperation = (Operation)jpa.find(Operation.class, code); 
-			
-			assertEquals(true, result);
+			Operation updateOperation = (Operation)jpa.find(Operation.class, code);
+
+			assertTrue(result);
 			assertEquals("Update", updateOperation.getDescription());
 			assertEquals(lock + 1, updateOperation.getLock().intValue());
 		} 
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -240,13 +242,13 @@ public class Tests
 			code = _setupTestOperation(false);
 			Operation foundOperation = (Operation)jpa.find(Operation.class, code); 
 			result = operationIoOperations.deleteOperation(foundOperation);
-			
-			assertEquals(true, result);
+
+			assertTrue(result);
 		} 
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -263,13 +265,13 @@ public class Tests
 		{		
 			code = _setupTestOperation(false);
 			result = operationIoOperations.isCodePresent(code);
-			
-			assertEquals(true, result);
+
+			assertTrue(result);
 		} 
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -287,13 +289,13 @@ public class Tests
 			code = _setupTestOperation(false);
 			Operation foundOperation = (Operation)jpa.find(Operation.class, code); 
 			result = operationIoOperations.isDescriptionPresent(foundOperation.getDescription(), foundOperation.getType().getCode());
-			
-			assertEquals(true, result);
+
+			assertTrue(result);
 		} 
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;

--- a/src/test/java/org/isf/opetype/test/Tests.java
+++ b/src/test/java/org/isf/opetype/test/Tests.java
@@ -2,6 +2,9 @@ package org.isf.opetype.test;
 
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.util.ArrayList;
 
@@ -84,7 +87,7 @@ public class Tests
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 				
 		return;
@@ -104,7 +107,7 @@ public class Tests
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -127,7 +130,7 @@ public class Tests
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -146,15 +149,15 @@ public class Tests
 			OperationType foundOperationType = (OperationType)jpa.find(OperationType.class, code); 
 			foundOperationType.setDescription("Update");
 			result = operationTypeIoOperation.updateOperationType(foundOperationType);
-			OperationType updateOperationType = (OperationType)jpa.find(OperationType.class, code); 
-			
-			assertEquals(true, result);
+			OperationType updateOperationType = (OperationType)jpa.find(OperationType.class, code);
+
+			assertTrue(result);
 			assertEquals("Update", updateOperationType.getDescription());
 		} 
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -170,14 +173,14 @@ public class Tests
 		{		
 			OperationType operationType = testOperationType.setup(true);
 			result = operationTypeIoOperation.newOperationType(operationType);
-			
-			assertEquals(true, result);
+
+			assertTrue(result);
 			_checkOperationTypeIntoDb(operationType.getCode());
 		} 
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -194,13 +197,13 @@ public class Tests
 		{		
 			code = _setupTestOperationType(false);
 			result = operationTypeIoOperation.isCodePresent(code);
-			
-			assertEquals(true, result);
+
+			assertTrue(result);
 		} 
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -218,15 +221,15 @@ public class Tests
 			code = _setupTestOperationType(false);
 			OperationType foundOperationType = (OperationType)jpa.find(OperationType.class, code); 
 			result = operationTypeIoOperation.deleteOperationType(foundOperationType);
-			
-			assertEquals(true, result);
-			result = operationTypeIoOperation.isCodePresent(code);			
-			assertEquals(false, result);
+
+			assertTrue(result);
+			result = operationTypeIoOperation.isCodePresent(code);
+			assertFalse(result);
 		} 
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;

--- a/src/test/java/org/isf/patient/MergePatientTests.java
+++ b/src/test/java/org/isf/patient/MergePatientTests.java
@@ -1,5 +1,8 @@
 package org.isf.patient;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
 import org.isf.examination.model.PatientExamination;
 import org.isf.examination.service.ExaminationIoOperationRepository;
 import org.isf.examination.test.TestPatientExamination;
@@ -19,8 +22,6 @@ import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringRunner;
-
-import static org.junit.Assert.assertEquals;
 
 @RunWith(SpringRunner.class)
 @ContextConfiguration(locations = { "classpath:applicationContext.xml" })
@@ -74,7 +75,7 @@ public class MergePatientTests {
 			assertThatPatientMergedEventWasSent(mergedPatient, obsoletePatient);
 		} catch (Exception e) {
 			e.printStackTrace();
-			assertEquals(true, false);
+			fail();
 		}
 	}
 
@@ -102,7 +103,7 @@ public class MergePatientTests {
 			assertThatPatientMergedEventWasSent(mergedPatient, obsoletePatient);
 		} catch (Exception e) {
 			e.printStackTrace();
-			assertEquals(true, false);
+			fail();
 		}
 	}
 

--- a/src/test/java/org/isf/patient/test/Tests.java
+++ b/src/test/java/org/isf/patient/test/Tests.java
@@ -4,6 +4,7 @@ package org.isf.patient.test;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -86,7 +87,7 @@ public class Tests
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 				
 		return;
@@ -106,7 +107,7 @@ public class Tests
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 				
 		return;
@@ -125,7 +126,7 @@ public class Tests
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -145,7 +146,7 @@ public class Tests
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -165,7 +166,7 @@ public class Tests
 			testPatient.check(patients.get(0));
 		} catch (Exception e) {
 			e.printStackTrace();
-			assertEquals(true, false);
+			fail();
 		}
 	}
 
@@ -183,7 +184,7 @@ public class Tests
 			testPatient.check(patients.get(0));
 		} catch (Exception e) {
 			e.printStackTrace();
-			assertEquals(true, false);
+			fail();
 		}
 	}
 
@@ -203,7 +204,7 @@ public class Tests
 		catch (Exception e)
 		{
 			e.printStackTrace();
-			assertEquals(true, false);
+			fail();
 		}
 	}
 
@@ -221,7 +222,7 @@ public class Tests
 			testPatient.check(patients.get(0));
 		} catch (Exception e) {
 			e.printStackTrace();
-			assertEquals(true, false);
+			fail();
 		}
 
 		return;
@@ -241,7 +242,7 @@ public class Tests
 		catch (Exception e)
 		{
 			e.printStackTrace();
-			assertEquals(true, false);
+			fail();
 		}
 
 		return;
@@ -261,7 +262,7 @@ public class Tests
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -281,7 +282,7 @@ public class Tests
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -305,7 +306,7 @@ public class Tests
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -336,14 +337,14 @@ public class Tests
 			Patient patient = (Patient)jpa.find(Patient.class, code); 
 			boolean result = patientIoOperation.deletePatient(patient);
 			Patient deletedPatient = _getDeletedPatient(code);
-			
-			assertEquals(true, result);
+
+			assertTrue(result);
 			assertEquals(code, deletedPatient.getCode());
 		} 
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -357,13 +358,13 @@ public class Tests
 			Integer code = _setupTestPatient(false);
 			Patient foundPatient = (Patient)jpa.find(Patient.class, code); 
 			boolean result = patientIoOperation.isPatientPresent(foundPatient.getName());
-			
-			assertEquals(true, result);
+
+			assertTrue(result);
 		} 
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -385,7 +386,7 @@ public class Tests
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -409,7 +410,7 @@ public class Tests
 			assertThatObsoletePatientWasDeletedAndMergedIsTheActiveOne(mergedPatient, obsoletePatient);
 		} catch (Exception e) {
 			e.printStackTrace();
-			assertEquals(true, false);
+			fail();
 		} finally {
 			testPatientContext.deleteNews(jpa); // we create 2 entries so additional deletion needed
 		}

--- a/src/test/java/org/isf/patvac/test/Tests.java
+++ b/src/test/java/org/isf/patvac/test/Tests.java
@@ -2,6 +2,9 @@ package org.isf.patvac.test;
 
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -118,7 +121,7 @@ public class Tests
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 				
 		return;
@@ -138,7 +141,7 @@ public class Tests
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -168,7 +171,7 @@ public class Tests
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -187,15 +190,15 @@ public class Tests
 			PatientVaccine foundPatientVaccine = (PatientVaccine)jpa.find(PatientVaccine.class, code); 
 			foundPatientVaccine.setPatName("Update");
 			result = patvacIoOperation.updatePatientVaccine(foundPatientVaccine);
-			PatientVaccine updatePatientVaccine = (PatientVaccine)jpa.find(PatientVaccine.class, code); 
-			
-			assertEquals(true, result);
+			PatientVaccine updatePatientVaccine = (PatientVaccine)jpa.find(PatientVaccine.class, code);
+
+			assertTrue(result);
 			assertEquals("Update", updatePatientVaccine.getPatName());
 		} 
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -220,14 +223,14 @@ public class Tests
 	    	
 			PatientVaccine patientVaccine = testPatientVaccine.setup(patient, vaccine, true);
 			result = patvacIoOperation.newPatientVaccine(patientVaccine);
-			
-			assertEquals(true, result);
+
+			assertTrue(result);
 			_checkPatientVaccineIntoDb(patientVaccine.getCode());
 		} 
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -246,14 +249,14 @@ public class Tests
 			PatientVaccine foundPatientVaccine = (PatientVaccine)jpa.find(PatientVaccine.class, code); 
 			result = patvacIoOperation.deletePatientVaccine(foundPatientVaccine);
 
-			assertEquals(true, result);
-			result = patvacIoOperation.isCodePresent(code);			
-			assertEquals(false, result);
+			assertTrue(result);
+			result = patvacIoOperation.isCodePresent(code);
+			assertFalse(result);
 		} 
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -281,7 +284,7 @@ public class Tests
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -303,7 +306,7 @@ public class Tests
 			assertEquals(mergedPatient.getCode(), result.getPatient().getCode());
 		} catch (Exception e) {
 			e.printStackTrace();
-			assertEquals(true, false);
+			fail();
 		}
 	}
 

--- a/src/test/java/org/isf/pregtreattype/test/Tests.java
+++ b/src/test/java/org/isf/pregtreattype/test/Tests.java
@@ -2,6 +2,9 @@ package org.isf.pregtreattype.test;
 
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.util.ArrayList;
 
@@ -84,7 +87,7 @@ public class Tests
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 				
 		return;
@@ -104,7 +107,7 @@ public class Tests
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -131,7 +134,7 @@ public class Tests
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -150,15 +153,15 @@ public class Tests
 			PregnantTreatmentType foundPregnantTreatmentType = (PregnantTreatmentType)jpa.find(PregnantTreatmentType.class, code); 
 			foundPregnantTreatmentType.setDescription("Update");
 			result = pregnantTreatmentTypeIoOperation.updatePregnantTreatmentType(foundPregnantTreatmentType);
-			PregnantTreatmentType updatePregnantTreatmentType = (PregnantTreatmentType)jpa.find(PregnantTreatmentType.class, code); 
-			
-			assertEquals(true, result);
+			PregnantTreatmentType updatePregnantTreatmentType = (PregnantTreatmentType)jpa.find(PregnantTreatmentType.class, code);
+
+			assertTrue(result);
 			assertEquals("Update", updatePregnantTreatmentType.getDescription());
 		} 
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -174,14 +177,14 @@ public class Tests
 		{		
 			PregnantTreatmentType pregnantTreatmentType = testPregnantTreatmentType.setup(true);
 			result = pregnantTreatmentTypeIoOperation.newPregnantTreatmentType(pregnantTreatmentType);
-			
-			assertEquals(true, result);
+
+			assertTrue(result);
 			_checkPregnantTreatmentTypeIntoDb(pregnantTreatmentType.getCode());
 		} 
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -198,13 +201,13 @@ public class Tests
 		{		
 			code = _setupTestPregnantTreatmentType(false);
 			result = pregnantTreatmentTypeIoOperation.isCodePresent(code);
-			
-			assertEquals(true, result);
+
+			assertTrue(result);
 		} 
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -222,15 +225,15 @@ public class Tests
 			code = _setupTestPregnantTreatmentType(false);
 			PregnantTreatmentType foundPregnantTreatmentType = (PregnantTreatmentType)jpa.find(PregnantTreatmentType.class, code); 
 			result = pregnantTreatmentTypeIoOperation.deletePregnantTreatmentType(foundPregnantTreatmentType);
-			
-			assertEquals(true, result);
-			result = pregnantTreatmentTypeIoOperation.isCodePresent(code);			
-			assertEquals(false, result);
+
+			assertTrue(result);
+			result = pregnantTreatmentTypeIoOperation.isCodePresent(code);
+			assertFalse(result);
 		} 
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;

--- a/src/test/java/org/isf/priceslist/test/Tests.java
+++ b/src/test/java/org/isf/priceslist/test/Tests.java
@@ -2,6 +2,7 @@ package org.isf.priceslist.test;
 
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import java.util.ArrayList;
 
@@ -147,7 +148,7 @@ public class Tests
 
 		// then:
 		Price foundPrice = priceIoOperationRepository.findOne(insertId);
-		assertEquals(true, result);
+		assertTrue(result);
 		assertEquals(priceList.getId(), foundPrice.getList().getId());
 	}
 		

--- a/src/test/java/org/isf/pricesothers/test/Tests.java
+++ b/src/test/java/org/isf/pricesothers/test/Tests.java
@@ -2,6 +2,8 @@ package org.isf.pricesothers.test;
 
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import java.util.ArrayList;
 
@@ -81,7 +83,7 @@ public class Tests {
 		PricesOthers updatePricesOthers = repository.findOne(id);
 
 		// then:
-		assertEquals(true, result);
+		assertTrue(result);
 		assertEquals("Update", updatePricesOthers.getDescription());
 	}
 
@@ -94,7 +96,7 @@ public class Tests {
 		boolean result = otherIoOperation.newOthers(pricesOthers);
 
 		// then:
-		assertEquals(true, result);
+		assertTrue(result);
 		_checkPricesOthersIntoDb(pricesOthers.getId());
 	}
 
@@ -108,8 +110,8 @@ public class Tests {
 		boolean result = otherIoOperation.deleteOthers(foundPricesOthers);
 
 		// then:
-		assertEquals(true, result);
-		assertEquals(false, repository.exists(id));
+		assertTrue(result);
+		assertFalse(repository.exists(id));
 	}
 
 	private int _setupTestPricesOthers(boolean usingSet) throws OHException {

--- a/src/test/java/org/isf/sms/test/Tests.java
+++ b/src/test/java/org/isf/sms/test/Tests.java
@@ -2,6 +2,9 @@ package org.isf.sms.test;
 
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.util.Date;
 import java.util.GregorianCalendar;
@@ -84,7 +87,7 @@ public class Tests
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 				
 		return;
@@ -104,7 +107,7 @@ public class Tests
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -120,14 +123,14 @@ public class Tests
 		{		
 			Sms sms = testSms.setup(true);
 			result = smsIoOperation.saveOrUpdate(sms);
-			
-			assertEquals(true, result);
+
+			assertTrue(result);
 			_checksmsIntoDb(sms.getSmsId());
 		} 
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -149,7 +152,7 @@ public class Tests
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -174,7 +177,7 @@ public class Tests
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -197,7 +200,7 @@ public class Tests
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -215,13 +218,13 @@ public class Tests
 			Sms foundSms = (Sms)jpa.find(Sms.class, code); 
 			smsIoOperation.delete(foundSms);
 			
-			boolean result = smsIoOperation.isCodePresent(code);			
-			assertEquals(false, result);
+			boolean result = smsIoOperation.isCodePresent(code);
+			assertFalse(result);
 		} 
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -242,13 +245,13 @@ public class Tests
 					foundSms.getModule(), 
 					foundSms.getModuleID());
 
-			boolean result = smsIoOperation.isCodePresent(code);			
-			assertEquals(false, result);
+			boolean result = smsIoOperation.isCodePresent(code);
+			assertFalse(result);
 		} 
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;

--- a/src/test/java/org/isf/supplier/test/Tests.java
+++ b/src/test/java/org/isf/supplier/test/Tests.java
@@ -1,7 +1,7 @@
 package org.isf.supplier.test;
 
-
-import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.util.List;
 
@@ -85,7 +85,7 @@ public class Tests
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 				
 		return;
@@ -105,7 +105,7 @@ public class Tests
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -121,14 +121,14 @@ public class Tests
 		{		
 			Supplier supplier = testSupplier.setup(true);
 			result = supplierIoOperation.saveOrUpdate(supplier);
-			
-			assertEquals(true, result);
+
+			assertTrue(result);
 			_checkSupplierIntoDb(supplier.getSupId());
 		} 
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -150,7 +150,7 @@ public class Tests
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -166,14 +166,14 @@ public class Tests
 		{		
 			code = _setupTestSupplier(false);
 			Supplier foundSupplier = (Supplier)jpa.find(Supplier.class, code); 
-			List<Supplier> suppliers = supplierIoOperation.getAll();			
-			
-			assertEquals(true, suppliers.contains(foundSupplier));
+			List<Supplier> suppliers = supplierIoOperation.getAll();
+
+			assertTrue(suppliers.contains(foundSupplier));
 		} 
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -189,14 +189,14 @@ public class Tests
 		{		
 			code = _setupTestSupplier(false);
 			Supplier foundSupplier = (Supplier)jpa.find(Supplier.class, code); 
-			List<Supplier> suppliers = supplierIoOperation.getList();			
-			
-			assertEquals(true, suppliers.contains(foundSupplier));
+			List<Supplier> suppliers = supplierIoOperation.getList();
+
+			assertTrue(suppliers.contains(foundSupplier));
 		} 
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;

--- a/src/test/java/org/isf/therapy/test/Tests.java
+++ b/src/test/java/org/isf/therapy/test/Tests.java
@@ -2,6 +2,9 @@ package org.isf.therapy.test;
 
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.util.ArrayList;
 
@@ -116,7 +119,7 @@ public class Tests
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 				
 		return;
@@ -136,7 +139,7 @@ public class Tests
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -159,7 +162,7 @@ public class Tests
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -179,7 +182,7 @@ public class Tests
 			assertEquals(foundTherapyRow.getNote(), therapyRows.get(therapyRows.size()-1).getNote());
 		} catch (Exception e) {
 			e.printStackTrace();
-			assertEquals(true, false);
+			fail();
 		}
 	}
 	
@@ -207,7 +210,7 @@ public class Tests
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -226,14 +229,14 @@ public class Tests
 			TherapyRow foundTherapyRow = (TherapyRow)jpa.find(TherapyRow.class, id); 
 			result = therapyIoOperation.deleteAllTherapies(foundTherapyRow.getPatID().getCode());
 
-			assertEquals(true, result);
-			result = therapyIoOperation.isCodePresent(id);			
-			assertEquals(false, result);
+			assertTrue(result);
+			result = therapyIoOperation.isCodePresent(id);
+			assertFalse(result);
 		} 
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -256,7 +259,7 @@ public class Tests
 			assertEquals(mergedPatient.getCode(), result.getPatID().getCode());
 		} catch (Exception e) {
 			e.printStackTrace();
-			assertEquals(true, false);
+			fail();
 		}
 	}
 

--- a/src/test/java/org/isf/vaccine/test/Tests.java
+++ b/src/test/java/org/isf/vaccine/test/Tests.java
@@ -3,6 +3,8 @@ package org.isf.vaccine.test;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.util.ArrayList;
 
@@ -95,7 +97,7 @@ public class Tests
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 				
 		return;
@@ -115,7 +117,7 @@ public class Tests
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -133,7 +135,7 @@ public class Tests
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 	}
 
@@ -153,7 +155,7 @@ public class Tests
 		catch (Exception e)
 		{
 			e.printStackTrace();
-			assertEquals(true, false);
+			fail();
 		}
 	}
 	
@@ -171,15 +173,15 @@ public class Tests
 			jpa.flush();
 			foundVaccine.setDescription("Update");
 			result = vaccineIoOperation.updateVaccine(foundVaccine);
-			Vaccine updateVaccine = (Vaccine)jpa.find(Vaccine.class, code); 
-			
-			assertEquals(true, result);
+			Vaccine updateVaccine = (Vaccine)jpa.find(Vaccine.class, code);
+
+			assertTrue(result);
 			assertEquals("Update", updateVaccine.getDescription());
 		} 
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -200,14 +202,14 @@ public class Tests
 	    	
 			Vaccine vaccine = testVaccine.setup(vaccineType, true);
 			result = vaccineIoOperation.newVaccine(vaccine);
-			
-			assertEquals(true, result);
+
+			assertTrue(result);
 			_checkVaccineIntoDb(vaccine.getCode());
 		} 
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -225,15 +227,15 @@ public class Tests
 			code = _setupTestVaccine(false);
 			Vaccine foundVaccine = (Vaccine)jpa.find(Vaccine.class, code); 
 			result = vaccineIoOperation.deleteVaccine(foundVaccine);
-			
-			assertEquals(true, result);
-			result = vaccineIoOperation.isCodePresent(code);			
-			assertEquals(false, result);
+
+			assertTrue(result);
+			result = vaccineIoOperation.isCodePresent(code);
+			assertFalse(result);
 		} 
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -250,13 +252,13 @@ public class Tests
 		{		
 			code = _setupTestVaccine(false);
 			result = vaccineIoOperation.isCodePresent(code);
-			
-			assertEquals(true, result);
+
+			assertTrue(result);
 		} 
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;

--- a/src/test/java/org/isf/vactype/test/Tests.java
+++ b/src/test/java/org/isf/vactype/test/Tests.java
@@ -2,6 +2,9 @@ package org.isf.vactype.test;
 
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.util.ArrayList;
 
@@ -84,7 +87,7 @@ public class Tests
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 				
 		return;
@@ -104,7 +107,7 @@ public class Tests
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -127,7 +130,7 @@ public class Tests
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -146,15 +149,15 @@ public class Tests
 			VaccineType foundVaccineType = (VaccineType)jpa.find(VaccineType.class, code); 
 			foundVaccineType.setDescription("Update");
 			result = vaccineTypeIoOperation.updateVaccineType(foundVaccineType);
-			VaccineType updateVaccineType = (VaccineType)jpa.find(VaccineType.class, code); 
-			
-			assertEquals(true, result);
+			VaccineType updateVaccineType = (VaccineType)jpa.find(VaccineType.class, code);
+
+			assertTrue(result);
 			assertEquals("Update", updateVaccineType.getDescription());
 		} 
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -170,14 +173,14 @@ public class Tests
 		{		
 			VaccineType vaccineType = testVaccineType.setup(true);
 			result = vaccineTypeIoOperation.newVaccineType(vaccineType);
-			
-			assertEquals(true, result);
+
+			assertTrue(result);
 			_checkVaccineTypeIntoDb(vaccineType.getCode());
 		} 
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -194,13 +197,13 @@ public class Tests
 		{		
 			code = _setupTestVaccineType(false);
 			result = vaccineTypeIoOperation.isCodePresent(code);
-			
-			assertEquals(true, result);
+
+			assertTrue(result);
 		} 
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -218,15 +221,15 @@ public class Tests
 			code = _setupTestVaccineType(false);
 			VaccineType foundVaccineType = (VaccineType)jpa.find(VaccineType.class, code); 
 			result = vaccineTypeIoOperation.deleteVaccineType(foundVaccineType);
-			
-			assertEquals(true, result);
-			result = vaccineTypeIoOperation.isCodePresent(code);			
-			assertEquals(false, result);
+
+			assertTrue(result);
+			result = vaccineTypeIoOperation.isCodePresent(code);
+			assertFalse(result);
 		} 
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;

--- a/src/test/java/org/isf/visits/test/Tests.java
+++ b/src/test/java/org/isf/visits/test/Tests.java
@@ -2,6 +2,9 @@ package org.isf.visits.test;
 
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.util.ArrayList;
 
@@ -102,7 +105,7 @@ public class Tests
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 				
 		return;
@@ -122,7 +125,7 @@ public class Tests
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -140,7 +143,7 @@ public class Tests
 			assertEquals(foundVisit.getDate(), visits.get(visits.size()-1).getDate());
 		} catch (Exception e) {
 			e.printStackTrace();
-			assertEquals(true, false);
+			fail();
 		}
 	}
 
@@ -158,7 +161,7 @@ public class Tests
 			assertEquals(foundVisit.getDate(), visits.get(visits.size()-1).getDate());
 		} catch (Exception e) {
 			e.printStackTrace();
-			assertEquals(true, false);
+			fail();
 		}
 	}
 	
@@ -184,7 +187,7 @@ public class Tests
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;
@@ -203,14 +206,14 @@ public class Tests
 			Visit foundVisit = (Visit)jpa.find(Visit.class, id); 
 			result = visitsIoOperation.deleteAllVisits(foundVisit.getPatient().getCode());
 
-			assertEquals(true, result);
-			result = visitsIoOperation.isCodePresent(id);			
-			assertEquals(false, result);
+			assertTrue(result);
+			result = visitsIoOperation.isCodePresent(id);
+			assertFalse(result);
 		} 
 		catch (Exception e) 
 		{
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 		
 		return;

--- a/src/test/java/org/isf/ward/test/Tests.java
+++ b/src/test/java/org/isf/ward/test/Tests.java
@@ -2,6 +2,9 @@ package org.isf.ward.test;
 
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.util.ArrayList;
 
@@ -71,7 +74,7 @@ public class Tests
 			_checkWardIntoDb(code);
 		} catch (Exception e) {
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 	}
 	
@@ -82,7 +85,7 @@ public class Tests
 			_checkWardIntoDb(code);
 		} catch (Exception e) {
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 	}
 
@@ -100,7 +103,7 @@ public class Tests
 			assertEquals(foundWard.getDescription(), wards.get(wards.size()-1).getDescription());
 		} catch (Exception e) {
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 	}
 
@@ -118,7 +121,7 @@ public class Tests
 			assertEquals(foundWard.getDescription(), wards.get(0).getDescription());
 		} catch (Exception e) {
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 	}
 	
@@ -128,11 +131,11 @@ public class Tests
 			Ward ward = testWard.setup(true);
 			boolean result = wardIoOperation.newWard(ward);
 
-			assertEquals(true, result);
+			assertTrue(result);
 			_checkWardIntoDb(ward.getCode());
 		} catch (Exception e) {
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 	}
 	
@@ -149,11 +152,11 @@ public class Tests
 			Ward updateWard = wardIoOperationRepository.findOne(code);
 
 			// then:
-			assertEquals(true, result);
+			assertTrue(result);
 			assertEquals("Update", updateWard.getDescription());
 		} catch (Exception e) {
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 	}
 	
@@ -164,10 +167,10 @@ public class Tests
 			ward.setCode("X");
 			boolean result = wardIoOperation.updateWard(ward);
 
-			assertEquals(true, result);
+			assertTrue(result);
 		} catch (Exception e) {
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 	}
 	
@@ -182,12 +185,12 @@ public class Tests
 			boolean result = wardIoOperation.deleteWard(foundWard);
 
 			// then:
-			assertEquals(true, result);
-			result = wardIoOperation.isCodePresent(code);			
-			assertEquals(false, result);
+			assertTrue(result);
+			result = wardIoOperation.isCodePresent(code);
+			assertFalse(result);
 		} catch (Exception e) {
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 	}
 
@@ -197,10 +200,10 @@ public class Tests
 			String code = _setupTestWard(false);
 			boolean result = wardIoOperation.isCodePresent(code);
 
-			assertEquals(true, result);
+			assertTrue(result);
 		} catch (Exception e) {
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 	}
 
@@ -210,10 +213,10 @@ public class Tests
 
 		try {
 			result = wardIoOperation.isCodePresent("X");
-			assertEquals(false, result);
+			assertFalse(result);
 		} catch (Exception e) {
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 	}
 
@@ -227,11 +230,11 @@ public class Tests
 			wardIoOperationRepository.save(ward);
 
 			result = wardIoOperation.isMaternityPresent();
-			
-			assertEquals(true, result);
+
+			assertTrue(result);
 		} catch (Exception e) {
 			e.printStackTrace();		
-			assertEquals(true, false);
+			fail();
 		}
 	}
 


### PR DESCRIPTION
Simplify assertions:

* `assertEquals(true, false);`  ==> `fail()`;
* `assertEquals(true, xxxx);`  ==> `assertTrue(xxxx);`
* `assertEquals(false, yyyy);` ==> `assertFalse(yyyy);`
* `assertEquals(true, (zzzz != null));` ==>`assertNotNull(zzzz);`

The imports were also updated and ordered as necessary.  No major code formatting was done because of the large number of files.  The formatting will be done in another PR at a latter date.