### PR TITLE
Remove dup dependency for jai_imageio and jai-core

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -231,22 +231,6 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-		    <groupId>com.sun.media</groupId>
-		    <artifactId>jai_imageio</artifactId>
-		    <version>1.1</version>
-		    <exclusions>
-		    	<exclusion>
-		    		<groupId>javax.media</groupId>
-		    		<artifactId>jai_core</artifactId>
-		    	</exclusion>
-		    </exclusions>
-		</dependency>
-		<dependency>
-		    <groupId>javax.media</groupId>
-		    <artifactId>jai-core</artifactId>
-		    <version>1.1.3</version>
-		</dependency>
-		<dependency>
 		    <groupId>com.sun</groupId>
 		    <artifactId>clibwrapper_jiio</artifactId>
 		    <version>1.1</version>

--- a/pom.xml
+++ b/pom.xml
@@ -432,5 +432,13 @@
 				<enabled>false</enabled>
 			</snapshots>
 		</repository>
+		<repository>
+			<id>JFrog</id>
+			<name>Atlassian JFrog></name>
+			<url>https://packages.atlassian.com/maven-3rdparty-legacy-local</url>
+			<snapshots>
+				<enabled>false</enabled>
+			</snapshots>
+		</repository>
 	</repositories>
 </project>


### PR DESCRIPTION
Remove duplicate dependency for `jai_imageio` and `jai-core`.   First definition was at lines 233-248 and the second one was at lines 254-269.

This was the result of a push on March 28, 2020.