### PR TITLE
Chore Fix comparison of String objects

### DIFF
--- a/src/main/java/org/isf/hospital/model/Hospital.java
+++ b/src/main/java/org/isf/hospital/model/Hospital.java
@@ -219,7 +219,7 @@ public class Hospital extends Auditable<String>
 						&& getAddress().equalsIgnoreCase(((Hospital) anObject).getAddress())
 						&& getCity().equalsIgnoreCase(((Hospital) anObject).getCity())
 						&& getEmail().equalsIgnoreCase(((Hospital) anObject).getEmail()) 
-						&& (getCurrencyCod() == ((Hospital) anObject).getCurrencyCod()));
+						&& getCurrencyCod().equalsIgnoreCase(((Hospital) anObject).getCurrencyCod()));
 	}
 
 	public String toString() {


### PR DESCRIPTION
Found using SpotBugs

The code compares java.lang.String objects for reference equality using the == operator. Unless both strings are either constants in a source file, or have been interned using the String.intern() method, the same string value may be represented by two different String objects and thus fail.  

Replaced with `equalsIgnoreCase()` to match the other tests.