### PR TITLE
OP-374 Add test prefix; format Manager class

### DIFF
--- a/src/main/java/org/isf/admtype/manager/AdmissionTypeBrowserManager.java
+++ b/src/main/java/org/isf/admtype/manager/AdmissionTypeBrowserManager.java
@@ -42,86 +42,93 @@ public class AdmissionTypeBrowserManager {
 
 	/**
 	 * Returns all the available {@link AdmissionType}s.
+	 *
 	 * @return a list of admission types or <code>null</code> if the operation fails.
 	 * @throws OHServiceException
 	 */
 	public ArrayList<AdmissionType> getAdmissionType() throws OHServiceException {
-        return ioOperations.getAdmissionType();
+		return ioOperations.getAdmissionType();
 	}
 
 	/**
 	 * Stores a new {@link AdmissionType}.
+	 *
 	 * @param admissionType the admission type to store.
 	 * @return <code>true</code> if the admission type has been stored, <code>false</code> otherwise.
 	 * @throws OHServiceException
 	 */
 	public boolean newAdmissionType(AdmissionType admissionType) throws OHServiceException {
-        validateAdmissionType(admissionType, true);
-        return ioOperations.newAdmissionType(admissionType);
+		validateAdmissionType(admissionType, true);
+		return ioOperations.newAdmissionType(admissionType);
 	}
 
 	/**
 	 * Updates the specified {@link AdmissionType}.
+	 *
 	 * @param admissionType the admission type to update.
 	 * @return <code>true</code> if the admission type has been updated, <code>false</code> otherwise.
 	 * @throws OHServiceException
 	 */
 	public boolean updateAdmissionType(AdmissionType admissionType) throws OHServiceException {
-        validateAdmissionType(admissionType, false);
-        return ioOperations.updateAdmissionType(admissionType);
+		validateAdmissionType(admissionType, false);
+		return ioOperations.updateAdmissionType(admissionType);
 	}
 
 	/**
 	 * Checks if the specified Code is already used by others {@link AdmissionType}s.
+	 *
 	 * @param code the admission type code to check.
 	 * @return <code>true</code> if the code is already used, <code>false</code> otherwise.
 	 * @throws OHServiceException
 	 */
 	public boolean codeControl(String code) throws OHServiceException {
-        return ioOperations.isCodePresent(code);
+		return ioOperations.isCodePresent(code);
 	}
 
 	/**
 	 * Deletes the specified {@link AdmissionType}.
+	 *
 	 * @param admissionType the admission type to delete.
 	 * @return <code>true</code> if the admission type has been deleted, <code>false</code> otherwise.
 	 * @throws OHServiceException
 	 */
 	public boolean deleteAdmissionType(AdmissionType admissionType) throws OHServiceException {
-        return ioOperations.deleteAdmissionType(admissionType);
+		return ioOperations.deleteAdmissionType(admissionType);
 	}
 
 	/**
 	 * Verify if the object is valid for CRUD and return a list of errors, if any
+	 *
 	 * @param admissionType
 	 * @param insert <code>true</code> or updated <code>false</code>
 	 * @throws OHDataValidationException
 	 */
-    protected void validateAdmissionType(AdmissionType admissionType, boolean insert) throws OHServiceException {
-        List<OHExceptionMessage> errors = new ArrayList<OHExceptionMessage>();
-        String key = admissionType.getCode();
-        if (key.equals("")){
-            errors.add(new OHExceptionMessage(MessageBundle.getMessage("angal.hospital"),MessageBundle.getMessage("angal.admtype.pleaseinsertacode"),
-                    OHSeverityLevel.ERROR));
-        }
-        if (key.length()>10){
-            errors.add(new OHExceptionMessage(MessageBundle.getMessage("angal.hospital"),MessageBundle.getMessage("angal.admtype.codetoolongmaxchars"),
-                    OHSeverityLevel.ERROR));
-        }
+	protected void validateAdmissionType(AdmissionType admissionType, boolean insert) throws OHServiceException {
+		List<OHExceptionMessage> errors = new ArrayList<>();
+		String key = admissionType.getCode();
+		if (key.equals("")) {
+			errors.add(new OHExceptionMessage(MessageBundle.getMessage("angal.hospital"), MessageBundle.getMessage("angal.admtype.pleaseinsertacode"),
+					OHSeverityLevel.ERROR));
+		}
+		if (key.length() > 10) {
+			errors.add(new OHExceptionMessage(MessageBundle.getMessage("angal.hospital"), MessageBundle.getMessage("angal.admtype.codetoolongmaxchars"),
+					OHSeverityLevel.ERROR));
+		}
 
-            if(insert){
-                if (codeControl(key)){
-                    errors.add(new OHExceptionMessage(MessageBundle.getMessage("angal.hospital"),MessageBundle.getMessage("angal.common.codealreadyinuse"),
-                            OHSeverityLevel.ERROR));
-                }
-            }
-        if (admissionType.getDescription().equals("")){
-            errors.add(new OHExceptionMessage(MessageBundle.getMessage("angal.hospital"),MessageBundle.getMessage("angal.admtype.pleaseinsertavaliddescription"),
-                    OHSeverityLevel.ERROR));
-        }
-        if(!errors.isEmpty()){
-            throw new OHDataValidationException(errors);
-        }
-    }
+		if (insert) {
+			if (codeControl(key)) {
+				errors.add(new OHExceptionMessage(MessageBundle.getMessage("angal.hospital"), MessageBundle.getMessage("angal.common.codealreadyinuse"),
+						OHSeverityLevel.ERROR));
+			}
+		}
+		if (admissionType.getDescription().equals("")) {
+			errors.add(
+					new OHExceptionMessage(MessageBundle.getMessage("angal.hospital"), MessageBundle.getMessage("angal.admtype.pleaseinsertavaliddescription"),
+							OHSeverityLevel.ERROR));
+		}
+		if (!errors.isEmpty()) {
+			throw new OHDataValidationException(errors);
+		}
+	}
 
 }

