### PR TITLE
Update SpringBootTest and SpringBootStarterTest from 1.4.0 to compatible version 1.5.22

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -389,7 +389,7 @@
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-test</artifactId>
-			<version>1.4.0.RELEASE</version>
+			<version>1.5.22.RELEASE</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
@@ -400,7 +400,7 @@
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
-			<version>1.4.0.RELEASE</version>
+			<version>1.5.22.RELEASE</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>


### PR DESCRIPTION
This replaces these two PRs:

- [spring-boot-test](https://github.com/informatici/openhospital-core/pull/162) 
- [spring-boot-starter-test](https://github.com/informatici/openhospital-core/pull/161)

by upgrading to compatible version.