### PR TITLE
OP-381 increase coverage for dlvrestype and dlvrtype packages

### DIFF
--- a/src/main/java/org/isf/dlvrrestype/manager/DeliveryResultTypeBrowserManager.java
+++ b/src/main/java/org/isf/dlvrrestype/manager/DeliveryResultTypeBrowserManager.java
@@ -32,8 +32,6 @@ import org.isf.utils.exception.OHDataValidationException;
 import org.isf.utils.exception.OHServiceException;
 import org.isf.utils.exception.model.OHExceptionMessage;
 import org.isf.utils.exception.model.OHSeverityLevel;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -43,53 +41,53 @@ import org.springframework.stereotype.Component;
 @Component
 public class DeliveryResultTypeBrowserManager {
 
-	private final Logger logger = LoggerFactory.getLogger(DeliveryResultTypeBrowserManager.class);
-	
 	@Autowired
 	private DeliveryResultTypeIoOperation ioOperations;
-	
+
 	/**
 	 * Verify if the object is valid for CRUD and return a list of errors, if any
+	 *
 	 * @param deliveryResultType
 	 * @param insert <code>true</code> or updated <code>false</code>
-	 * @throws OHServiceException 
+	 * @throws OHServiceException
 	 */
 	protected void validateDeliveryResultType(DeliveryResultType deliveryResultType, boolean insert) throws OHServiceException {
 		String key = deliveryResultType.getCode();
 		String description = deliveryResultType.getDescription();
-        List<OHExceptionMessage> errors = new ArrayList<OHExceptionMessage>();
-        if(key.isEmpty() ){
-	        errors.add(new OHExceptionMessage("codeEmptyError", 
-	        		MessageBundle.getMessage("angal.dlvrrestype.pleaseinsertacode"), 
-	        		OHSeverityLevel.ERROR));
-        }
-        if(key.length()>1){
-	        errors.add(new OHExceptionMessage("codeTooLongError", 
-	        		MessageBundle.getMessage("angal.dlvrrestype.codetoolongmaxchar"), 
-	        		OHSeverityLevel.ERROR));
-        }
-        if(description.isEmpty() ){
-            errors.add(new OHExceptionMessage("descriptionEmptyError", 
-            		MessageBundle.getMessage("angal.dlvrrestype.pleaseinsertavaliddescription"), 
-            		OHSeverityLevel.ERROR));
-        }
-        if (insert) {
-        	if (codeControl(key)){
-				throw new OHDataIntegrityViolationException(new OHExceptionMessage(null, 
-						MessageBundle.getMessage("angal.common.codealreadyinuse"), 
+		List<OHExceptionMessage> errors = new ArrayList<>();
+		if (key.isEmpty()) {
+			errors.add(new OHExceptionMessage("codeEmptyError",
+					MessageBundle.getMessage("angal.dlvrrestype.pleaseinsertacode"),
+					OHSeverityLevel.ERROR));
+		}
+		if (key.length() > 1) {
+			errors.add(new OHExceptionMessage("codeTooLongError",
+					MessageBundle.getMessage("angal.dlvrrestype.codetoolongmaxchar"),
+					OHSeverityLevel.ERROR));
+		}
+		if (description.isEmpty()) {
+			errors.add(new OHExceptionMessage("descriptionEmptyError",
+					MessageBundle.getMessage("angal.dlvrrestype.pleaseinsertavaliddescription"),
+					OHSeverityLevel.ERROR));
+		}
+		if (insert) {
+			if (codeControl(key)) {
+				throw new OHDataIntegrityViolationException(new OHExceptionMessage(null,
+						MessageBundle.getMessage("angal.common.codealreadyinuse"),
 						OHSeverityLevel.ERROR));
 			}
-        }
-        if (!errors.isEmpty()){
-	        throw new OHDataValidationException(errors);
-	    }
-    }
-	
+		}
+		if (!errors.isEmpty()) {
+			throw new OHDataValidationException(errors);
+		}
+	}
+
 	/**
 	 * Returns all stored {@link DeliveryResultType}s.
 	 * In case of error a message error is shown and a <code>null</code> value is returned.
+	 *
 	 * @return the stored {@link DeliveryResultType}s, <code>null</code> if an error occurred.
-	 * @throws OHServiceException 
+	 * @throws OHServiceException
 	 */
 	public ArrayList<DeliveryResultType> getDeliveryResultType() throws OHServiceException {
 		return ioOperations.getDeliveryResultType();
@@ -98,21 +96,23 @@ public class DeliveryResultTypeBrowserManager {
 	/**
 	 * Stores the specified {@link DeliveryResultType}.
 	 * In case of error a message error is shown and a <code>false</code> value is returned.
+	 *
 	 * @param deliveryresultType the delivery result type to store.
 	 * @return <code>true</code> if the delivery result type has been stored.
-	 * @throws OHServiceException 
+	 * @throws OHServiceException
 	 */
 	public boolean newDeliveryResultType(DeliveryResultType deliveryresultType) throws OHServiceException {
 		validateDeliveryResultType(deliveryresultType, true);
-        return ioOperations.newDeliveryResultType(deliveryresultType);
+		return ioOperations.newDeliveryResultType(deliveryresultType);
 	}
 
 	/**
 	 * Updates the specified {@link DeliveryResultType}.
 	 * In case of error a message error is shown and a <code>false</code> value is returned.
+	 *
 	 * @param deliveryresultType the delivery result type to update.
 	 * @return <code>true</code> if the delivery result type has been updated, <code>false</code> otherwise.
-	 * @throws OHServiceException 
+	 * @throws OHServiceException
 	 */
 	public boolean updateDeliveryResultType(DeliveryResultType deliveryresultType) throws OHServiceException {
 		validateDeliveryResultType(deliveryresultType, false);
@@ -122,9 +122,10 @@ public class DeliveryResultTypeBrowserManager {
 	/**
 	 * Checks if the specified code is already used by others {@link DeliveryResultType}s.
 	 * In case of error a message error is shown and a <code>false</code> value is returned.
+	 *
 	 * @param code the code to check.
 	 * @return <code>true</code> if the code is used, <code>false</code> otherwise.
-	 * @throws OHServiceException 
+	 * @throws OHServiceException
 	 */
 	public boolean codeControl(String code) throws OHServiceException {
 		return ioOperations.isCodePresent(code);
@@ -133,9 +134,10 @@ public class DeliveryResultTypeBrowserManager {
 	/**
 	 * Deletes the specified {@link DeliveryResultType}.
 	 * In case of error a message error is shown and a <code>false</code> value is returned.
+	 *
 	 * @param deliveryresultType the delivery result type to delete.
 	 * @return <code>true</code> if the delivery result type has been deleted, <code>false</code> otherwise.
-	 * @throws OHServiceException 
+	 * @throws OHServiceException
 	 */
 	public boolean deleteDeliveryResultType(DeliveryResultType deliveryresultType) throws OHServiceException {
 		return ioOperations.deleteDeliveryResultType(deliveryresultType);

--- a/src/main/java/org/isf/dlvrtype/manager/DeliveryTypeBrowserManager.java
+++ b/src/main/java/org/isf/dlvrtype/manager/DeliveryTypeBrowserManager.java
@@ -27,8 +27,8 @@ import java.util.List;
 import org.isf.dlvrtype.model.DeliveryType;
 import org.isf.dlvrtype.service.DeliveryTypeIoOperation;
 import org.isf.generaldata.MessageBundle;
-import org.isf.utils.exception.OHServiceException;
 import org.isf.utils.exception.OHDataValidationException;
+import org.isf.utils.exception.OHServiceException;
 import org.isf.utils.exception.model.OHExceptionMessage;
 import org.isf.utils.exception.model.OHSeverityLevel;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -41,93 +41,100 @@ import org.springframework.stereotype.Component;
 public class DeliveryTypeBrowserManager {
 
 	@Autowired
-    private DeliveryTypeIoOperation ioOperations;
+	private DeliveryTypeIoOperation ioOperations;
 
-    /**
-     * Returns all stored {@link DeliveryType}s.
-     * In case of error a message error is shown and a <code>null</code> value is returned.
-     * @return all stored delivery types, <code>null</code> if an error occurred.
-     * @throws OHServiceException
-     */
-    public ArrayList<DeliveryType> getDeliveryType() throws OHServiceException {
-        return ioOperations.getDeliveryType();
-    }
+	/**
+	 * Returns all stored {@link DeliveryType}s.
+	 * In case of error a message error is shown and a <code>null</code> value is returned.
+	 *
+	 * @return all stored delivery types, <code>null</code> if an error occurred.
+	 * @throws OHServiceException
+	 */
+	public ArrayList<DeliveryType> getDeliveryType() throws OHServiceException {
+		return ioOperations.getDeliveryType();
+	}
 
-    /**
-     * Stores the specified {@link DeliveryType}.
-     * In case of error a message error is shown and a <code>false</code> value is returned.
-     * @param deliveryType the delivery type to store.
-     * @return <code>true</code> if the delivery type has been stored, <code>false</code> otherwise.
-     * @throws OHServiceException
-     */
-    public boolean newDeliveryType(DeliveryType deliveryType) throws OHServiceException {
-        validateDeliveryType(deliveryType, true);
-        return ioOperations.newDeliveryType(deliveryType);
-    }
+	/**
+	 * Stores the specified {@link DeliveryType}.
+	 * In case of error a message error is shown and a <code>false</code> value is returned.
+	 *
+	 * @param deliveryType the delivery type to store.
+	 * @return <code>true</code> if the delivery type has been stored, <code>false</code> otherwise.
+	 * @throws OHServiceException
+	 */
+	public boolean newDeliveryType(DeliveryType deliveryType) throws OHServiceException {
+		validateDeliveryType(deliveryType, true);
+		return ioOperations.newDeliveryType(deliveryType);
+	}
 
-    /**
-     * Updates the specified {@link DeliveryType}.
-     * In case of error a message error is shown and a <code>false</code> value is returned.
-     * @param deliveryType the delivery type to update.
-     * @return <code>true</code> if the delivery type has been update.
-     * @throws OHServiceException
-     */
-    public boolean updateDeliveryType(DeliveryType deliveryType) throws OHServiceException {
-        validateDeliveryType(deliveryType, false);
-        return ioOperations.updateDeliveryType(deliveryType);
-    }
+	/**
+	 * Updates the specified {@link DeliveryType}.
+	 * In case of error a message error is shown and a <code>false</code> value is returned.
+	 *
+	 * @param deliveryType the delivery type to update.
+	 * @return <code>true</code> if the delivery type has been update.
+	 * @throws OHServiceException
+	 */
+	public boolean updateDeliveryType(DeliveryType deliveryType) throws OHServiceException {
+		validateDeliveryType(deliveryType, false);
+		return ioOperations.updateDeliveryType(deliveryType);
+	}
 
-    /**
-     * Checks if the specified code is already used by others {@link DeliveryType}s.
-     * In case of error a message error is shown and a <code>false</code> value is returned.
-     * @param code the code to check.
-     * @return <code>true</code> if the code is used, <code>false</code> otherwise.
-     * @throws OHServiceException
-     */
-    public boolean codeControl(String code) throws OHServiceException {
-        return ioOperations.isCodePresent(code);
-    }
+	/**
+	 * Checks if the specified code is already used by others {@link DeliveryType}s.
+	 * In case of error a message error is shown and a <code>false</code> value is returned.
+	 *
+	 * @param code the code to check.
+	 * @return <code>true</code> if the code is used, <code>false</code> otherwise.
+	 * @throws OHServiceException
+	 */
+	public boolean codeControl(String code) throws OHServiceException {
+		return ioOperations.isCodePresent(code);
+	}
 
-    /**
-     * Delete the specified {@link DeliveryType}.
-     * In case of error a message error is shown and a <code>false</code> value is returned.
-     * @param deliveryType the delivery type to delete.
-     * @return <code>true</code> if the delivery type has been deleted, <code>false</code> otherwise.
-     * @throws OHServiceException
-     */
-    public boolean deleteDeliveryType(DeliveryType deliveryType) throws OHServiceException {
-        return ioOperations.deleteDeliveryType(deliveryType);
-    }
+	/**
+	 * Delete the specified {@link DeliveryType}.
+	 * In case of error a message error is shown and a <code>false</code> value is returned.
+	 *
+	 * @param deliveryType the delivery type to delete.
+	 * @return <code>true</code> if the delivery type has been deleted, <code>false</code> otherwise.
+	 * @throws OHServiceException
+	 */
+	public boolean deleteDeliveryType(DeliveryType deliveryType) throws OHServiceException {
+		return ioOperations.deleteDeliveryType(deliveryType);
+	}
 
-    /**
+	/**
 	 * Verify if the object is valid for CRUD and return a list of errors, if any
+	 *
 	 * @param deliveryType
 	 * @param insert <code>true</code> or updated <code>false</code>
-	 * @throws OHServiceException 
+	 * @throws OHServiceException
 	 */
-    protected void validateDeliveryType(DeliveryType deliveryType, boolean insert) throws OHServiceException {
-        List<OHExceptionMessage> errors = new ArrayList<OHExceptionMessage>();
-        String key = deliveryType.getCode();
-        if (key.equals("")){
-            errors.add(new OHExceptionMessage(MessageBundle.getMessage("angal.hospital"),  MessageBundle.getMessage("angal.dlvrtype.pleaseinsertacode"),
-                    OHSeverityLevel.ERROR));
-        }
-        if (key.length()>1){
-            errors.add(new OHExceptionMessage(MessageBundle.getMessage("angal.hospital"),  MessageBundle.getMessage("angal.dlvrtype.codetoolongmaxchars"),
-                    OHSeverityLevel.ERROR));
-        }
-        if(insert){
-            if (codeControl(key)){
-                errors.add(new OHExceptionMessage(MessageBundle.getMessage("angal.hospital"),  MessageBundle.getMessage("angal.common.codealreadyinuse"),
-                        OHSeverityLevel.ERROR));
-            }
-        }
-        if (deliveryType.getDescription().equals("")){
-            errors.add(new OHExceptionMessage(MessageBundle.getMessage("angal.hospital"),  MessageBundle.getMessage("angal.dlvrtype.pleaseinsertavaliddescription"),
-                    OHSeverityLevel.ERROR));
-        }
-        if (!errors.isEmpty()){
-	        throw new OHDataValidationException(errors);
-	    }
-    }
+	protected void validateDeliveryType(DeliveryType deliveryType, boolean insert) throws OHServiceException {
+		List<OHExceptionMessage> errors = new ArrayList<>();
+		String key = deliveryType.getCode();
+		if (key.equals("")) {
+			errors.add(new OHExceptionMessage(MessageBundle.getMessage("angal.hospital"), MessageBundle.getMessage("angal.dlvrtype.pleaseinsertacode"),
+					OHSeverityLevel.ERROR));
+		}
+		if (key.length() > 1) {
+			errors.add(new OHExceptionMessage(MessageBundle.getMessage("angal.hospital"), MessageBundle.getMessage("angal.dlvrtype.codetoolongmaxchars"),
+					OHSeverityLevel.ERROR));
+		}
+		if (insert) {
+			if (codeControl(key)) {
+				errors.add(new OHExceptionMessage(MessageBundle.getMessage("angal.hospital"), MessageBundle.getMessage("angal.common.codealreadyinuse"),
+						OHSeverityLevel.ERROR));
+			}
+		}
+		if (deliveryType.getDescription().equals("")) {
+			errors.add(
+					new OHExceptionMessage(MessageBundle.getMessage("angal.hospital"), MessageBundle.getMessage("angal.dlvrtype.pleaseinsertavaliddescription"),
+							OHSeverityLevel.ERROR));
+		}
+		if (!errors.isEmpty()) {
+			throw new OHDataValidationException(errors);
+		}
+	}
 }

--- a/src/test/java/org/isf/dlvrrestype/test/Tests.java
+++ b/src/test/java/org/isf/dlvrrestype/test/Tests.java
@@ -22,12 +22,20 @@
 package org.isf.dlvrrestype.test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.util.ArrayList;
+
+import org.assertj.core.api.Condition;
 import org.isf.OHCoreTestCase;
+import org.isf.dlvrrestype.manager.DeliveryResultTypeBrowserManager;
 import org.isf.dlvrrestype.model.DeliveryResultType;
 import org.isf.dlvrrestype.service.DeliveryResultIoOperationRepository;
 import org.isf.dlvrrestype.service.DeliveryResultTypeIoOperation;
+import org.isf.utils.exception.OHDataIntegrityViolationException;
+import org.isf.utils.exception.OHDataValidationException;
 import org.isf.utils.exception.OHException;
+import org.isf.utils.exception.OHServiceException;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -41,6 +49,8 @@ public class Tests extends OHCoreTestCase {
 	DeliveryResultTypeIoOperation deliveryResultTypeIoOperation;
 	@Autowired
 	DeliveryResultIoOperationRepository deliveryResultIoOperationRepository;
+	@Autowired
+	DeliveryResultTypeBrowserManager deliveryResultTypeBrowserManager;
 
 	@BeforeClass
 	public static void setUpClass() {
@@ -104,6 +114,99 @@ public class Tests extends OHCoreTestCase {
 		boolean result = deliveryResultTypeIoOperation.deleteDeliveryResultType(foundDeliveryResultType);
 		result = deliveryResultTypeIoOperation.isCodePresent(code);
 		assertThat(result).isFalse();
+	}
+
+	@Test
+	public void mgrGetDeliveryResultType() throws Exception {
+		String code = _setupTestDeliveryResultType(false);
+		DeliveryResultType foundDeliveryResultType = deliveryResultIoOperationRepository.findOne(code);
+		ArrayList<DeliveryResultType> foundDeliveryResultTypes = deliveryResultTypeBrowserManager.getDeliveryResultType();
+		assertThat(foundDeliveryResultTypes).contains(foundDeliveryResultType);
+	}
+
+	@Test
+	public void mgrUpdateDeliveryResultType() throws Exception {
+		String code = _setupTestDeliveryResultType(false);
+		DeliveryResultType foundDeliveryResultType = deliveryResultIoOperationRepository.findOne(code);
+		foundDeliveryResultType.setDescription("Update");
+		boolean result = deliveryResultTypeBrowserManager.updateDeliveryResultType(foundDeliveryResultType);
+		assertThat(result).isTrue();
+		DeliveryResultType updateDeliveryResultType = deliveryResultIoOperationRepository.findOne(code);
+		assertThat(updateDeliveryResultType.getDescription()).isEqualTo("Update");
+	}
+
+	@Test
+	public void mgrNewDeliveryResultType() throws Exception {
+		DeliveryResultType deliveryResultType = testDeliveryResultType.setup(true);
+		boolean result = deliveryResultTypeBrowserManager.newDeliveryResultType(deliveryResultType);
+		assertThat(result).isTrue();
+		_checkDeliveryResultTypeIntoDb(deliveryResultType.getCode());
+	}
+
+	@Test
+	public void mgrIsCodePresent() throws Exception {
+		String code = _setupTestDeliveryResultType(false);
+		boolean result = deliveryResultTypeBrowserManager.codeControl(code);
+		assertThat(result).isTrue();
+	}
+
+	@Test
+	public void mgrDeleteDeliveryResultType() throws Exception {
+		String code = _setupTestDeliveryResultType(false);
+		DeliveryResultType foundDeliveryResultType = deliveryResultIoOperationRepository.findOne(code);
+		boolean result = deliveryResultTypeBrowserManager.deleteDeliveryResultType(foundDeliveryResultType);
+		result = deliveryResultTypeBrowserManager.codeControl(code);
+		assertThat(result).isFalse();
+	}
+
+	@Test
+	public void mgrValidateDischargeType() throws Exception {
+		String code = _setupTestDeliveryResultType(false);
+		DeliveryResultType deliveryResultType = deliveryResultIoOperationRepository.findOne(code);
+		deliveryResultType.setDescription("Update");
+		boolean result = deliveryResultTypeBrowserManager.updateDeliveryResultType(deliveryResultType);
+		// empty string
+		deliveryResultType.setCode("");
+		assertThatThrownBy(() -> deliveryResultTypeBrowserManager.updateDeliveryResultType(deliveryResultType))
+				.isInstanceOf(OHDataValidationException.class)
+				.has(
+						new Condition<Throwable>(
+								(e -> ((OHServiceException) e).getMessages().size() == 1), "Expecting single validation error")
+				);
+		// too long
+		deliveryResultType.setCode("123456789ABCDEF");
+		assertThatThrownBy(() -> deliveryResultTypeBrowserManager.updateDeliveryResultType(deliveryResultType))
+				.isInstanceOf(OHDataValidationException.class)
+				.has(
+						new Condition<Throwable>(
+								(e -> ((OHServiceException) e).getMessages().size() == 1), "Expecting single validation error")
+				);
+		// key already exists
+		deliveryResultType.setCode(code);
+		assertThatThrownBy(() -> deliveryResultTypeBrowserManager.newDeliveryResultType(deliveryResultType))
+				.isInstanceOf(OHDataIntegrityViolationException.class)
+				.has(
+						new Condition<Throwable>(
+								(e -> ((OHServiceException) e).getMessages().size() == 1), "Expecting single validation error")
+				);
+		// description empty
+		deliveryResultType.setDescription("");
+		assertThatThrownBy(() -> deliveryResultTypeBrowserManager.updateDeliveryResultType(deliveryResultType))
+				.isInstanceOf(OHDataValidationException.class)
+				.has(
+						new Condition<Throwable>(
+								(e -> ((OHServiceException) e).getMessages().size() == 1), "Expecting single validation error")
+				);
+	}
+
+	@Test
+	public void deliveryResultTypeHashToString() throws Exception {
+		String code = _setupTestDeliveryResultType(false);
+		DeliveryResultType deliveryResultType = deliveryResultIoOperationRepository.findOne(code);
+		assertThat(deliveryResultType.hashCode()).isPositive();
+
+		DeliveryResultType deliveryResultType2 = new DeliveryResultType("someCode", "someDescription");
+		assertThat(deliveryResultType2.toString()).isEqualTo("someDescription");
 	}
 
 	private String _setupTestDeliveryResultType(boolean usingSet) throws OHException {

--- a/src/test/java/org/isf/dlvrrestype/test/Tests.java
+++ b/src/test/java/org/isf/dlvrrestype/test/Tests.java
@@ -117,7 +117,7 @@ public class Tests extends OHCoreTestCase {
 	}
 
 	@Test
-	public void mgrGetDeliveryResultType() throws Exception {
+	public void testMgrGetDeliveryResultType() throws Exception {
 		String code = _setupTestDeliveryResultType(false);
 		DeliveryResultType foundDeliveryResultType = deliveryResultIoOperationRepository.findOne(code);
 		ArrayList<DeliveryResultType> foundDeliveryResultTypes = deliveryResultTypeBrowserManager.getDeliveryResultType();
@@ -125,7 +125,7 @@ public class Tests extends OHCoreTestCase {
 	}
 
 	@Test
-	public void mgrUpdateDeliveryResultType() throws Exception {
+	public void testMgrUpdateDeliveryResultType() throws Exception {
 		String code = _setupTestDeliveryResultType(false);
 		DeliveryResultType foundDeliveryResultType = deliveryResultIoOperationRepository.findOne(code);
 		foundDeliveryResultType.setDescription("Update");
@@ -136,7 +136,7 @@ public class Tests extends OHCoreTestCase {
 	}
 
 	@Test
-	public void mgrNewDeliveryResultType() throws Exception {
+	public void testMgrNewDeliveryResultType() throws Exception {
 		DeliveryResultType deliveryResultType = testDeliveryResultType.setup(true);
 		boolean result = deliveryResultTypeBrowserManager.newDeliveryResultType(deliveryResultType);
 		assertThat(result).isTrue();
@@ -144,14 +144,14 @@ public class Tests extends OHCoreTestCase {
 	}
 
 	@Test
-	public void mgrIsCodePresent() throws Exception {
+	public void testMgrIsCodePresent() throws Exception {
 		String code = _setupTestDeliveryResultType(false);
 		boolean result = deliveryResultTypeBrowserManager.codeControl(code);
 		assertThat(result).isTrue();
 	}
 
 	@Test
-	public void mgrDeleteDeliveryResultType() throws Exception {
+	public void testMgrDeleteDeliveryResultType() throws Exception {
 		String code = _setupTestDeliveryResultType(false);
 		DeliveryResultType foundDeliveryResultType = deliveryResultIoOperationRepository.findOne(code);
 		boolean result = deliveryResultTypeBrowserManager.deleteDeliveryResultType(foundDeliveryResultType);
@@ -160,7 +160,7 @@ public class Tests extends OHCoreTestCase {
 	}
 
 	@Test
-	public void mgrValidateDischargeType() throws Exception {
+	public void testMgrDeliveryResultTypeValidate() throws Exception {
 		String code = _setupTestDeliveryResultType(false);
 		DeliveryResultType deliveryResultType = deliveryResultIoOperationRepository.findOne(code);
 		deliveryResultType.setDescription("Update");
@@ -200,7 +200,7 @@ public class Tests extends OHCoreTestCase {
 	}
 
 	@Test
-	public void deliveryResultTypeHashToString() throws Exception {
+	public void testDeliveryResultTypeHashToString() throws Exception {
 		String code = _setupTestDeliveryResultType(false);
 		DeliveryResultType deliveryResultType = deliveryResultIoOperationRepository.findOne(code);
 		assertThat(deliveryResultType.hashCode()).isPositive();

--- a/src/test/java/org/isf/dlvrtype/test/Tests.java
+++ b/src/test/java/org/isf/dlvrtype/test/Tests.java
@@ -118,7 +118,7 @@ public class Tests extends OHCoreTestCase {
 	}
 
 	@Test
-	public void mgrGetDeliveryType() throws Exception {
+	public void testMgrGetDeliveryType() throws Exception {
 		String code = _setupTestDeliveryType(false);
 		DeliveryType foundDeliveryType = deliveryTypeIoOperationRepository.findOne(code);
 		ArrayList<DeliveryType> deliveryTypes = deliveryTypeBrowserManager.getDeliveryType();
@@ -126,7 +126,7 @@ public class Tests extends OHCoreTestCase {
 	}
 
 	@Test
-	public void mgrUpdateDeliveryType() throws Exception {
+	public void testMgrUpdateDeliveryType() throws Exception {
 		String code = _setupTestDeliveryType(false);
 		DeliveryType foundDeliveryType = deliveryTypeIoOperationRepository.findOne(code);
 		foundDeliveryType.setDescription("Update");
@@ -137,7 +137,7 @@ public class Tests extends OHCoreTestCase {
 	}
 
 	@Test
-	public void mgrNewDeliveryType() throws Exception {
+	public void testMgrNewDeliveryType() throws Exception {
 		DeliveryType deliveryType = testDeliveryType.setup(true);
 		boolean result = deliveryTypeBrowserManager.newDeliveryType(deliveryType);
 		assertThat(result).isTrue();
@@ -145,14 +145,14 @@ public class Tests extends OHCoreTestCase {
 	}
 
 	@Test
-	public void tmgrIsCodePresent() throws Exception {
+	public void testMgrIsCodePresent() throws Exception {
 		String code = _setupTestDeliveryType(false);
 		boolean result = deliveryTypeBrowserManager.codeControl(code);
 		assertThat(result).isTrue();
 	}
 
 	@Test
-	public void mgrDeleteDeliveryType() throws Exception {
+	public void testMgrDeleteDeliveryType() throws Exception {
 		String code = _setupTestDeliveryType(false);
 		DeliveryType foundDeliveryType = deliveryTypeIoOperationRepository.findOne(code);
 		boolean result = deliveryTypeBrowserManager.deleteDeliveryType(foundDeliveryType);
@@ -162,7 +162,7 @@ public class Tests extends OHCoreTestCase {
 	}
 
 	@Test
-	public void mgrValidateDeliveryType() throws Exception {
+	public void testMgrDeliveryTypeValidate() throws Exception {
 		String code = _setupTestDeliveryType(false);
 		DeliveryType deliveryType = deliveryTypeIoOperationRepository.findOne(code);
 		deliveryType.setDescription("Update");
@@ -201,9 +201,8 @@ public class Tests extends OHCoreTestCase {
 				);
 	}
 
-
 	@Test
-	public void deliveryTypeEqualHashToString() throws Exception {
+	public void testDeliveryTypeEqualHashToString() throws Exception {
 		String code = _setupTestDeliveryType(false);
 		DeliveryType deliveryType = deliveryTypeIoOperationRepository.findOne(code);
 		DeliveryType deliveryType2 = new DeliveryType("someCode", "someDescription");

--- a/src/test/java/org/isf/dlvrtype/test/Tests.java
+++ b/src/test/java/org/isf/dlvrtype/test/Tests.java
@@ -22,14 +22,19 @@
 package org.isf.dlvrtype.test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.ArrayList;
 
+import org.assertj.core.api.Condition;
 import org.isf.OHCoreTestCase;
+import org.isf.dlvrtype.manager.DeliveryTypeBrowserManager;
 import org.isf.dlvrtype.model.DeliveryType;
 import org.isf.dlvrtype.service.DeliveryTypeIoOperation;
 import org.isf.dlvrtype.service.DeliveryTypeIoOperationRepository;
+import org.isf.utils.exception.OHDataValidationException;
 import org.isf.utils.exception.OHException;
+import org.isf.utils.exception.OHServiceException;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -43,6 +48,8 @@ public class Tests extends OHCoreTestCase {
 	DeliveryTypeIoOperation deliveryTypeIoOperation;
 	@Autowired
 	DeliveryTypeIoOperationRepository deliveryTypeIoOperationRepository;
+	@Autowired
+	DeliveryTypeBrowserManager deliveryTypeBrowserManager;
 
 	@BeforeClass
 	public static void setUpClass() {
@@ -108,6 +115,108 @@ public class Tests extends OHCoreTestCase {
 		assertThat(result).isTrue();
 		result = deliveryTypeIoOperation.isCodePresent(code);
 		assertThat(result).isFalse();
+	}
+
+	@Test
+	public void mgrGetDeliveryType() throws Exception {
+		String code = _setupTestDeliveryType(false);
+		DeliveryType foundDeliveryType = deliveryTypeIoOperationRepository.findOne(code);
+		ArrayList<DeliveryType> deliveryTypes = deliveryTypeBrowserManager.getDeliveryType();
+		assertThat(deliveryTypes.get(deliveryTypes.size() - 1).getDescription()).isEqualTo(foundDeliveryType.getDescription());
+	}
+
+	@Test
+	public void mgrUpdateDeliveryType() throws Exception {
+		String code = _setupTestDeliveryType(false);
+		DeliveryType foundDeliveryType = deliveryTypeIoOperationRepository.findOne(code);
+		foundDeliveryType.setDescription("Update");
+		boolean result = deliveryTypeBrowserManager.updateDeliveryType(foundDeliveryType);
+		DeliveryType updateDeliveryType = deliveryTypeIoOperationRepository.findOne(code);
+		assertThat(result).isTrue();
+		assertThat(updateDeliveryType.getDescription()).isEqualTo("Update");
+	}
+
+	@Test
+	public void mgrNewDeliveryType() throws Exception {
+		DeliveryType deliveryType = testDeliveryType.setup(true);
+		boolean result = deliveryTypeBrowserManager.newDeliveryType(deliveryType);
+		assertThat(result).isTrue();
+		_checkDeliveryTypeIntoDb(deliveryType.getCode());
+	}
+
+	@Test
+	public void tmgrIsCodePresent() throws Exception {
+		String code = _setupTestDeliveryType(false);
+		boolean result = deliveryTypeBrowserManager.codeControl(code);
+		assertThat(result).isTrue();
+	}
+
+	@Test
+	public void mgrDeleteDeliveryType() throws Exception {
+		String code = _setupTestDeliveryType(false);
+		DeliveryType foundDeliveryType = deliveryTypeIoOperationRepository.findOne(code);
+		boolean result = deliveryTypeBrowserManager.deleteDeliveryType(foundDeliveryType);
+		assertThat(result).isTrue();
+		result = deliveryTypeBrowserManager.codeControl(code);
+		assertThat(result).isFalse();
+	}
+
+	@Test
+	public void mgrValidateDeliveryType() throws Exception {
+		String code = _setupTestDeliveryType(false);
+		DeliveryType deliveryType = deliveryTypeIoOperationRepository.findOne(code);
+		deliveryType.setDescription("Update");
+		boolean result = deliveryTypeBrowserManager.updateDeliveryType(deliveryType);
+		// empty string
+		deliveryType.setCode("");
+		assertThatThrownBy(() -> deliveryTypeBrowserManager.updateDeliveryType(deliveryType))
+				.isInstanceOf(OHDataValidationException.class)
+				.has(
+						new Condition<Throwable>(
+								(e -> ((OHServiceException) e).getMessages().size() == 1), "Expecting single validation error")
+				);
+		// too long
+		deliveryType.setCode("123456789ABCDEF");
+		assertThatThrownBy(() -> deliveryTypeBrowserManager.updateDeliveryType(deliveryType))
+				.isInstanceOf(OHDataValidationException.class)
+				.has(
+						new Condition<Throwable>(
+								(e -> ((OHServiceException) e).getMessages().size() == 1), "Expecting single validation error")
+				);
+		// key already exists
+		deliveryType.setCode(code);
+		assertThatThrownBy(() -> deliveryTypeBrowserManager.newDeliveryType(deliveryType))
+				.isInstanceOf(OHDataValidationException.class)
+				.has(
+						new Condition<Throwable>(
+								(e -> ((OHServiceException) e).getMessages().size() == 1), "Expecting single validation error")
+				);
+		// description empty
+		deliveryType.setDescription("");
+		assertThatThrownBy(() -> deliveryTypeBrowserManager.updateDeliveryType(deliveryType))
+				.isInstanceOf(OHDataValidationException.class)
+				.has(
+						new Condition<Throwable>(
+								(e -> ((OHServiceException) e).getMessages().size() == 1), "Expecting single validation error")
+				);
+	}
+
+
+	@Test
+	public void deliveryTypeEqualHashToString() throws Exception {
+		String code = _setupTestDeliveryType(false);
+		DeliveryType deliveryType = deliveryTypeIoOperationRepository.findOne(code);
+		DeliveryType deliveryType2 = new DeliveryType("someCode", "someDescription");
+		assertThat(deliveryType.equals(deliveryType)).isTrue();
+		assertThat(deliveryType.equals(deliveryType2)).isFalse();
+		assertThat(deliveryType.equals(new String("xyzzy"))).isFalse();
+		deliveryType2.setCode(code);
+		deliveryType2.setDescription(deliveryType.getDescription());
+		assertThat(deliveryType.equals(deliveryType2)).isTrue();
+
+		assertThat(deliveryType.hashCode()).isPositive();
+
+		assertThat(deliveryType2.toString()).isEqualTo(deliveryType.getDescription());
 	}
 
 	private String _setupTestDeliveryType(boolean usingSet) throws OHException {


### PR DESCRIPTION
Add tests to increase coverage and formatter `Manager` files to match standards.

Coverage before:
![image](https://user-images.githubusercontent.com/1105445/100927555-0c97d700-34b3-11eb-96e2-e428526e9bf3.png)

Coverage after:
![image](https://user-images.githubusercontent.com/1105445/100927586-16b9d580-34b3-11eb-961e-fdff7a8ed5e9.png)

All tests pass locally.