### PR TITLE
Update Spring from 4.3.18 to latest 4.x branch version 4.3.28

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<spring.framework.version>4.3.18.RELEASE</spring.framework.version>
+		<spring.framework.version>4.3.28.RELEASE</spring.framework.version>
 	</properties>
 
 	<build>


### PR DESCRIPTION
This replaces this [PR](https://github.com/informatici/openhospital-core/pull/140) which updates to 5.x branch which currently is not compatible. 