### PR TITLE
OP-247 Method ambiguity

### DIFF
--- a/src/main/java/org/isf/accounting/manager/BillBrowserManager.java
+++ b/src/main/java/org/isf/accounting/manager/BillBrowserManager.java
@@ -123,7 +123,7 @@ public class BillBrowserManager {
 	 * @throws OHServiceException 
 	 */
 	public ArrayList<Bill> getBills(GregorianCalendar dateFrom, GregorianCalendar dateTo,Patient patient) throws OHServiceException {
-		return ioOperations.getBills(dateFrom, dateTo, patient);
+		return ioOperations.getBillsBetweenDatesWherePatient(dateFrom, dateTo, patient);
 	}
 
 	/**
@@ -135,7 +135,7 @@ public class BillBrowserManager {
 	 * @throws OHServiceException 
 	 */
 	public ArrayList<BillPayments> getPayments(GregorianCalendar dateFrom, GregorianCalendar dateTo,Patient patient) throws OHServiceException {
-		return ioOperations.getPayments(dateFrom, dateTo, patient);
+		return ioOperations.getPaymentsBetweenDatesWherePatient(dateFrom, dateTo, patient);
 	}
 	
 	/**
@@ -304,7 +304,7 @@ public class BillBrowserManager {
 	 * @throws OHServiceException 
 	 */
 	public ArrayList<Bill> getBills(GregorianCalendar dateFrom, GregorianCalendar dateTo) throws OHServiceException {
-		return ioOperations.getBills(dateFrom, dateTo);
+		return ioOperations.getBillsBetweenDates(dateFrom, dateTo);
 	}
 
 	/**
@@ -368,6 +368,6 @@ public class BillBrowserManager {
 	 * @throws OHServiceException 
 	 */
 	public ArrayList<Bill> getBills(GregorianCalendar dateFrom, GregorianCalendar dateTo,BillItems billItem) throws OHServiceException {
-		return ioOperations.getBills(dateFrom, dateTo, billItem);
+		return ioOperations.getBillsBetweenDatesWhereBillItem(dateFrom, dateTo, billItem);
 	}
 }

