### PR TITLE
Chore No need for null check with instanceof

### DIFF
--- a/src/main/java/org/isf/disease/model/Disease.java
+++ b/src/main/java/org/isf/disease/model/Disease.java
@@ -178,7 +178,7 @@ public class Disease extends Auditable<String>
 
 	@Override
 	public boolean equals(Object anObject) {
-        return (anObject == null) || !(anObject instanceof Disease) ? false
+        return !(anObject instanceof Disease) ? false
                 : (getCode().equals(((Disease) anObject).getCode())
                         && getDescription().equalsIgnoreCase(
                                 ((Disease) anObject).getDescription()) && getType()

--- a/src/main/java/org/isf/dlvrrestype/model/DeliveryResultType.java
+++ b/src/main/java/org/isf/dlvrrestype/model/DeliveryResultType.java
@@ -90,7 +90,7 @@ public class DeliveryResultType
 
 	@Override
     public boolean equals(Object anObject) {
-        return (anObject == null) || !(anObject instanceof DeliveryResultType) ? false
+        return !(anObject instanceof DeliveryResultType) ? false
                 : (getCode().equals(((DeliveryResultType) anObject).getCode())
                         && getDescription().equalsIgnoreCase(
                                 ((DeliveryResultType) anObject).getDescription()));

--- a/src/main/java/org/isf/dlvrtype/model/DeliveryType.java
+++ b/src/main/java/org/isf/dlvrtype/model/DeliveryType.java
@@ -103,7 +103,7 @@ public class DeliveryType  extends Auditable<String>
 
 	@Override
     public boolean equals(Object anObject) {
-        return (anObject == null) || !(anObject instanceof DeliveryType) ? false
+        return !(anObject instanceof DeliveryType) ? false
                 : (getCode().equals(((DeliveryType) anObject).getCode())
                         && getDescription().equalsIgnoreCase(
                                 ((DeliveryType) anObject).getDescription()));

--- a/src/main/java/org/isf/exa/model/Exam.java
+++ b/src/main/java/org/isf/exa/model/Exam.java
@@ -160,7 +160,7 @@ public class Exam extends Auditable<String>
 
 	@Override
 	public boolean equals(Object anObject) {
-		return (anObject == null) || !(anObject instanceof Exam) ? false
+		return !(anObject instanceof Exam) ? false
 				: (getCode().equals(((Exam) anObject).getCode())
 						&& getDescription().equalsIgnoreCase(
 								((Exam) anObject).getDescription())

--- a/src/main/java/org/isf/exa/model/ExamRow.java
+++ b/src/main/java/org/isf/exa/model/ExamRow.java
@@ -110,7 +110,7 @@ public class ExamRow extends Auditable<String>
 	
 	@Override
 	public boolean equals(Object anObject) {
-		return (anObject == null) || !(anObject instanceof ExamRow) ? false
+		return !(anObject instanceof ExamRow) ? false
 				: (getCode() == ((ExamRow) anObject).getCode()
 						&& getDescription().equalsIgnoreCase(
 								((ExamRow) anObject).getDescription())

--- a/src/main/java/org/isf/exatype/model/ExamType.java
+++ b/src/main/java/org/isf/exatype/model/ExamType.java
@@ -104,7 +104,7 @@ public class ExamType extends Auditable<String>
 
 	@Override
 	public boolean equals(Object anObject) {
-		return (anObject == null) || !(anObject instanceof ExamType) ? false
+		return !(anObject instanceof ExamType) ? false
 				: (getCode().equals(((ExamType) anObject).getCode())
 						&& getDescription().equalsIgnoreCase(
 								((ExamType) anObject).getDescription()));

--- a/src/main/java/org/isf/hospital/model/Hospital.java
+++ b/src/main/java/org/isf/hospital/model/Hospital.java
@@ -211,7 +211,7 @@ public class Hospital extends Auditable<String>
 
 	@Override
 	public boolean equals(Object anObject) {
-		return (anObject == null) || !(anObject instanceof Hospital) ? false
+		return !(anObject instanceof Hospital) ? false
 				: (getCode().equals(((Hospital) anObject).getCode())
 						&& getDescription().equalsIgnoreCase(((Hospital) anObject).getDescription())
 						&& getTelephone().equalsIgnoreCase(((Hospital) anObject).getTelephone())

--- a/src/main/java/org/isf/medtype/model/MedicalType.java
+++ b/src/main/java/org/isf/medtype/model/MedicalType.java
@@ -102,7 +102,7 @@ public class MedicalType extends Auditable<String>
 
 	@Override
 	public boolean equals(Object anObject) {
-		return (anObject == null) || !(anObject instanceof MedicalType) ? false
+		return !(anObject instanceof MedicalType) ? false
 				: (getCode().equalsIgnoreCase(
 						((MedicalType) anObject).getCode()) && getDescription()
 						.equalsIgnoreCase(

--- a/src/main/java/org/isf/menu/model/GroupMenu.java
+++ b/src/main/java/org/isf/menu/model/GroupMenu.java
@@ -105,7 +105,7 @@ public class GroupMenu extends Auditable<String>
 	
 	@Override
 	public boolean equals(Object anObject) {
-        return (anObject == null) || !(anObject instanceof GroupMenu) ? false
+        return !(anObject instanceof GroupMenu) ? false
                 : (getCode().equals(((GroupMenu) anObject).getCode())
                   && getUserGroup().equalsIgnoreCase(((GroupMenu) anObject).getUserGroup()) 
                   && getMenuItem().equals(((GroupMenu) anObject).getMenuItem())

--- a/src/main/java/org/isf/menu/model/User.java
+++ b/src/main/java/org/isf/menu/model/User.java
@@ -114,7 +114,7 @@ public class User extends Auditable<String>
 	
 	@Override
 	public boolean equals(Object anObject) {
-		return (anObject == null) || !(anObject instanceof User) ? false
+		return !(anObject instanceof User) ? false
 				: (getUserName().equalsIgnoreCase(
 						((User) anObject).getUserName()) && getDesc()
 						.equalsIgnoreCase(

--- a/src/main/java/org/isf/menu/model/UserGroup.java
+++ b/src/main/java/org/isf/menu/model/UserGroup.java
@@ -87,7 +87,7 @@ public class UserGroup extends Auditable<String>
 	
 	@Override
 	public boolean equals(Object anObject) {
-		return (anObject == null) || !(anObject instanceof UserGroup) ? false
+		return !(anObject instanceof UserGroup) ? false
 				: (getCode().equalsIgnoreCase(
 						((UserGroup) anObject).getCode()) && getDesc()
 						.equalsIgnoreCase(

--- a/src/main/java/org/isf/menu/model/UserMenuItem.java
+++ b/src/main/java/org/isf/menu/model/UserMenuItem.java
@@ -188,7 +188,7 @@ public class UserMenuItem
 		
 	@Override
 	public boolean equals(Object anObject) {
-        return (anObject == null) || !(anObject instanceof UserMenuItem) ? false
+        return !(anObject instanceof UserMenuItem) ? false
                 : (getCode().equals(((UserMenuItem) anObject).getCode())
                   && getButtonLabel().equalsIgnoreCase(((UserMenuItem) anObject).getButtonLabel()) 
                   && getAltLabel().equals(((UserMenuItem) anObject).getAltLabel())

--- a/src/main/java/org/isf/pregtreattype/model/PregnantTreatmentType.java
+++ b/src/main/java/org/isf/pregtreattype/model/PregnantTreatmentType.java
@@ -103,7 +103,7 @@ public class PregnantTreatmentType extends Auditable<String>
 
 	@Override
     public boolean equals(Object anObject) {
-        return (anObject == null) || !(anObject instanceof PregnantTreatmentType) ? false
+        return !(anObject instanceof PregnantTreatmentType) ? false
                 : (getCode().equals(((PregnantTreatmentType) anObject).getCode())
                         && getDescription().equalsIgnoreCase(
                                 ((PregnantTreatmentType) anObject).getDescription()));

--- a/src/main/java/org/isf/vaccine/model/Vaccine.java
+++ b/src/main/java/org/isf/vaccine/model/Vaccine.java
@@ -129,7 +129,7 @@ public class Vaccine extends Auditable<String>
     }
 
     public boolean equals(Object anObject) {
-        return (anObject == null) || !(anObject instanceof Vaccine) ? false
+        return !(anObject instanceof Vaccine) ? false
                 : (getCode().equals(((Vaccine) anObject).getCode())
                         && getDescription().equalsIgnoreCase(
                                 ((Vaccine) anObject).getDescription())

--- a/src/main/java/org/isf/vactype/model/VaccineType.java
+++ b/src/main/java/org/isf/vactype/model/VaccineType.java
@@ -107,7 +107,7 @@ public class VaccineType extends Auditable<String>
 
 	@Override
 	public boolean equals(Object anObject) {
-		return (anObject == null) || !(anObject instanceof VaccineType) ? false
+		return !(anObject instanceof VaccineType) ? false
 				: (getCode().equals(((VaccineType) anObject).getCode())
 						&& getDescription().equalsIgnoreCase(
 								((VaccineType) anObject).getDescription()));

--- a/src/main/java/org/isf/ward/model/Ward.java
+++ b/src/main/java/org/isf/ward/model/Ward.java
@@ -263,7 +263,7 @@ public class Ward extends Auditable<String>
 
 	@Override
 	public boolean equals(Object anObject) {
-        return (anObject == null) || !(anObject instanceof Ward) ? false
+        return !(anObject instanceof Ward) ? false
                 : (getCode().equals(((Ward) anObject).getCode())
                         && getDescription().equalsIgnoreCase(
                                 ((Ward) anObject).getDescription())


### PR DESCRIPTION
Found with SonarLint

TItle: Null checks should not be used with "instanceof"
 
Description: There's no need to null test in conjunction with an `instanceof` test. null is not an `instanceof` anything, so a null check is redundant.

So I removed the `null` checks.

