### PR TITLE
[OP-282] excluded transient dependency to itext in jesperreports

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -208,6 +208,12 @@
 		    <groupId>net.sf.jasperreports</groupId>
 		    <artifactId>jasperreports</artifactId>
 		    <version>6.14.0</version>
+			<exclusions>
+				<exclusion>
+					<groupId>com.lowagie</groupId>
+					<artifactId>itext</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>com.lowagie</groupId>


### PR DESCRIPTION
I had to exclude transient dep to com.lowagie it was in version which was not found in maven central repo