--- a/src/main/java/org/isf/accounting/service/AccountingIoOperations.java
+++ b/src/main/java/org/isf/accounting/service/AccountingIoOperations.java
@@ -287,8 +287,21 @@ public class AccountingIoOperations {
 	 * @param dateTo the high date range endpoint, inclusive.
 	 * @return a list of retrieved {@link Bill}s.
 	 * @throws OHServiceException if an error occurs retrieving the bill list.
+	 * @deprecated use {@link #getBillsByDate(GregorianCalendar, GregorianCalendar)}
 	 */
+	@Deprecated
 	public ArrayList<Bill> getBills(GregorianCalendar dateFrom, GregorianCalendar dateTo) throws OHServiceException {
+		return getBillsByDate(dateFrom, dateTo);
+	}
+
+	/**
+	 * Retrieves all the {@link Bill}s for the specified date range.
+	 * @param dateFrom the low date range endpoint, inclusive.
+	 * @param dateTo the high date range endpoint, inclusive.
+	 * @return a list of retrieved {@link Bill}s.
+	 * @throws OHServiceException if an error occurs retrieving the bill list.
+	 */
+	public ArrayList<Bill> getBillsByDate(GregorianCalendar dateFrom, GregorianCalendar dateTo) throws OHServiceException {
 		return new ArrayList<Bill>(billRepository.findByDateBetween(TimeTools.getBeginningOfDay(dateFrom), TimeTools.getBeginningOfNextDay(dateTo)));
 	}
 
@@ -329,12 +342,42 @@ public class AccountingIoOperations {
 	 * @param patient
 	 * @return
 	 * @throws OHServiceException
+	 * @deprecated use {@link #getPaymentsForPatient(GregorianCalendar, GregorianCalendar, Patient)}
 	 */
+	@Deprecated
 	public ArrayList<BillPayments> getPayments(GregorianCalendar dateFrom, GregorianCalendar dateTo, Patient patient)
+			throws OHServiceException {
+		return getPaymentsForPatient(dateFrom, dateTo, patient);
+	}
+
+	/**
+	 * Retrieves all billPayments for a given patient in the period dateFrom -> dateTo
+	 * @param dateFrom
+	 * @param dateTo
+	 * @param patient
+	 * @return
+	 * @throws OHServiceException
+	 */
+	public ArrayList<BillPayments> getPaymentsForPatient(GregorianCalendar dateFrom, GregorianCalendar dateTo, Patient patient)
 			throws OHServiceException {
 		ArrayList<BillPayments> payments =  billPaymentRepository.findByDateAndPatient(dateFrom, dateTo, patient.getCode());
 		return payments;
 	}
+
+	/**
+	 * Retrieves all the bills for a given patient in the period dateFrom -> dateTo
+	 * @param dateFrom
+	 * @param dateTo
+	 * @param patient
+	 * @return the bill list
+	 * @throws OHServiceException
+	 * @deprecated use {@link #getBillsForPatient(GregorianCalendar, GregorianCalendar, Patient)}
+	 */
+	@Deprecated
+	public ArrayList<Bill> getBills(GregorianCalendar dateFrom, GregorianCalendar dateTo, Patient patient) throws OHServiceException {
+		return getBillsForPatient(dateFrom, dateTo, patient);
+	}
+
 	/**
 	 * Retrieves all the bills for a given patient in the period dateFrom -> dateTo
 	 * @param dateFrom
@@ -343,10 +386,11 @@ public class AccountingIoOperations {
 	 * @return the bill list
 	 * @throws OHServiceException
 	 */
-	public ArrayList<Bill> getBills(GregorianCalendar dateFrom, GregorianCalendar dateTo, Patient patient) throws OHServiceException {
+	public ArrayList<Bill> getBillsForPatient(GregorianCalendar dateFrom, GregorianCalendar dateTo, Patient patient) throws OHServiceException {
 		ArrayList<Bill> bills = billRepository.findByDateAndPatient(dateFrom, dateTo, patient.getCode());
 		return bills;
 	}
+
 	/**
 	 * 
 	 * @param patID
@@ -379,15 +423,30 @@ public class AccountingIoOperations {
 	}
 	
 	/**
-	 * return the bill list which date between dateFrom and dateTo and containing given billItem
+	 * Return the bill list which date between dateFrom and dateTo and containing given billItem
 	 * added by u2g
 	 * @param dateFrom
 	 * @param dateTo
 	 * @param billItem
 	 * @return the bill list
 	 * @throws OHServiceException
+	 * @deprecated use {@link #getBillsWithBillItem(GregorianCalendar, GregorianCalendar, BillItems)}
 	 */
+	@Deprecated
 	public ArrayList<Bill> getBills(GregorianCalendar dateFrom, GregorianCalendar dateTo, BillItems billItem) throws OHServiceException {
+		return getBillsWithBillItem(dateFrom, dateTo, billItem);
+	}
+
+	/**
+	 * Return the bill list which date between dateFrom and dateTo and containing given billItem
+	 *
+	 * @param dateFrom
+	 * @param dateTo
+	 * @param billItem
+	 * @return the bill list
+	 * @throws OHServiceException
+	 */
+	public ArrayList<Bill> getBillsWithBillItem(GregorianCalendar dateFrom, GregorianCalendar dateTo, BillItems billItem) throws OHServiceException {
 		ArrayList<Bill> bills = null;
 		if(billItem == null) {
 			bills = (ArrayList<Bill>) billRepository.findByDateBetween(TimeTools.getBeginningOfDay(dateFrom), TimeTools.getBeginningOfNextDay(dateTo));
@@ -398,17 +457,4 @@ public class AccountingIoOperations {
 		}
 		return bills;
 	}
-
-	/**
-	 * Return the entire bill list when the date is between dateFrom and dateTo
-	 *
-	 * @param dateFrom
-	 * @param dateTo
-	 * @return the bill list
-	 * @throws OHServiceException
-	 */
-	public ArrayList<Bill> getAllBills(GregorianCalendar dateFrom, GregorianCalendar dateTo) throws OHServiceException {
-		return (ArrayList<Bill>)billRepository.findByDateBetween(TimeTools.getBeginningOfDay(dateFrom), TimeTools.getBeginningOfNextDay(dateTo));
-	}
-
 }

--- a/src/main/java/org/isf/accounting/service/AccountingIoOperations.java
+++ b/src/main/java/org/isf/accounting/service/AccountingIoOperations.java
@@ -287,11 +287,11 @@ public class AccountingIoOperations {
 	 * @param dateTo the high date range endpoint, inclusive.
 	 * @return a list of retrieved {@link Bill}s.
 	 * @throws OHServiceException if an error occurs retrieving the bill list.
-	 * @deprecated use {@link #getBillsBetweenDates (GregorianCalendar, GregorianCalendar)}
+	 * @deprecated use {@link #getBillsBetweenDates(GregorianCalendar, GregorianCalendar)}
 	 */
 	@Deprecated
 	public ArrayList<Bill> getBills(GregorianCalendar dateFrom, GregorianCalendar dateTo) throws OHServiceException {
-		return getBillsBetweenDates (dateFrom, dateTo);
+		return getBillsBetweenDates(dateFrom, dateTo);
 	}
 
 	/**
@@ -301,7 +301,7 @@ public class AccountingIoOperations {
 	 * @return a list of retrieved {@link Bill}s.
 	 * @throws OHServiceException if an error occurs retrieving the bill list.
 	 */
-	public ArrayList<Bill> getBillsBetweenDates (GregorianCalendar dateFrom, GregorianCalendar dateTo) throws OHServiceException {
+	public ArrayList<Bill> getBillsBetweenDates(GregorianCalendar dateFrom, GregorianCalendar dateTo) throws OHServiceException {
 		return new ArrayList<Bill>(billRepository.findByDateBetween(TimeTools.getBeginningOfDay(dateFrom), TimeTools.getBeginningOfNextDay(dateTo)));
 	}
 

--- a/src/main/java/org/isf/accounting/service/AccountingIoOperations.java
+++ b/src/main/java/org/isf/accounting/service/AccountingIoOperations.java
@@ -399,4 +399,16 @@ public class AccountingIoOperations {
 		return bills;
 	}
 
+	/**
+	 * Return the entire bill list when the date is between dateFrom and dateTo
+	 *
+	 * @param dateFrom
+	 * @param dateTo
+	 * @return the bill list
+	 * @throws OHServiceException
+	 */
+	public ArrayList<Bill> getAllBills(GregorianCalendar dateFrom, GregorianCalendar dateTo) throws OHServiceException {
+		return (ArrayList<Bill>)billRepository.findByDateBetween(TimeTools.getBeginningOfDay(dateFrom), TimeTools.getBeginningOfNextDay(dateTo));
+	}
+
 }

--- a/src/main/java/org/isf/accounting/service/AccountingIoOperations.java
+++ b/src/main/java/org/isf/accounting/service/AccountingIoOperations.java
@@ -287,11 +287,11 @@ public class AccountingIoOperations {
 	 * @param dateTo the high date range endpoint, inclusive.
 	 * @return a list of retrieved {@link Bill}s.
 	 * @throws OHServiceException if an error occurs retrieving the bill list.
-	 * @deprecated use {@link #getBillsByDate(GregorianCalendar, GregorianCalendar)}
+	 * @deprecated use {@link #getBillsBetweenDates (GregorianCalendar, GregorianCalendar)}
 	 */
 	@Deprecated
 	public ArrayList<Bill> getBills(GregorianCalendar dateFrom, GregorianCalendar dateTo) throws OHServiceException {
-		return getBillsByDate(dateFrom, dateTo);
+		return getBillsBetweenDates (dateFrom, dateTo);
 	}
 
 	/**
@@ -301,7 +301,7 @@ public class AccountingIoOperations {
 	 * @return a list of retrieved {@link Bill}s.
 	 * @throws OHServiceException if an error occurs retrieving the bill list.
 	 */
-	public ArrayList<Bill> getBillsByDate(GregorianCalendar dateFrom, GregorianCalendar dateTo) throws OHServiceException {
+	public ArrayList<Bill> getBillsBetweenDates (GregorianCalendar dateFrom, GregorianCalendar dateTo) throws OHServiceException {
 		return new ArrayList<Bill>(billRepository.findByDateBetween(TimeTools.getBeginningOfDay(dateFrom), TimeTools.getBeginningOfNextDay(dateTo)));
 	}
 
@@ -342,12 +342,12 @@ public class AccountingIoOperations {
 	 * @param patient
 	 * @return
 	 * @throws OHServiceException
-	 * @deprecated use {@link #getPaymentsForPatient(GregorianCalendar, GregorianCalendar, Patient)}
+	 * @deprecated use {@link #getPaymentsBetweenDatesWherePatient(GregorianCalendar, GregorianCalendar, Patient)}
 	 */
 	@Deprecated
 	public ArrayList<BillPayments> getPayments(GregorianCalendar dateFrom, GregorianCalendar dateTo, Patient patient)
 			throws OHServiceException {
-		return getPaymentsForPatient(dateFrom, dateTo, patient);
+		return getPaymentsBetweenDatesWherePatient(dateFrom, dateTo, patient);
 	}
 
 	/**
@@ -358,7 +358,7 @@ public class AccountingIoOperations {
 	 * @return
 	 * @throws OHServiceException
 	 */
-	public ArrayList<BillPayments> getPaymentsForPatient(GregorianCalendar dateFrom, GregorianCalendar dateTo, Patient patient)
+	public ArrayList<BillPayments> getPaymentsBetweenDatesWherePatient(GregorianCalendar dateFrom, GregorianCalendar dateTo, Patient patient)
 			throws OHServiceException {
 		ArrayList<BillPayments> payments =  billPaymentRepository.findByDateAndPatient(dateFrom, dateTo, patient.getCode());
 		return payments;
@@ -371,11 +371,11 @@ public class AccountingIoOperations {
 	 * @param patient
 	 * @return the bill list
 	 * @throws OHServiceException
-	 * @deprecated use {@link #getBillsForPatient(GregorianCalendar, GregorianCalendar, Patient)}
+	 * @deprecated use {@link #getBillsBetweenDatesWherePatient(GregorianCalendar, GregorianCalendar, Patient)}
 	 */
 	@Deprecated
 	public ArrayList<Bill> getBills(GregorianCalendar dateFrom, GregorianCalendar dateTo, Patient patient) throws OHServiceException {
-		return getBillsForPatient(dateFrom, dateTo, patient);
+		return getBillsBetweenDatesWherePatient(dateFrom, dateTo, patient);
 	}
 
 	/**
@@ -386,7 +386,7 @@ public class AccountingIoOperations {
 	 * @return the bill list
 	 * @throws OHServiceException
 	 */
-	public ArrayList<Bill> getBillsForPatient(GregorianCalendar dateFrom, GregorianCalendar dateTo, Patient patient) throws OHServiceException {
+	public ArrayList<Bill> getBillsBetweenDatesWherePatient(GregorianCalendar dateFrom, GregorianCalendar dateTo, Patient patient) throws OHServiceException {
 		ArrayList<Bill> bills = billRepository.findByDateAndPatient(dateFrom, dateTo, patient.getCode());
 		return bills;
 	}
@@ -430,11 +430,11 @@ public class AccountingIoOperations {
 	 * @param billItem
 	 * @return the bill list
 	 * @throws OHServiceException
-	 * @deprecated use {@link #getBillsWithBillItem(GregorianCalendar, GregorianCalendar, BillItems)}
+	 * @deprecated use {@link #getBillsBetweenDatesWhereBillItem(GregorianCalendar, GregorianCalendar, BillItems)}
 	 */
 	@Deprecated
 	public ArrayList<Bill> getBills(GregorianCalendar dateFrom, GregorianCalendar dateTo, BillItems billItem) throws OHServiceException {
-		return getBillsWithBillItem(dateFrom, dateTo, billItem);
+		return getBillsBetweenDatesWhereBillItem(dateFrom, dateTo, billItem);
 	}
 
 	/**
@@ -446,7 +446,7 @@ public class AccountingIoOperations {
 	 * @return the bill list
 	 * @throws OHServiceException
 	 */
-	public ArrayList<Bill> getBillsWithBillItem(GregorianCalendar dateFrom, GregorianCalendar dateTo, BillItems billItem) throws OHServiceException {
+	public ArrayList<Bill> getBillsBetweenDatesWhereBillItem(GregorianCalendar dateFrom, GregorianCalendar dateTo, BillItems billItem) throws OHServiceException {
 		ArrayList<Bill> bills = null;
 		if(billItem == null) {
 			bills = (ArrayList<Bill>) billRepository.findByDateBetween(TimeTools.getBeginningOfDay(dateFrom), TimeTools.getBeginningOfNextDay(dateTo));

--- a/src/test/java/org/isf/accounting/test/Tests.java
+++ b/src/test/java/org/isf/accounting/test/Tests.java
@@ -659,12 +659,6 @@ public class Tests
 			bills = accountingIoOperation.getBills(dateFrom, dateTo, foundBillItem);
 			assertTrue(bills.contains(foundBill));
 
-			bills = accountingIoOperation.getBills(dateFrom, dateTo, (BillItems)null);
-			assertTrue(bills.contains(foundBill));
-
-			bills = accountingIoOperation.getAllBills(dateFrom, dateTo);
-			assertTrue(bills.contains(foundBill));
-
 			id = _setupTestBillItems(true);
 			foundBillItem = (BillItems)jpa.find(BillItems.class, id);
 			

--- a/src/test/java/org/isf/accounting/test/Tests.java
+++ b/src/test/java/org/isf/accounting/test/Tests.java
@@ -658,7 +658,13 @@ public class Tests
 			
 			bills = accountingIoOperation.getBills(dateFrom, dateTo, foundBillItem);
 			assertTrue(bills.contains(foundBill));
-			
+
+			bills = accountingIoOperation.getBills(dateFrom, dateTo, (BillItems)null);
+			assertTrue(bills.contains(foundBill));
+
+			bills = accountingIoOperation.getAllBills(dateFrom, dateTo);
+			assertTrue(bills.contains(foundBill));
+
 			id = _setupTestBillItems(true);
 			foundBillItem = (BillItems)jpa.find(BillItems.class, id);
 			


### PR DESCRIPTION
Per [OP-247](https://openhospital.atlassian.net/jira/software/c/projects/OP/issues/OP-247) add new method that doesn't require the casting of null to `BillItems` to get all items.   The new method is `getAllBills(dateFrom, dateTo)`.   

Also added junit tests for both methods.