--- a/src/main/java/org/isf/agetype/manager/AgeTypeBrowserManager.java
+++ b/src/main/java/org/isf/agetype/manager/AgeTypeBrowserManager.java
@@ -27,8 +27,8 @@ import java.util.List;
 import org.isf.agetype.model.AgeType;
 import org.isf.agetype.service.AgeTypeIoOperations;
 import org.isf.generaldata.MessageBundle;
-import org.isf.utils.exception.OHServiceException;
 import org.isf.utils.exception.OHDataValidationException;
+import org.isf.utils.exception.OHServiceException;
 import org.isf.utils.exception.model.OHExceptionMessage;
 import org.isf.utils.exception.model.OHSeverityLevel;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -42,72 +42,78 @@ public class AgeTypeBrowserManager {
 
 	/**
 	 * Returns all available age types.
+	 *
 	 * @return a list of {@link AgeType} or <code>null</code> if the operation fails.
-	 * @throws OHServiceException 
+	 * @throws OHServiceException
 	 */
 	public ArrayList<AgeType> getAgeType() throws OHServiceException {
-        return ioOperations.getAgeType();
+		return ioOperations.getAgeType();
 	}
 
 	/**
 	 * Updates the list of {@link AgeType}s.
+	 *
 	 * @param ageTypes the {@link AgeType}s to update.
 	 * @return <code>true</code> if the list has been updated, <code>false</code> otherwise.
-	 * @throws OHServiceException 
+	 * @throws OHServiceException
 	 */
 	public boolean updateAgeType(ArrayList<AgeType> ageTypes) throws OHServiceException {
-        validateAgeTypes(ageTypes);
-        return ioOperations.updateAgeType(ageTypes);
+		validateAgeTypes(ageTypes);
+		return ioOperations.updateAgeType(ageTypes);
 	}
 
-
-    /**
+	/**
 	 * Retrieves the {@link AgeType} code using the age value.
+	 *
 	 * @param age the age value.
 	 * @return the retrieved code, <code>null</code> if age value is out of any range.
-	 * @throws OHServiceException 
+	 * @throws OHServiceException
 	 */
 	public String getTypeByAge(int age) throws OHServiceException {
-        ArrayList<AgeType> ageTable = ioOperations.getAgeType();
+		ArrayList<AgeType> ageTable = ioOperations.getAgeType();
 
-        for (AgeType ageType : ageTable) {
+		for (AgeType ageType : ageTable) {
 
-            if (age >= ageType.getFrom() && age <= ageType.getTo()) {
-                return ageType.getCode();
-            }
-        }
-        return null;
+			if (age >= ageType.getFrom() && age <= ageType.getTo()) {
+				return ageType.getCode();
+			}
+		}
+		return null;
 	}
 
 	/**
 	 * Gets the {@link AgeType} from the code index.
+	 *
 	 * @param index the code index.
 	 * @return the retrieved element, <code>null</code> otherwise.
-	 * @throws OHServiceException 
+	 * @throws OHServiceException
 	 */
 	public AgeType getTypeByCode(int index) throws OHServiceException {
-        return ioOperations.getAgeTypeByCode(index);
+		return ioOperations.getAgeTypeByCode(index);
 	}
 
 	/**
 	 * Verify if the object is valid for CRUD and return a list of errors, if any
+	 *
 	 * @param ageTypes
 	 * @throws OHDataValidationException
 	 */
-    protected void validateAgeTypes(ArrayList<AgeType> ageTypes) throws OHDataValidationException {
-        List<OHExceptionMessage> errors = new ArrayList<OHExceptionMessage>();
-        for (int i = 1; i < ageTypes.size(); i++) {
-            if (ageTypes.get(i).getFrom() <= ageTypes.get(i-1).getTo()) {
-                errors.add(new OHExceptionMessage(MessageBundle.getMessage("angal.hospital"),MessageBundle.getMessage("angal.agetype.rangesoverlappleasecheck"),
-                        OHSeverityLevel.ERROR));
-            }
-            if (ageTypes.get(i).getFrom() - ageTypes.get(i-1).getTo() > 1) {
-                errors.add(new OHExceptionMessage(MessageBundle.getMessage("angal.hospital"),MessageBundle.getMessage("angal.agetype.rangesnotdefinedpleasecheck"),
-                        OHSeverityLevel.ERROR));
-            }
-        }
-        if (!errors.isEmpty()){
-	        throw new OHDataValidationException(errors);
-	    }
-    }
+	protected void validateAgeTypes(ArrayList<AgeType> ageTypes) throws OHDataValidationException {
+		List<OHExceptionMessage> errors = new ArrayList<>();
+		for (int i = 1; i < ageTypes.size(); i++) {
+			if (ageTypes.get(i).getFrom() <= ageTypes.get(i - 1).getTo()) {
+				errors.add(
+						new OHExceptionMessage(MessageBundle.getMessage("angal.hospital"), MessageBundle.getMessage("angal.agetype.rangesoverlappleasecheck"),
+								OHSeverityLevel.ERROR));
+			}
+			if (ageTypes.get(i).getFrom() - ageTypes.get(i - 1).getTo() > 1) {
+				errors.add(new OHExceptionMessage(MessageBundle.getMessage("angal.hospital"),
+						MessageBundle.getMessage("angal.agetype.rangesnotdefinedpleasecheck"),
+						OHSeverityLevel.ERROR));
+			}
+		}
+		if (!errors.isEmpty()) {
+			throw new OHDataValidationException(errors);
+		}
+	}
 }

