### PR TITLE
Chore: Private method cannot be overridden at runtime

### DIFF
--- a/src/main/java/org/isf/medicalstock/manager/MovStockInsertingManager.java
+++ b/src/main/java/org/isf/medicalstock/manager/MovStockInsertingManager.java
@@ -347,7 +347,7 @@ public class MovStockInsertingManager {
 	 * @throws OHServiceException 
 	 */
 	@Transactional(rollbackFor=OHServiceException.class)
-	private boolean prepareChargingMovement(Movement movement, boolean checkReference) throws OHServiceException {
+	protected boolean prepareChargingMovement(Movement movement, boolean checkReference) throws OHServiceException {
 		validateMovement(movement, checkReference);
 		return ioOperations.prepareChargingMovement(movement);
 	}


### PR DESCRIPTION
Fix a case where code prevents a class from being subclassed (because of the `private` modifier) by some frameworks (e.g. Spring and Hibernate) at runtime.