### PR TITLE
OP-374 increase coverage for admtype and agetype packages

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -403,12 +403,24 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<version>1.5.22.RELEASE</version>
 			<scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.assertj</groupId>
+                    <artifactId>assertj-core</artifactId>
+                </exclusion>
+            </exclusions>
 		</dependency>
 		<dependency>
              <groupId>org.springframework</groupId>
              <artifactId>spring-aspects</artifactId>
              <version>${spring.framework.version}</version>
          </dependency>
+	 	 <dependency>
+			<groupId>org.assertj</groupId>
+			<artifactId>assertj-core</artifactId>
+			<version>3.18.1</version>
+			<scope>test</scope>
+		 </dependency>
 	</dependencies>
 	<repositories>
 		<repository>

--- a/src/main/java/org/isf/admtype/manager/AdmissionTypeBrowserManager.java
+++ b/src/main/java/org/isf/admtype/manager/AdmissionTypeBrowserManager.java
@@ -27,8 +27,8 @@ import java.util.List;
 import org.isf.admtype.model.AdmissionType;
 import org.isf.admtype.service.AdmissionTypeIoOperation;
 import org.isf.generaldata.MessageBundle;
-import org.isf.utils.exception.OHServiceException;
 import org.isf.utils.exception.OHDataValidationException;
+import org.isf.utils.exception.OHServiceException;
 import org.isf.utils.exception.model.OHExceptionMessage;
 import org.isf.utils.exception.model.OHSeverityLevel;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -40,18 +40,10 @@ public class AdmissionTypeBrowserManager {
 	@Autowired
 	private AdmissionTypeIoOperation ioOperations;
 
-	public AdmissionTypeIoOperation getIoOperations() {
-		return ioOperations;
-	}
-
-	public void setIoOperations(AdmissionTypeIoOperation ioOperations) {
-		this.ioOperations = ioOperations;
-	}
-
 	/**
 	 * Returns all the available {@link AdmissionType}s.
 	 * @return a list of admission types or <code>null</code> if the operation fails.
-	 * @throws OHServiceException 
+	 * @throws OHServiceException
 	 */
 	public ArrayList<AdmissionType> getAdmissionType() throws OHServiceException {
         return ioOperations.getAdmissionType();
@@ -61,7 +53,7 @@ public class AdmissionTypeBrowserManager {
 	 * Stores a new {@link AdmissionType}.
 	 * @param admissionType the admission type to store.
 	 * @return <code>true</code> if the admission type has been stored, <code>false</code> otherwise.
-	 * @throws OHServiceException 
+	 * @throws OHServiceException
 	 */
 	public boolean newAdmissionType(AdmissionType admissionType) throws OHServiceException {
         validateAdmissionType(admissionType, true);
@@ -72,7 +64,7 @@ public class AdmissionTypeBrowserManager {
 	 * Updates the specified {@link AdmissionType}.
 	 * @param admissionType the admission type to update.
 	 * @return <code>true</code> if the admission type has been updated, <code>false</code> otherwise.
-	 * @throws OHServiceException 
+	 * @throws OHServiceException
 	 */
 	public boolean updateAdmissionType(AdmissionType admissionType) throws OHServiceException {
         validateAdmissionType(admissionType, false);
@@ -83,7 +75,7 @@ public class AdmissionTypeBrowserManager {
 	 * Checks if the specified Code is already used by others {@link AdmissionType}s.
 	 * @param code the admission type code to check.
 	 * @return <code>true</code> if the code is already used, <code>false</code> otherwise.
-	 * @throws OHServiceException 
+	 * @throws OHServiceException
 	 */
 	public boolean codeControl(String code) throws OHServiceException {
         return ioOperations.isCodePresent(code);
@@ -93,7 +85,7 @@ public class AdmissionTypeBrowserManager {
 	 * Deletes the specified {@link AdmissionType}.
 	 * @param admissionType the admission type to delete.
 	 * @return <code>true</code> if the admission type has been deleted, <code>false</code> otherwise.
-	 * @throws OHServiceException 
+	 * @throws OHServiceException
 	 */
 	public boolean deleteAdmissionType(AdmissionType admissionType) throws OHServiceException {
         return ioOperations.deleteAdmissionType(admissionType);


### PR DESCRIPTION
Coverage before:
![image](https://user-images.githubusercontent.com/1105445/100474831-93ae0f00-30af-11eb-86e1-436e7a67281b.png)

Coverage after:
![image](https://user-images.githubusercontent.com/1105445/100474844-9f99d100-30af-11eb-8be2-13c518545cc5.png)

Updated `assertj` to something newer to use newer features

Also removed from `AgeTypeBrowserManager` two methods that are not needed given autowiring.  I also grepped across all the repos and found no uses:
`````
	public AdmissionTypeIoOperation getIoOperations() {
		return ioOperations;
	}

	public void setIoOperations(AdmissionTypeIoOperation ioOperations) {
		this.ioOperations = ioOperations;
	}

