### PR TITLE
Replace concatenation with parameterized log message

### DIFF
--- a/src/main/java/org/isf/dicom/manager/FileSystemDicomManager.java
+++ b/src/main/java/org/isf/dicom/manager/FileSystemDicomManager.java
@@ -335,12 +335,12 @@ public class FileSystemDicomManager implements DicomManagerInterface {
 		try {
 			rv.setIdFile(Long.parseLong(p.getProperty("idFile")));
 		} catch (Exception e) {
-			logger.debug("Unparsable 'idFile': " + p.getProperty("idFile"));
+			logger.debug("Unparsable 'idFile': {}", p.getProperty("idFile"));
 		}
 		try {
 			rv.setPatId(Integer.parseInt(p.getProperty("patId")));
 		} catch (Exception e) {
-			logger.debug("Unparsable 'patId': " + p.getProperty("patId"));
+			logger.debug("Unparsable 'patId': {}", p.getProperty("patId"));
 		}
 		rv.setFileName(p.getProperty("fileName"));
 		rv.setDicomAccessionNumber(p.getProperty("dicomAccessionNumber"));
@@ -355,8 +355,8 @@ public class FileSystemDicomManager implements DicomManagerInterface {
 		try {
 			rv.setDicomStudyDate(new SimpleDateFormat(DICOM_DATE_FORMAT, new Locale(GeneralData.LANGUAGE)).parse(p.getProperty("dicomStudyDate")));
 		} catch (ParseException e) {
-			logger.debug("1. example: " + new SimpleDateFormat(DICOM_DATE_FORMAT, new Locale(GeneralData.LANGUAGE)).format(new Date()));
-			logger.debug("1. Unparsable 'dicomStudyDate': " + p.getProperty("dicomStudyDate"));
+			logger.debug("1. example: {}", new SimpleDateFormat(DICOM_DATE_FORMAT, new Locale(GeneralData.LANGUAGE)).format(new Date()));
+			logger.debug("1. Unparsable 'dicomStudyDate': {}", p.getProperty("dicomStudyDate"));
 		}
 		rv.setDicomStudyDescription(p.getProperty("dicomStudyDescription"));
 		rv.setDicomSeriesUID(p.getProperty("dicomSeriesUID"));
@@ -366,8 +366,8 @@ public class FileSystemDicomManager implements DicomManagerInterface {
 		try {
 			rv.setDicomSeriesDate(new SimpleDateFormat(DICOM_DATE_FORMAT, new Locale(GeneralData.LANGUAGE)).parse(p.getProperty("dicomSeriesDate")));
 		} catch (ParseException e) {
-			logger.debug("2. example: " + new SimpleDateFormat(DICOM_DATE_FORMAT, new Locale(GeneralData.LANGUAGE)).format(new Date()));
-			logger.debug("Unparsable 'dicomSeriesDate': " + p.getProperty("dicomSeriesDate"));
+			logger.debug("2. example: {}", new SimpleDateFormat(DICOM_DATE_FORMAT, new Locale(GeneralData.LANGUAGE)).format(new Date()));
+			logger.debug("Unparsable 'dicomSeriesDate': {}", p.getProperty("dicomSeriesDate"));
 		}
 		rv.setDicomSeriesDescription(p.getProperty("dicomSeriesDescription"));
 		rv.setDicomInstanceUID(p.getProperty("dicomInstanceUID"));

--- a/src/main/java/org/isf/generaldata/ExaminationParameters.java
+++ b/src/main/java/org/isf/generaldata/ExaminationParameters.java
@@ -209,7 +209,7 @@ public class ExaminationParameters {
 		try {
 			value = Integer.parseInt(p.getProperty(property));
 		} catch (Exception e) {
-			logger.warn(property + " property not found: default is " + defaultValue);
+			logger.warn("{} property not found: default is {}", property, defaultValue);
 			return defaultValue;
 		}
 		return value;
@@ -227,7 +227,7 @@ public class ExaminationParameters {
 		try {
 			value = Double.parseDouble(p.getProperty(property));
 		} catch (Exception e) {
-			logger.warn(property + " property not found: default is " + defaultValue);
+			logger.warn("{} property not found: default is {}", property, defaultValue);
 			return defaultValue;
 		}
 		return value;

--- a/src/main/java/org/isf/generaldata/GeneralData.java
+++ b/src/main/java/org/isf/generaldata/GeneralData.java
@@ -187,7 +187,7 @@ public class GeneralData {
 		try {
 			value = p.getProperty(property).equalsIgnoreCase("YES");
 		} catch (Exception e) {
-			logger.warn(">> " + property + " property not found: default is " + defaultValue);
+			logger.warn(">> {} property not found: default is {}", property, defaultValue);
 			return defaultValue;
 		}
 		return value;
@@ -205,7 +205,7 @@ public class GeneralData {
 		String value;
 		value = p.getProperty(property);
 		if (value == null) {
-			logger.warn(">> " + property + " property not found: default is " + defaultValue);
+			logger.warn(">> {} property not found: default is {}", property, defaultValue);
 			return defaultValue;
 		}
 		return value;

--- a/src/main/java/org/isf/generaldata/MessageBundle.java
+++ b/src/main/java/org/isf/generaldata/MessageBundle.java
@@ -55,7 +55,7 @@ public class MessageBundle {
 					message = key;
 				}
 			}
-			logger.error(">> key not found: " + key);
+			logger.error(">> key not found: {}", key);
 		}
 		return message;
 	}
@@ -74,7 +74,7 @@ public class MessageBundle {
 			} else {
 				message = defaultResourceBundle.getString(key);
 			}
-			logger.error(">> key not found: " + key);
+			logger.error(">> key not found: {}", key);
 		}
 		message = message.replace("#", input.toString());
 		return message;
@@ -94,7 +94,7 @@ public class MessageBundle {
 			} else {
 				message = defaultResourceBundle.getString(key);
 			}
-			logger.error(">> key not found: " + key);
+			logger.error(">> key not found: {}", key);
 		}
 
 		for (Object input : inputs) {

--- a/src/main/java/org/isf/generaldata/PropertyReader.java
+++ b/src/main/java/org/isf/generaldata/PropertyReader.java
@@ -37,7 +37,7 @@ public class PropertyReader {
 			value = (T) typePropertyExtractorMap.get(defaultValue.getClass())
 					.getProperty(propertyName);
 		} catch (Exception e) {
-			this.logger.warn(">> " + propertyName + " property not found: default is " + defaultValue);
+			this.logger.warn(">> {} property not found: default is {}", propertyName, defaultValue);
 			return defaultValue;
 		}
 		

--- a/src/main/java/org/isf/generaldata/SmsParameters.java
+++ b/src/main/java/org/isf/generaldata/SmsParameters.java
@@ -66,7 +66,7 @@ public class SmsParameters {
 		String value;
 		value = p.getProperty(property);
 		if (value == null) {
-			logger.warn(">> " + property + " property not found: default is " + defaultValue);
+			logger.warn(">> {} property not found: default is {}", property, defaultValue);
 			return defaultValue;
 		}
 		return value;
@@ -84,7 +84,7 @@ public class SmsParameters {
 		try {
 			value = Integer.parseInt(p.getProperty(property));
 		} catch (Exception e) {
-			logger.warn(">> " + property + " property not found: default is " + defaultValue);
+			logger.warn(">> {} property not found: default is {}", property, defaultValue);
 			return defaultValue;
 		}
 		return value;

--- a/src/main/java/org/isf/generaldata/TxtPrinter.java
+++ b/src/main/java/org/isf/generaldata/TxtPrinter.java
@@ -67,7 +67,7 @@ public class TxtPrinter {
 		try {
 			value = Integer.parseInt(p.getProperty(property));
 		} catch (Exception e) {
-			logger.warn(">> " + property + " property not found: default is " + defaultValue);
+			logger.warn(">> {} property not found: default is {}", property, defaultValue);
 			return defaultValue;
 		}
 		return value;
@@ -86,7 +86,7 @@ public class TxtPrinter {
 		try {
 			value = p.getProperty(property).equalsIgnoreCase("YES");
 		} catch (Exception e) {
-			logger.warn(">> " + property + " property not found: default is " + defaultValue);
+			logger.warn(">> {} property not found: default is {}", property, defaultValue);
 			return defaultValue;
 		}
 		return value;
@@ -111,7 +111,7 @@ public class TxtPrinter {
 		String value;
 		value = p.getProperty(property);
 		if (value == null) {
-			logger.warn(">> " + property + " property not found: default is " + defaultValue);
+			logger.warn(">> {} property not found: default is {}", property, defaultValue);
 			return defaultValue;
 		}
 		return value;

--- a/src/main/java/org/isf/generaldata/Version.java
+++ b/src/main/java/org/isf/generaldata/Version.java
@@ -53,7 +53,7 @@ public class Version {
 		String value;
 		value = p.getProperty(property);
 		if (value == null) {
-			logger.warn(">> " + property + " property not found: default is " + defaultValue);
+			logger.warn(">> {} property not found: default is {}", property, defaultValue);
 			return defaultValue;
 		}
 		return value;

--- a/src/main/java/org/isf/serviceprinting/manager/PrintReceipt.java
+++ b/src/main/java/org/isf/serviceprinting/manager/PrintReceipt.java
@@ -83,7 +83,7 @@ public class PrintReceipt {
 
 				} else {
 					logger.debug("invalid MODE");
-					logger.debug("MODE: " + TxtPrinter.MODE);
+					logger.debug("MODE: {}", TxtPrinter.MODE);
 				}
 			} else {
 				logger.debug("printer was not found.");
@@ -177,7 +177,7 @@ public class PrintReceipt {
 	 * @param printService
 	 */
 	private void getPrinterDetails(PrintService printService) {
-		logger.debug("Printer: " + printService.getName());
+		logger.debug("Printer: {}", printService.getName());
 		logger.debug("Supported flavors:");
 		DocFlavor[] flavors = printService.getSupportedDocFlavors();
 		if (flavors != null) {
@@ -189,7 +189,7 @@ public class PrintReceipt {
 		Attribute[] attributes = printService.getAttributes().toArray();
 		if (attributes != null) {
 			for (Attribute attr : attributes) {
-				logger.debug(attr.getName() + ": " + (attr.getClass()).toString());
+				logger.debug("{}: {}", attr.getName(), (attr.getClass()).toString());
 			}
 		}
 	}

--- a/src/main/java/org/isf/sms/providers/GSMParameters.java
+++ b/src/main/java/org/isf/sms/providers/GSMParameters.java
@@ -66,7 +66,7 @@ public class GSMParameters {
 		String value;
 		value = p.getProperty(property);
 		if (value == null) {
-			logger.warn(">> " + property + " property not found: default is " + defaultValue);
+			logger.warn(">> {} property not found: default is {}", property, defaultValue);
 			return defaultValue;
 		}
 		return value;

--- a/src/main/java/org/isf/sms/providers/SkebbyGateway.java
+++ b/src/main/java/org/isf/sms/providers/SkebbyGateway.java
@@ -75,7 +75,7 @@ public class SkebbyGateway implements SmsSenderInterface {
 		// For eventual errors see http:#www.skebby.com/business/index/send-docs/#errorCodesSection
 		// WARNING: in case of error DON'T retry the sending, since they are blocking errors
 		// ------------------------------------------------------------------	
-        logger.debug("result: "+result);
+		logger.debug("result: {}", result);
     }
     
     /**
@@ -163,7 +163,7 @@ public class SkebbyGateway implements SmsSenderInterface {
 		SkebbyParameters.getSkebbyParameters();
 		String url = SkebbyParameters.URL;
 		if (url.equals("")) {
-			logger.error("No HTTP URL has been set for the Gateway: " + SmsParameters.GATEWAY);
+			logger.error("No HTTP URL has been set for the Gateway: {}", SmsParameters.GATEWAY);
 			logger.error("Please check Skebby.properties file");
 			return false;
 		}

--- a/src/main/java/org/isf/sms/providers/SkebbyParameters.java
+++ b/src/main/java/org/isf/sms/providers/SkebbyParameters.java
@@ -74,7 +74,7 @@ public class SkebbyParameters {
 		String value;
 		value = p.getProperty(property);
 		if (value == null) {
-			logger.warn(">> " + property + " property not found: default is " + defaultValue);
+			logger.warn(">> {} property not found: default is {}", property, defaultValue);
 			return defaultValue;
 		}
 		return value;

--- a/src/main/java/org/isf/sms/service/SmsSender.java
+++ b/src/main/java/org/isf/sms/service/SmsSender.java
@@ -32,7 +32,7 @@ public class SmsSender implements Runnable {
 		logger.info("SMS Sender started...");
 		SmsParameters.getSmsParameters();
 		delay = SmsParameters.LOOP;
-		logger.info("SMS Sender loop set to " + delay + " seconds.");
+		logger.info("SMS Sender loop set to {} seconds.", delay);
 	}
 
 	public void run() {
@@ -47,7 +47,7 @@ public class SmsSender implements Runnable {
 				e1.printStackTrace();
 			}
 			if (!smsList.isEmpty()) {
-				logger.info("Found " + smsList.size() + " SMS to send");
+				logger.info("Found {} SMS to send", smsList.size());
 				if (SmsParameters.MODE.equals("GSM")) {
 					
 					SmsSenderGSM sender = new SmsSenderGSM();

--- a/src/main/java/org/isf/sms/service/SmsSenderGSM.java
+++ b/src/main/java/org/isf/sms/service/SmsSenderGSM.java
@@ -70,8 +70,8 @@ public class SmsSenderGSM implements SmsSenderInterface, SerialPortEventListener
 			portId = (CommPortIdentifier) portList.nextElement();
 			
 			if (portId.getName().equals(port) && portId.getPortType() == CommPortIdentifier.PORT_SERIAL) {
-				
-				logger.debug("COM PORT found (" + port + ")");
+
+				logger.debug("COM PORT found ({})", port);
 				break;
 				
 			} else portId = null; 
@@ -94,12 +94,12 @@ public class SmsSenderGSM implements SmsSenderInterface, SerialPortEventListener
 				} else logger.debug("Not possible to open the stream");
 				
 			} catch (PortInUseException e) {
-				logger.error("Port in use: " + portId.getCurrentOwner());
+				logger.error("Port in use: {}", portId.getCurrentOwner());
 			} catch (Exception e) {
-				logger.error("Failed to open port " + portId.getName() + " " + e);
+				logger.error("Failed to open port {} {}", portId.getName(), e);
 			}
 		} else {
-			logger.error("COM PORT not found (" + port + ")!!!");
+			logger.error("COM PORT not found ({})!!!", port);
  		}
 		return connected;
 	}
@@ -107,8 +107,8 @@ public class SmsSenderGSM implements SmsSenderInterface, SerialPortEventListener
 	@Override
 	public boolean sendSMS(Sms sms, boolean debug) {
 		if (connected) {
-			logger.debug("Sending SMS (" + sms.getSmsId() + ") to: " + sms.getSmsNumber());
-			logger.debug("Sending text: " + sms.getSmsText());
+			logger.debug("Sending SMS ({}) to: {}", sms.getSmsId(), sms.getSmsNumber());
+			logger.debug("Sending text: {}", sms.getSmsText());
 			
 			StringBuilder build_CMGS = new StringBuilder(GSMParameters.CMGS);
 			build_CMGS.append(sms.getSmsNumber());
@@ -183,7 +183,7 @@ public class SmsSenderGSM implements SmsSenderInterface, SerialPortEventListener
 			// TODO Auto-generated catch block
 			e.printStackTrace();
 		}
-		logger.debug("Found " + smsList.size() + " SMS to send");
+		logger.debug("Found {} SMS to send", smsList.size());
 		
 		//Send
 		SmsSenderGSM sender = new SmsSenderGSM();
@@ -191,6 +191,6 @@ public class SmsSenderGSM implements SmsSenderInterface, SerialPortEventListener
 		if (sender.initialize()) {
 			result = sender.sendSMS(smsList.get(0), true);
 		}
-		logger.debug(""+result);
+		logger.debug("{}", result);
 	}
 }

--- a/src/main/java/org/isf/stat/manager/JasperReportsManager.java
+++ b/src/main/java/org/isf/stat/manager/JasperReportsManager.java
@@ -431,7 +431,7 @@ public class JasperReportsManager {
 						new Locale(language), 
 						new UTF8Control());
 			} catch (MissingResourceException e) {
-				logger.error(">> no resource bundle for language = " + language + " found for this report.");
+				logger.error(">> no resource bundle for language = {} found for this report.", language);
 				logger.error(e.getMessage());
 				resourceBundle = ResourceBundle.getBundle(jasperFileName, new Locale("en"));
 			}
@@ -693,7 +693,7 @@ public class JasperReportsManager {
         try {
 			fromDateQuery = TimeTools.parseDate(fromDate, "dd/MM/yyyy", false).getTime();
 		} catch (ParseException e) {
-        	logger.error("Error parsing '" + fromDate + "' to a Date using pattern: 'dd/MM/yyyy'");
+	        logger.error("Error parsing '{}' to a Date using pattern: 'dd/MM/yyyy'", fromDate);
 			throw new OHReportException(e, new OHExceptionMessage(MessageBundle.getMessage("angal.hospital"),
 					MessageBundle.getMessage("angal.stat.reporterror"), OHSeverityLevel.ERROR));
 		}
@@ -701,7 +701,7 @@ public class JasperReportsManager {
         try {
         	toDateQuery = TimeTools.parseDate(toDate, "dd/MM/yyyy", false).getTime();;
 		} catch (ParseException e) {
-        	logger.error("Error parsing '" + toDate + "' to a Date using pattern: 'dd/MM/yyyy'");
+	        logger.error("Error parsing '{}' to a Date using pattern: 'dd/MM/yyyy'", toDate);
 			throw new OHReportException(e, new OHExceptionMessage(MessageBundle.getMessage("angal.hospital"),
 					MessageBundle.getMessage("angal.stat.reporterror"), OHSeverityLevel.ERROR));
 		}
@@ -721,7 +721,7 @@ public class JasperReportsManager {
 		try {
 			fromDateQuery = TimeTools.parseDate(fromDate, "dd/MM/yyyy", false).getTime();
 		} catch (ParseException e) {
-			logger.error("Error parsing '" + fromDate + "' to a Date using pattern: 'dd/MM/yyyy'");
+			logger.error("Error parsing '{}' to a Date using pattern: 'dd/MM/yyyy'", fromDate);
 			throw new OHReportException(e, new OHExceptionMessage(MessageBundle.getMessage("angal.hospital"),
 					MessageBundle.getMessage("angal.stat.reporterror"), OHSeverityLevel.ERROR));
 		}
@@ -729,7 +729,7 @@ public class JasperReportsManager {
 		try {
 			toDateQuery = TimeTools.parseDate(toDate, "dd/MM/yyyy", false).getTime();;
 		} catch (ParseException e) {
-			logger.error("Error parsing '" + toDate + "' to a Date using pattern: 'dd/MM/yyyy'");
+			logger.error("Error parsing '{}' to a Date using pattern: 'dd/MM/yyyy'", toDate);
 			throw new OHReportException(e, new OHExceptionMessage(MessageBundle.getMessage("angal.hospital"),
 					MessageBundle.getMessage("angal.stat.reporterror"), OHSeverityLevel.ERROR));
 		}

--- a/src/main/java/org/isf/utils/db/DbJpaUtil.java
+++ b/src/main/java/org/isf/utils/db/DbJpaUtil.java
@@ -97,7 +97,7 @@ public class DbJpaUtil
     		Object entity) throws OHException
     {    	
     	try {
-    		logger.debug("Persist: " + entity);
+		    logger.debug("Persist: {}", entity);
     		entityManager.persist(entity);  
 		} catch (EntityExistsException e) {
 			logger.error("EntityExistsException");
@@ -127,8 +127,8 @@ public class DbJpaUtil
     	
     	
     	try {
-    		mergedEntity = entityManager.merge(entity);  
-    		logger.debug("Merge: " + mergedEntity);
+    		mergedEntity = entityManager.merge(entity);
+		    logger.debug("Merge: {}", mergedEntity);
 		} catch (IllegalArgumentException e) {
 			logger.error("IllegalArgumentException");
 			e.printStackTrace();
@@ -155,8 +155,8 @@ public class DbJpaUtil
     	
 
     	try {
-    		entity = entityManager.find(entityClass, primaryKey);  
-    		logger.debug("Find: " + entity);
+    		entity = entityManager.find(entityClass, primaryKey);
+		    logger.debug("Find: {}", entity);
 		} catch (IllegalArgumentException e) {
 			logger.error("IllegalArgumentException");
 			e.printStackTrace();
@@ -175,7 +175,7 @@ public class DbJpaUtil
     		Object entity) throws OHException
     {    
     	try {
-    		logger.debug("Remove: " + entity);
+		    logger.debug("Remove: {}", entity);
     		entityManager.remove(entityManager.contains(entity) ? entity : entityManager.merge(entity));  
 		} catch (IllegalArgumentException e) {
 			logger.error("IllegalArgumentException");

--- a/src/main/java/org/isf/utils/db/DbQueryLogger.java
+++ b/src/main/java/org/isf/utils/db/DbQueryLogger.java
@@ -35,7 +35,7 @@ public class DbQueryLogger {
      */
     public ResultSet getData(String aQuery, boolean autocommit) throws OHException {
     	if (logger.isDebugEnabled()) {
-			logger.debug("Query " + sanitize(aQuery));
+		    logger.debug("Query {}", sanitize(aQuery));
 		}
     	try{
 	        Connection conn = DbSingleJpaConn.getConnection();
@@ -61,8 +61,9 @@ public class DbQueryLogger {
      */
     public ResultSet getDataWithParams(String aQuery, List<?> params, boolean autocommit) throws OHException {
     	if (logger.isDebugEnabled()) {
-			logger.debug("Query " + sanitize(aQuery));
-			if (!params.isEmpty()) logger.trace("	parameters : " + sanitize(params));
+		    logger.debug("Query {}", sanitize(aQuery));
+			if (!params.isEmpty())
+				logger.trace("	parameters : {}", sanitize(params));
 		}
     	ResultSet results = null;
     	Connection conn = null;
@@ -95,7 +96,7 @@ public class DbQueryLogger {
      */
     public boolean setData(String aQuery, boolean autocommit) throws OHException {
     	if (logger.isDebugEnabled()) {
-			logger.debug("Query " + sanitize(aQuery));
+		    logger.debug("Query {}", sanitize(aQuery));
 		}
     	try{
 	        Connection conn = DbSingleJpaConn.getConnection();
@@ -124,8 +125,9 @@ public class DbQueryLogger {
      */
     public boolean setDataWithParams(String aQuery, List<?> params, boolean autocommit) throws OHException {
     	if (logger.isDebugEnabled()) {
-			logger.debug("Query " + sanitize(aQuery));
-			if (!params.isEmpty()) logger.trace("	parameters : " + sanitize(params));
+		    logger.debug("Query {}", sanitize(aQuery));
+			if (!params.isEmpty())
+				logger.trace("	parameters : {}", sanitize(params));
 		}
     	Connection conn = null;
     	try {
@@ -159,7 +161,7 @@ public class DbQueryLogger {
      */
     public ResultSet setDataReturnGeneratedKey(String aQuery, boolean autocommit) throws OHException {
     	if (logger.isDebugEnabled()) {
-			logger.debug("Query " + sanitize(aQuery));
+		    logger.debug("Query {}", sanitize(aQuery));
 		}
     	try{
 	        Connection conn = DbSingleJpaConn.getConnection();
@@ -188,8 +190,9 @@ public class DbQueryLogger {
      */
     public ResultSet setDataReturnGeneratedKeyWithParams(String aQuery, List<?> params, boolean autocommit) throws OHException {
     	if (logger.isDebugEnabled()) {
-			logger.debug("Query " + sanitize(aQuery));
-			if (!params.isEmpty()) logger.trace("	parameters : " + sanitize(params));
+		    logger.debug("Query {}", sanitize(aQuery));
+			if (!params.isEmpty())
+				logger.trace("	parameters : {}", sanitize(params));
 		}
     	try{
 	        Connection conn = DbSingleJpaConn.getConnection();
@@ -220,7 +223,7 @@ public class DbQueryLogger {
      */
     public boolean isData(String aQuery) throws OHException {
     	if (logger.isDebugEnabled()) {
-			logger.debug("Query " + sanitize(aQuery));
+		    logger.debug("Query {}", sanitize(aQuery));
 		}
     	try {
             Connection conn = DbSingleJpaConn.getConnection();

--- a/src/main/java/org/isf/utils/db/DbSingleConn.java
+++ b/src/main/java/org/isf/utils/db/DbSingleConn.java
@@ -43,7 +43,7 @@ public class DbSingleConn {
 				pConn = createConnection();
 			} catch (CommunicationsException ce) {
 				String message = MessageBundle.getMessage("angal.utils.dbserverconnectionfailure");
-				logger.error(">> " + message);
+				logger.error(">> {}", message);
 				JOptionPane.showMessageDialog(null, message);
 				System.exit(1);
 			}

--- a/src/main/java/org/isf/utils/db/DbSingleJpaConn.java
+++ b/src/main/java/org/isf/utils/db/DbSingleJpaConn.java
@@ -28,7 +28,7 @@ public class DbSingleJpaConn {
 				connection = createConnection();
 			} catch (Exception e){
 				String message = MessageBundle.getMessage("angal.utils.dbserverconnectionfailure");
-				logger.error(">> " + message);
+				logger.error(">> {}", message);
                 throw new OHException(message, e);
 			}
 		}

--- a/src/main/java/org/isf/utils/exception/OHException.java
+++ b/src/main/java/org/isf/utils/exception/OHException.java
@@ -19,8 +19,8 @@ public class OHException extends Exception {
 	public OHException(String message, Throwable cause) {
 		super(message, cause);
 		if (logger.isErrorEnabled()) {
-			logger.error(">> EXCEPTION: " + sanitize(message));
-			logger.error(">> " + cause);
+			logger.error(">> EXCEPTION: {}", sanitize(message));
+			logger.error(">> {}", cause);
 		}
 	}
 	
@@ -31,7 +31,7 @@ public class OHException extends Exception {
 	public OHException(String message) {
 		super(message);
 		if (logger.isErrorEnabled()) {
-			logger.error(">> EXCEPTION: " + sanitize(message));
+			logger.error(">> EXCEPTION: {}", sanitize(message));
 		}
 	}
 	

--- a/src/main/java/org/isf/xmpp/manager/Interaction.java
+++ b/src/main/java/org/isf/xmpp/manager/Interaction.java
@@ -80,10 +80,10 @@ public class Interaction{
 		new ServiceDiscoveryManager(server.getConnection());
 		FileTransferManager manager= new FileTransferManager(server.getConnection());
 		FileTransferNegotiator.setServiceEnabled(server.getConnection(), true);
-		logger.debug("Manager: " + manager);
+		logger.debug("Manager: {}", manager);
 		String userID = user+server.getUserAddress()+"/Smack";
 		//String userID=getUseradd(user);
-		logger.debug("Recipient: " + userID);
+		logger.debug("Recipient: {}", userID);
 		//OutgoingFileTransfer.setResponseTimeout(10000);
 		OutgoingFileTransfer transfer = manager.createOutgoingFileTransfer(userID);
 		try {
@@ -91,12 +91,12 @@ public class Interaction{
 		} catch (XMPPException e) {
 			e.printStackTrace();
 		}
-		logger.debug("Transfer status: " + transfer.isDone() + ", " + transfer.getStatus());
+		logger.debug("Transfer status: {}, {}", transfer.isDone(), transfer.getStatus());
 
 		if(transfer.isDone())
 			logger.debug("Transfer successfully completed!");
 		if(transfer.getStatus().equals(Status.error))
-			logger.debug("Error while transferring: " + transfer.getError());
+			logger.debug("Error while transferring: {}", transfer.getError());
 
 	}
 

--- a/src/main/java/org/isf/xmpp/service/Server.java
+++ b/src/main/java/org/isf/xmpp/service/Server.java
@@ -55,10 +55,10 @@ public class Server {
 		Chat chat = null;
 		id = id + "@" + user;
 		if (connection.getChatManager().getThreadChat(id) == null) {
-			logger.debug("Creation chat: " + to + ", id = " + id);
+			logger.debug("Creation chat: {}, id = {}", to, id);
 			chat = connection.getChatManager().createChat(to, id, listener);
 		} else {
-			logger.debug("Existing chat: " + to + ", id = " + id);
+			logger.debug("Existing chat: {}, id = {}", to, id);
 			chat = connection.getChatManager().getThreadChat(id);
 		}
 		return chat;

--- a/src/test/java/org/isf/lab/test/Tests.java
+++ b/src/test/java/org/isf/lab/test/Tests.java
@@ -388,16 +388,16 @@ public class Tests {
 			assertEquals(true, result);
 			_checkLaboratoryIntoDb(laboratory.getCode());
 		} catch (OHServiceException e) {
-			logger.debug("==> Voluntary Exception: " + e);
+			logger.debug("==> Voluntary Exception: {}", e);
 			try {
 				Laboratory foundlaboratory = (Laboratory) jpa.find(Laboratory.class, laboratory.getCode());
 				assertEquals(null, foundlaboratory);
 			} catch (Exception e1) {
-				logger.debug("==> Test Exception: " + e);
+				logger.debug("==> Test Exception: {}", e);
 				assertEquals(true, false);
 			}
 		} catch (Exception e) {
-			logger.debug("==> Test Exception: " + e);
+			logger.debug("==> Test Exception: {}", e);
 			assertEquals(true, false);
 		}
 
@@ -445,9 +445,9 @@ public class Tests {
 		} catch (OHServiceException e) {
 			logger.debug("==> Voluntary Exception: ");
 			for (OHExceptionMessage error : e.getMessages())
-				logger.debug("    " + error.getMessage());
+				logger.debug("    {}", error.getMessage());
 		} catch (Exception e) {
-			logger.debug("==> Test Exception: " + e);
+			logger.debug("==> Test Exception: {}", e);
 			assertEquals(true, false);
 		}
 		return;
@@ -513,7 +513,7 @@ public class Tests {
 			result = labIoOperation.isCodePresent(code);
 			assertEquals(false, result);
 		} catch (OHServiceException e) {
-			logger.debug("==> Test Exception: " + e);
+			logger.debug("==> Test Exception: {}", e);
 			e.printStackTrace();
 			assertEquals(true, false);
 		} catch (Exception e) {


### PR DESCRIPTION
Non-constant concatenations in logging messages are evaluated at runtime even when the logging message is not logged; this can negatively impact performance. Thus these changes use a parameterized log message instead which will not be evaluated when logging is disabled.

Because of the large number of files, reformatting of the files was not done in this PR.