--- a/src/test/java/org/isf/admtype/test/Tests.java
+++ b/src/test/java/org/isf/admtype/test/Tests.java
@@ -117,7 +117,7 @@ public class Tests extends OHCoreTestCase {
 	}
 
 	@Test
-	public void mgrGetAdmissionType() throws Exception {
+	public void testMgrGetAdmissionType() throws Exception {
 		String code = _setupTestAdmissionType(false);
 		ArrayList<AdmissionType> admissionTypes = admissionTypeBrowserManager.getAdmissionType();
 		assertThat(admissionTypes).hasSize(1);
@@ -125,7 +125,7 @@ public class Tests extends OHCoreTestCase {
 	}
 
 	@Test
-	public void mgrUpdateAdmissionType() throws Exception {
+	public void testMgrUpdateAdmissionType() throws Exception {
 		String code = _setupTestAdmissionType(false);
 		AdmissionType foundAdmissionType = admissionTypeIoOperationRepository.findOne(code);
 		foundAdmissionType.setDescription("Update");
@@ -136,7 +136,7 @@ public class Tests extends OHCoreTestCase {
 	}
 
 	@Test
-	public void admissionTypeEqualHashToString() throws Exception {
+	public void testAdmissionTypeEqualHashToString() throws Exception {
 		String code = _setupTestAdmissionType(false);
 		AdmissionType admissionType = admissionTypeIoOperationRepository.findOne(code);
 		AdmissionType admissionType2 = new AdmissionType("someCode", "someDescription");
@@ -152,7 +152,7 @@ public class Tests extends OHCoreTestCase {
 	}
 
 	@Test
-	public void mgrValidation() throws Exception {
+	public void testMgrAdmissionValidation() throws Exception {
 		String code = _setupTestAdmissionType(false);
 		AdmissionType admissionType = admissionTypeIoOperationRepository.findOne(code);
 
@@ -194,7 +194,7 @@ public class Tests extends OHCoreTestCase {
 	}
 
 	@Test
-	public void mgrNewAdmissionType() throws Exception {
+	public void testMgrNewAdmissionType() throws Exception {
 		AdmissionType admissionType = testAdmissionType.setup(true);
 		boolean result = admissionTypeBrowserManager.newAdmissionType(admissionType);
 		assertThat(result).isTrue();
@@ -202,14 +202,14 @@ public class Tests extends OHCoreTestCase {
 	}
 
 	@Test
-	public void mgrIsCodePresent() throws Exception {
+	public void testMgrIsCodePresent() throws Exception {
 		String code = _setupTestAdmissionType(false);
 		boolean result = admissionTypeBrowserManager.codeControl(code);
 		assertThat(result).isTrue();
 	}
 
 	@Test
-	public void mgrDeleteAdmissionType() throws Exception {
+	public void testMgrDeleteAdmissionType() throws Exception {
 		String code = _setupTestAdmissionType(false);
 		AdmissionType foundAdmissionType = admissionTypeIoOperationRepository.findOne(code);
 		boolean result = admissionTypeBrowserManager.deleteAdmissionType(foundAdmissionType);

--- a/src/test/java/org/isf/agetype/test/Tests.java
+++ b/src/test/java/org/isf/agetype/test/Tests.java
@@ -107,7 +107,7 @@ public class Tests extends OHCoreTestCase {
 	}
 
 	@Test
-	public void mgrGetAgeType() throws Exception {
+	public void testMgrGetAgeType() throws Exception {
 		String code = _setupTestAgeType(false);
 		AgeType foundAgeType = ageTypeIoOperationRepository.findOneByCode(code);
 		ArrayList<AgeType> ageTypes = ageTypeBrowserManager.getAgeType();
@@ -116,7 +116,7 @@ public class Tests extends OHCoreTestCase {
 	}
 
 	@Test
-	public void mgrUpdateAgeType() throws Exception {
+	public void testMgrUpdateAgeType() throws Exception {
 		String code = _setupTestAgeType(false);
 		AgeType foundAgeType = ageTypeIoOperationRepository.findOneByCode(code);
 		foundAgeType.setFrom(4);
@@ -131,7 +131,7 @@ public class Tests extends OHCoreTestCase {
 	}
 
 	@Test
-	public void mgrGetTypeByAge() throws Exception {
+	public void testMgrGetTypeByAge() throws Exception {
 		String code = _setupTestAgeType(false);
 		AgeType ageType = ageTypeIoOperationRepository.findOneByCode(code);
 		String foundCode = ageTypeBrowserManager.getTypeByAge(9);
@@ -141,7 +141,7 @@ public class Tests extends OHCoreTestCase {
 	}
 
 	@Test
-	public void mgrGetAgeTypeByCode() throws Exception {
+	public void testMgrGetAgeTypeByCode() throws Exception {
 		String code = _setupTestAgeType(false);
 		AgeType ageType = ageTypeIoOperationRepository.findOneByCode(code);
 		AgeType foundAgeType = ageTypeBrowserManager.getTypeByCode(9);
@@ -152,7 +152,7 @@ public class Tests extends OHCoreTestCase {
 	}
 
 	@Test
-	public void ageTypeEqualHashToString() throws Exception {
+	public void testAgeTypeEqualHashToString() throws Exception {
 		String code = _setupTestAgeType(false);
 		AgeType ageType = ageTypeIoOperationRepository.findOneByCode(code);
 		AgeType ageType2 = new AgeType(ageType.getCode(), ageType.getDescription());
@@ -170,7 +170,7 @@ public class Tests extends OHCoreTestCase {
 	}
 
 	@Test
-	public void mgrValidation() throws Exception {
+	public void testMgrAgeTypeValidation() throws Exception {
 		String code = _setupTestAgeType(false);
 		AgeType foundAgeType = ageTypeIoOperationRepository.findOneByCode(code);
 		foundAgeType.setFrom(0);


### PR DESCRIPTION
Given the decision to keep the "test" prefix on test methods for the time being; added them and did simple reformatting of the `Manager` classes.

This is for the admtype and agetype packages.