### PR TITLE
OP-382 Increase coverage and format Manager files

### DIFF
--- a/src/main/java/org/isf/exa/manager/ExamBrowsingManager.java
+++ b/src/main/java/org/isf/exa/manager/ExamBrowsingManager.java
@@ -38,17 +38,14 @@ import org.isf.utils.exception.OHDataValidationException;
 import org.isf.utils.exception.OHServiceException;
 import org.isf.utils.exception.model.OHExceptionMessage;
 import org.isf.utils.exception.model.OHSeverityLevel;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 /**
  * Class that provides gui separation from database operations and gives some
  * useful logic manipulations of the dinamic data (memory)
- * 
+ *
  * @author bob
- * 
  */
 @Component
 public class ExamBrowsingManager {
@@ -56,79 +53,83 @@ public class ExamBrowsingManager {
 	@Autowired
 	private ExamIoOperations ioOperations;
 
-	private final Logger logger = LoggerFactory.getLogger(ExamBrowsingManager.class);
-	
 	/**
 	 * Verify if the object is valid for CRUD and return a list of errors, if any
+	 *
 	 * @param exam
 	 * @param insert <code>true</code> or updated <code>false</code>
-	 * @throws OHServiceException 
+	 * @throws OHServiceException
 	 */
 	protected void validateExam(Exam exam, boolean insert) throws OHServiceException {
 		String key = exam.getCode();
 		String description = exam.getDescription();
-        List<OHExceptionMessage> errors = new ArrayList<OHExceptionMessage>();
-        if(key.isEmpty() || description.isEmpty()){
-	        errors.add(new OHExceptionMessage("codeAndOrDescriptionEmptyError", 
-	        		MessageBundle.getMessage("angal.exa.pleaseinsertcodeoranddescription"), 
-	        		OHSeverityLevel.ERROR));
-        }
-        if (insert) {
-        	if (true == isKeyPresent(exam)) {
-				throw new OHDataIntegrityViolationException(new OHExceptionMessage(null, 
+		List<OHExceptionMessage> errors = new ArrayList<>();
+		if (key.isEmpty() || description.isEmpty()) {
+			errors.add(new OHExceptionMessage("codeAndOrDescriptionEmptyError",
+					MessageBundle.getMessage("angal.exa.pleaseinsertcodeoranddescription"),
+					OHSeverityLevel.ERROR));
+		}
+		if (insert) {
+			if (isKeyPresent(exam)) {
+				throw new OHDataIntegrityViolationException(new OHExceptionMessage(null,
 						MessageBundle.getMessage("angal.exa.changethecodebecauseisalreadyinuse"),
 						OHSeverityLevel.ERROR));
 			}
-        }
-        if (!errors.isEmpty()){
-	        throw new OHDataValidationException(errors);
-	    }
-    }
-	
+		}
+		if (!errors.isEmpty()) {
+			throw new OHDataValidationException(errors);
+		}
+	}
+
 	/**
 	 * Returns the list of {@link Exam}s
+	 *
 	 * @return the list of {@link Exam}s. It could be <code>null</code>
-	 * @throws OHServiceException 
+	 * @throws OHServiceException
 	 */
 	public ArrayList<Exam> getExams() throws OHServiceException {
 		return new ArrayList<Exam>(ioOperations.getExams());
 	}
-	
+
 	/**
 	 * Returns the list of {@link Exam}s
+	 *
 	 * @return the list of {@link Exam}s. It could be <code>null</code>
-	 * @throws OHServiceException 
+	 * @throws OHServiceException
 	 * @deprecated use getExam() instead
 	 */
 	@Deprecated
 	public ArrayList<Exam> getExamsbyDesc() throws OHServiceException {
 		return this.getExams();
 	}
-	
+
 	/**
 	 * Returns the list of {@link Exam}s that matches passed description
+	 *
 	 * @param description - the exam description
 	 * @return the list of {@link Exam}s. It could be <code>null</code>
-	 * @throws OHServiceException 
+	 * @throws OHServiceException
 	 */
 	public ArrayList<Exam> getExams(String description) throws OHServiceException {
 		return new ArrayList<Exam>(ioOperations.getExamsByDesc(description));
 	}
-	
+
 	/**
 	 * Returns the list of {@link Exam}s by {@link ExamType} description
+	 *
 	 * @param description - the exam description
 	 * @return the list of {@link Exam}s. It could be <code>null</code>
-	 * @throws OHServiceException 
+	 * @throws OHServiceException
 	 */
 	public ArrayList<Exam> getExamsByTypeDescription(String description) throws OHServiceException {
 		return new ArrayList<Exam>(ioOperations.getExamsByExamTypeDesc(description));
 	}
-	
+
 	/**
 	 * Returns the list of {@link ExamType}s
+	 *
 	 * @return the list of {@link ExamType}s. It could be <code>null</code>
-	 * @throws OHServiceException 
+	 * @throws OHServiceException
 	 */
 	public ArrayList<ExamType> getExamType() throws OHServiceException {
 		return ioOperations.getExamType();
@@ -138,21 +139,21 @@ public class ExamBrowsingManager {
 	 * This function controls the presence of a record with the same key as in
 	 * the parameter; Returns false if the query finds no record, else returns
 	 * true
-	 * 
+	 *
 	 * @param exam the {@link Exam}
 	 * @return <code>true</code> if the Exam code has already been used, <code>false</code> otherwise
-	 * @throws OHServiceException 
+	 * @throws OHServiceException
 	 */
 	public boolean isKeyPresent(Exam exam) throws OHServiceException {
 		return ioOperations.isKeyPresent(exam);
 	}
-	
+
 	/**
 	 * Insert a new {@link Exam} in the DB.
-	 * 
+	 *
 	 * @param exam - the {@link Exam} to insert
 	 * @return <code>true</code> if the {@link Exam} has been inserted, <code>false</code> otherwise
-	 * @throws OHServiceException 
+	 * @throws OHServiceException
 	 */
 	public boolean newExam(Exam exam) throws OHServiceException {
 		validateExam(exam, true);
@@ -161,10 +162,10 @@ public class ExamBrowsingManager {
 
 	/**
 	 * Updates an existing {@link Exam} in the db
-	 * 
+	 *
 	 * @param exam -  the {@link Exam} to update
 	 * @return <code>true</code> if the existing {@link Exam} has been updated, <code>false</code> otherwise
-	 * @throws OHServiceException 
+	 * @throws OHServiceException
 	 */
 	public boolean updateExam(Exam exam) throws OHServiceException {
 		validateExam(exam, false);
@@ -173,9 +174,10 @@ public class ExamBrowsingManager {
 
 	/**
 	 * Delete an {@link Exam}
+	 *
 	 * @param exam - the {@link Exam} to delete
 	 * @return <code>true</code> if the {@link Exam} has been deleted, <code>false</code> otherwise
-	 * @throws OHServiceException 
+	 * @throws OHServiceException
 	 */
 	public boolean deleteExam(Exam exam) throws OHServiceException {
 		return ioOperations.deleteExam(exam);

--- a/src/main/java/org/isf/exa/manager/ExamRowBrowsingManager.java
+++ b/src/main/java/org/isf/exa/manager/ExamRowBrowsingManager.java
@@ -27,55 +27,55 @@ import java.util.List;
 import org.isf.exa.model.ExamRow;
 import org.isf.exa.service.ExamRowIoOperations;
 import org.isf.generaldata.MessageBundle;
-import org.isf.utils.exception.OHServiceException;
 import org.isf.utils.exception.OHDataValidationException;
+import org.isf.utils.exception.OHServiceException;
 import org.isf.utils.exception.model.OHExceptionMessage;
 import org.isf.utils.exception.model.OHSeverityLevel;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 @Component
 public class ExamRowBrowsingManager {
-	
+
 	@Autowired
 	private ExamRowIoOperations ioOperations;
-		
-	private final Logger logger = LoggerFactory.getLogger(ExamRowBrowsingManager.class);
-	
+
 	/**
 	 * Verify if the object is valid for CRUD and return a list of errors, if any
+	 *
 	 * @param examRow
-	 * @throws OHDataValidationException 
+	 * @throws OHDataValidationException
 	 */
 	protected void validateExamRow(ExamRow examRow) throws OHDataValidationException {
 		String description = examRow.getDescription();
-        List<OHExceptionMessage> errors = new ArrayList<OHExceptionMessage>();
-        if(description.isEmpty()){
-	        errors.add(new OHExceptionMessage("descriptionEmptyError", 
-	        		MessageBundle.getMessage("angal.exa.insertdescription"), 
-	        		OHSeverityLevel.ERROR));
-        }
-        if (!errors.isEmpty()){
-	        throw new OHDataValidationException(errors);
-	    }
-    }
-	
+		List<OHExceptionMessage> errors = new ArrayList<>();
+		if (description.isEmpty()) {
+			errors.add(new OHExceptionMessage("descriptionEmptyError",
+					MessageBundle.getMessage("angal.exa.insertdescription"),
+					OHSeverityLevel.ERROR));
+		}
+		if (!errors.isEmpty()) {
+			throw new OHDataValidationException(errors);
+		}
+	}
+
 	/**
 	 * Returns the list of {@link ExamRow}s
+	 *
 	 * @return the list of {@link ExamRow}s. It could be <code>null</code>
-	 * @throws OHServiceException 
+	 * @throws OHServiceException
 	 */
 	public ArrayList<ExamRow> getExamRow() throws OHServiceException {
-            
-            return this.getExamRow(0, null);
+
+		return this.getExamRow(0, null);
 	}
+
 	/**
 	 * Returns a list of {@link ExamRow}s that matches passed exam code
+	 *
 	 * @param aExamCode - the exam code
 	 * @return the list of {@link ExamRow}s. It could be <code>null</code>
-	 * @throws OHServiceException 
+	 * @throws OHServiceException
 	 */
 	public ArrayList<ExamRow> getExamRow(int aExamCode) throws OHServiceException {
 		return this.getExamRow(aExamCode, null);
@@ -83,21 +83,22 @@ public class ExamRowBrowsingManager {
 
 	/**
 	 * Returns a list of {@link ExamRow}s that matches passed exam code and description
+	 *
 	 * @param aExamRowCode - the exam code
 	 * @param aDescription - the exam description
 	 * @return the list of {@link ExamRow}s. It could be <code>null</code>
-	 * @throws OHServiceException 
+	 * @throws OHServiceException
 	 */
 	public ArrayList<ExamRow> getExamRow(int aExamRowCode, String aDescription) throws OHServiceException {
 		return ioOperations.getExamRow(aExamRowCode, aDescription);
 	}
-	
+
 	/**
 	 * Insert a new {@link ExamRow} in the DB.
-	 * 
+	 *
 	 * @param examRow - the {@link ExamRow} to insert
 	 * @return <code>true</code> if the {@link ExamRow} has been inserted, <code>false</code> otherwise
-	 * @throws OHServiceException 
+	 * @throws OHServiceException
 	 */
 	public boolean newExamRow(ExamRow examRow) throws OHServiceException {
 		validateExamRow(examRow);
@@ -106,19 +107,21 @@ public class ExamRowBrowsingManager {
 
 	/**
 	 * Delete an {@link ExamRow}.
+	 *
 	 * @param examRow - the {@link ExamRow} to delete
 	 * @return <code>true</code> if the {@link ExamRow} has been deleted, <code>false</code> otherwise
-	 * @throws OHServiceException 
+	 * @throws OHServiceException
 	 */
 	public boolean deleteExamRow(ExamRow examRow) throws OHServiceException {
 		return ioOperations.deleteExamRow(examRow);
 	}
 
-    /**
+	/**
 	 * Returns a list of {@link ExamRow}s that matches passed exam code
+	 *
 	 * @param aExamCode - the exam code
 	 * @return the list of {@link ExamRow}s. It could be <code>null</code>
-	 * @throws OHServiceException 
+	 * @throws OHServiceException
 	 */
 	public ArrayList<ExamRow> getExamRowByExamCode(String aExamCode) throws OHServiceException {
 		return ioOperations.getExamRowByExamCode(aExamCode);

--- a/src/main/java/org/isf/exa/service/ExamRowIoOperations.java
+++ b/src/main/java/org/isf/exa/service/ExamRowIoOperations.java
@@ -91,12 +91,24 @@ public class ExamRowIoOperations {
 	 * Returns the list of {@link ExamRow}s
 	 * @return the list of {@link ExamRow}s
 	 * @throws OHServiceException
+	 * @deprecated use <code>getExamRows()</code>
 	 */
+	@Deprecated
 	public ArrayList<ExamRow> getExamrows() throws OHServiceException 
+	{
+		return getExamRows();
+	}
+
+	/**
+	 * Returns the list of {@link ExamRow}s
+	 * @return the list of {@link ExamRow}s
+	 * @throws OHServiceException
+	 */
+	public ArrayList<ExamRow> getExamRows() throws OHServiceException
 	{
 		return getExamsRowByDesc(null);
 	}
-	
+
 	/**
 	 * Returns the list of {@link ExamRow}s that matches passed description
 	 * @param description - the examRow description

--- a/src/main/java/org/isf/examination/manager/ExaminationBrowserManager.java
+++ b/src/main/java/org/isf/examination/manager/ExaminationBrowserManager.java
@@ -42,9 +42,10 @@ import org.springframework.stereotype.Component;
 
 @Component
 public class ExaminationBrowserManager {
-	
+
 	@Autowired
 	private ExaminationOperations ioOperations;
+
 	protected HashMap<String, String> diuresisDescriptionHashMap;
 	protected HashMap<String, String> bowelDescriptionHashMap;
 	protected LinkedHashMap<String, String> auscultationHashMap;
@@ -52,17 +53,17 @@ public class ExaminationBrowserManager {
 	/**
 	 * Default PatientExamination
 	 */
-	public PatientExamination getDefaultPatientExamination(Patient patient){
+	public PatientExamination getDefaultPatientExamination(Patient patient) {
 		PatientExamination defaultPatient = new PatientExamination(
-				new GregorianCalendar(), 
-				patient, 
-				new Integer(ExaminationParameters.HEIGHT_INIT), 
-				new Double(ExaminationParameters.WEIGHT_INIT), 
-				new Integer(ExaminationParameters.AP_MIN_INIT), 
+				new GregorianCalendar(),
+				patient,
+				new Integer(ExaminationParameters.HEIGHT_INIT),
+				new Double(ExaminationParameters.WEIGHT_INIT),
+				new Integer(ExaminationParameters.AP_MIN_INIT),
 				new Integer(ExaminationParameters.AP_MAX_INIT),
-				new Integer(ExaminationParameters.HR_INIT), 
-				new Double(ExaminationParameters.TEMP_INIT), 
-				new Double(ExaminationParameters.SAT_INIT), 
+				new Integer(ExaminationParameters.HR_INIT),
+				new Double(ExaminationParameters.TEMP_INIT),
+				new Double(ExaminationParameters.SAT_INIT),
 				new Integer(ExaminationParameters.HGT_INIT),
 				new Integer(ExaminationParameters.DIURESIS_INIT),
 				ExaminationParameters.DIURESIS_DESC_INIT,
@@ -76,17 +77,20 @@ public class ExaminationBrowserManager {
 	/**
 	 * Get from last PatientExamination (only height, weight & note)
 	 */
-	public PatientExamination getFromLastPatientExamination(PatientExamination lastPatientExamination){
-		PatientExamination newPatientExamination = new PatientExamination(new GregorianCalendar(), lastPatientExamination.getPatient(), lastPatientExamination.getPex_height(),
-				lastPatientExamination.getPex_weight(), lastPatientExamination.getPex_ap_min(), lastPatientExamination.getPex_ap_max(), lastPatientExamination.getPex_hr(), 
+	public PatientExamination getFromLastPatientExamination(PatientExamination lastPatientExamination) {
+		PatientExamination newPatientExamination = new PatientExamination(new GregorianCalendar(), lastPatientExamination.getPatient(),
+				lastPatientExamination.getPex_height(),
+				lastPatientExamination.getPex_weight(), lastPatientExamination.getPex_ap_min(), lastPatientExamination.getPex_ap_max(),
+				lastPatientExamination.getPex_hr(),
 				lastPatientExamination.getPex_temp(), lastPatientExamination.getPex_sat(), lastPatientExamination.getPex_hgt(),
-				lastPatientExamination.getPex_diuresis(), lastPatientExamination.getPex_diuresis_desc(), lastPatientExamination.getPex_bowel_desc(), lastPatientExamination.getPex_rr(), 
-				lastPatientExamination.getPex_auscultation(),lastPatientExamination.getPex_note());
+				lastPatientExamination.getPex_diuresis(), lastPatientExamination.getPex_diuresis_desc(), lastPatientExamination.getPex_bowel_desc(),
+				lastPatientExamination.getPex_rr(),
+				lastPatientExamination.getPex_auscultation(), lastPatientExamination.getPex_note());
 		return newPatientExamination;
 	}
 
 	private void buildAuscultationHashMap() {
-		auscultationHashMap = new LinkedHashMap<String, String>();
+		auscultationHashMap = new LinkedHashMap<>();
 		auscultationHashMap.put("normal", MessageBundle.getMessage("angal.examination.auscultation.normal"));
 		auscultationHashMap.put("wheezes", MessageBundle.getMessage("angal.examination.auscultation.wheezes"));
 		auscultationHashMap.put("rhonchi", MessageBundle.getMessage("angal.examination.auscultation.rhonchi"));
@@ -95,20 +99,23 @@ public class ExaminationBrowserManager {
 		auscultationHashMap.put("bronchial", MessageBundle.getMessage("angal.examination.auscultation.bronchial"));
 	}
 
-	public ArrayList<String> getAuscultationList() {	
-		if (auscultationHashMap == null) buildAuscultationHashMap();
-		ArrayList<String> auscultationDescriptionList = new ArrayList<String>(auscultationHashMap.values());
+	public ArrayList<String> getAuscultationList() {
+		if (auscultationHashMap == null)
+			buildAuscultationHashMap();
+		ArrayList<String> auscultationDescriptionList = new ArrayList<>(auscultationHashMap.values());
 		Collections.sort(auscultationDescriptionList, new DefaultSorter(MessageBundle.getMessage("angal.examination.auscultation.normal")));
 		return auscultationDescriptionList;
 	}
 
 	public String getAuscultationTranslated(String auscultationKey) {
-		if (auscultationHashMap == null) buildAuscultationHashMap();
+		if (auscultationHashMap == null)
+			buildAuscultationHashMap();
 		return auscultationHashMap.get(auscultationKey);
 	}
 
 	public String getAuscultationKey(String description) {
-		if (auscultationHashMap == null) buildAuscultationHashMap();
+		if (auscultationHashMap == null)
+			buildAuscultationHashMap();
 		String key = "";
 		for (String value : auscultationHashMap.keySet()) {
 			if (auscultationHashMap.get(value).equals(description)) {
@@ -121,42 +128,42 @@ public class ExaminationBrowserManager {
 
 	/**
 	 * @param patex - the PatientExamination to save
-	 * @throws OHServiceException 
+	 * @throws OHServiceException
 	 */
 	public void saveOrUpdate(PatientExamination patex) throws OHServiceException {
 		List<OHExceptionMessage> errors = validateExamination(patex);
-        if(!errors.isEmpty()){
-            throw new OHServiceException(errors);
-        }
-        ioOperations.saveOrUpdate(patex);
+		if (!errors.isEmpty()) {
+			throw new OHServiceException(errors);
+		}
+		ioOperations.saveOrUpdate(patex);
 	}
 
-	public PatientExamination getByID(int id) throws OHServiceException{
-        return ioOperations.getByID(id);
+	public PatientExamination getByID(int id) throws OHServiceException {
+		return ioOperations.getByID(id);
 	}
 
 	public PatientExamination getLastByPatID(int patID) throws OHServiceException {
 		ArrayList<PatientExamination> patExamination = getByPatID(patID);
-		
+
 		return !patExamination.isEmpty() ? patExamination.get(0) : null;
 	}
 
 	public ArrayList<PatientExamination> getLastNByPatID(int patID, int number) throws OHServiceException {
-        return ioOperations.getLastNByPatID(patID, number);
+		return ioOperations.getLastNByPatID(patID, number);
 	}
 
 	public ArrayList<PatientExamination> getByPatID(int patID) throws OHServiceException {
-        return ioOperations.getByPatID(patID);
+		return ioOperations.getByPatID(patID);
 	}
-	
+
 	/**
 	 * @param patexList - the {@link PatientExamination} to delete.
-	 * @throws OHServiceException 
+	 * @throws OHServiceException
 	 */
 	public void remove(ArrayList<PatientExamination> patexList) throws OHServiceException {
 		ioOperations.remove(patexList);
 	}
-	
+
 	public String getBMIdescription(double bmi) {
 		if (bmi < 16.5)
 			return MessageBundle.getMessage("angal.examination.bmi.severeunderweight");
@@ -170,13 +177,11 @@ public class ExaminationBrowserManager {
 			return MessageBundle.getMessage("angal.examination.bmi.obesityclassilight");
 		if (bmi >= 35 && bmi < 40)
 			return MessageBundle.getMessage("angal.examination.bmi.obesityclassiimedium");
-		if (bmi >= 40)
-			return MessageBundle.getMessage("angal.examination.bmi.obesityclassiiisevere");
-		return "";
+		return MessageBundle.getMessage("angal.examination.bmi.obesityclassiiisevere");
 	}
-	
+
 	private void buildDiuresisDescriptionHashMap() {
-		diuresisDescriptionHashMap = new HashMap<String, String>();
+		diuresisDescriptionHashMap = new HashMap<>();
 		diuresisDescriptionHashMap.put("physiological", MessageBundle.getMessage("angal.examination.diuresis.physiological"));
 		diuresisDescriptionHashMap.put("oliguria", MessageBundle.getMessage("angal.examination.diuresis.oliguria"));
 		diuresisDescriptionHashMap.put("anuria", MessageBundle.getMessage("angal.examination.diuresis.anuria"));
@@ -186,9 +191,9 @@ public class ExaminationBrowserManager {
 		diuresisDescriptionHashMap.put("hematuria", MessageBundle.getMessage("angal.examination.diuresis.hematuria"));
 		diuresisDescriptionHashMap.put("pyuria", MessageBundle.getMessage("angal.examination.diuresis.pyuria"));
 	}
-	
+
 	private void buildBowelDescriptionHashMap() {
-		bowelDescriptionHashMap = new HashMap<String, String>();
+		bowelDescriptionHashMap = new HashMap<>();
 		bowelDescriptionHashMap.put("regular", MessageBundle.getMessage("angal.examination.bowel.regular"));
 		bowelDescriptionHashMap.put("irregular", MessageBundle.getMessage("angal.examination.bowel.irregular"));
 		bowelDescriptionHashMap.put("constipation", MessageBundle.getMessage("angal.examination.bowel.constipation"));
@@ -205,37 +210,43 @@ public class ExaminationBrowserManager {
 	 * stranguria,
 	 * hematuria,
 	 * pyuria
+	 *
 	 * @return
 	 */
 	public ArrayList<String> getDiuresisDescriptionList() {
-		if (diuresisDescriptionHashMap == null) buildDiuresisDescriptionHashMap();
-		ArrayList<String> diuresisDescriptionList = new ArrayList<String>(diuresisDescriptionHashMap.values());
+		if (diuresisDescriptionHashMap == null)
+			buildDiuresisDescriptionHashMap();
+		ArrayList<String> diuresisDescriptionList = new ArrayList<>(diuresisDescriptionHashMap.values());
 		Collections.sort(diuresisDescriptionList, new DefaultSorter(MessageBundle.getMessage("angal.examination.diuresis.physiological")));
 		return diuresisDescriptionList;
 	}
-	
+
 	/**
 	 * return a list of bowel descriptions:
 	 * regular,
 	 * irregular,
 	 * constipation,
 	 * diarrheal
+	 *
 	 * @return
 	 */
 	public ArrayList<String> getBowelDescriptionList() {
-		if (bowelDescriptionHashMap == null) buildBowelDescriptionHashMap();
-		ArrayList<String> bowelDescriptionList = new ArrayList<String>(bowelDescriptionHashMap.values());
-		Collections.sort(bowelDescriptionList,  new DefaultSorter(MessageBundle.getMessage("angal.examination.bowel.regular")));
+		if (bowelDescriptionHashMap == null)
+			buildBowelDescriptionHashMap();
+		ArrayList<String> bowelDescriptionList = new ArrayList<>(bowelDescriptionHashMap.values());
+		Collections.sort(bowelDescriptionList, new DefaultSorter(MessageBundle.getMessage("angal.examination.bowel.regular")));
 		return bowelDescriptionList;
 	}
-	
+
 	public String getBowelDescriptionTranslated(String pex_bowel_desc_key) {
-		if (bowelDescriptionHashMap == null) buildBowelDescriptionHashMap();
+		if (bowelDescriptionHashMap == null)
+			buildBowelDescriptionHashMap();
 		return bowelDescriptionHashMap.get(pex_bowel_desc_key);
 	}
-	
+
 	public String getBowelDescriptionKey(String description) {
-		if (bowelDescriptionHashMap == null) buildBowelDescriptionHashMap();
+		if (bowelDescriptionHashMap == null)
+			buildBowelDescriptionHashMap();
 		String key = "";
 		for (String value : bowelDescriptionHashMap.keySet()) {
 			if (bowelDescriptionHashMap.get(value).equals(description)) {
@@ -245,14 +256,16 @@ public class ExaminationBrowserManager {
 		}
 		return key;
 	}
-	
+
 	public String getDiuresisDescriptionTranslated(String pex_diuresis_desc_key) {
-		if (diuresisDescriptionHashMap == null) buildDiuresisDescriptionHashMap();
+		if (diuresisDescriptionHashMap == null)
+			buildDiuresisDescriptionHashMap();
 		return diuresisDescriptionHashMap.get(pex_diuresis_desc_key);
 	}
-	
+
 	public String getDiuresisDescriptionKey(String description) {
-		if (diuresisDescriptionHashMap == null) buildDiuresisDescriptionHashMap();
+		if (diuresisDescriptionHashMap == null)
+			buildDiuresisDescriptionHashMap();
 		String key = "";
 		for (String value : diuresisDescriptionHashMap.keySet()) {
 			if (diuresisDescriptionHashMap.get(value).equals(description)) {
@@ -262,26 +275,27 @@ public class ExaminationBrowserManager {
 		}
 		return key;
 	}
-	
+
 	/**
 	 * Verify if the object is valid for CRUD and return a list of errors, if any
+	 *
 	 * @param patex
 	 * @return list of {@link OHExceptionMessage}
 	 */
 	protected List<OHExceptionMessage> validateExamination(PatientExamination patex) {
-        List<OHExceptionMessage> errors = new ArrayList<OHExceptionMessage>();
-        if (patex.getPex_diuresis_desc() != null && !diuresisDescriptionHashMap.keySet().contains(patex.getPex_diuresis_desc()))
-        	errors.add(new OHExceptionMessage("diuresisDescriptionNotAllowed", 
-        		MessageBundle.getMessage("angal.examination.pleaseinsertavaliddiuresisdescription"), 
-        		OHSeverityLevel.ERROR));
-        if (patex.getPex_bowel_desc() != null && !bowelDescriptionHashMap.keySet().contains(patex.getPex_bowel_desc()))
-        	errors.add(new OHExceptionMessage("bowelDescriptionNotAllowed", 
-        		MessageBundle.getMessage("angal.examination.pleaseinsertavalidboweldescription"), 
-        		OHSeverityLevel.ERROR));
-        if (patex.getPex_auscultation() != null && !auscultationHashMap.keySet().contains(patex.getPex_auscultation()))
-        	errors.add(new OHExceptionMessage("auscultationDescriptionNotAllowed", 
-        		MessageBundle.getMessage("angal.examination.pleaseinsertavalidauscultationdescription"), 
-        		OHSeverityLevel.ERROR));
-        return errors;
-    }
+		List<OHExceptionMessage> errors = new ArrayList<>();
+		if (patex.getPex_diuresis_desc() != null && !diuresisDescriptionHashMap.keySet().contains(patex.getPex_diuresis_desc()))
+			errors.add(new OHExceptionMessage("diuresisDescriptionNotAllowed",
+					MessageBundle.getMessage("angal.examination.pleaseinsertavaliddiuresisdescription"),
+					OHSeverityLevel.ERROR));
+		if (patex.getPex_bowel_desc() != null && !bowelDescriptionHashMap.keySet().contains(patex.getPex_bowel_desc()))
+			errors.add(new OHExceptionMessage("bowelDescriptionNotAllowed",
+					MessageBundle.getMessage("angal.examination.pleaseinsertavalidboweldescription"),
+					OHSeverityLevel.ERROR));
+		if (patex.getPex_auscultation() != null && !auscultationHashMap.keySet().contains(patex.getPex_auscultation()))
+			errors.add(new OHExceptionMessage("auscultationDescriptionNotAllowed",
+					MessageBundle.getMessage("angal.examination.pleaseinsertavalidauscultationdescription"),
+					OHSeverityLevel.ERROR));
+		return errors;
+	}
 }

--- a/src/main/java/org/isf/exatype/manager/ExamTypeBrowserManager.java
+++ b/src/main/java/org/isf/exatype/manager/ExamTypeBrowserManager.java
@@ -28,64 +28,62 @@ import org.isf.exatype.model.ExamType;
 import org.isf.exatype.service.ExamTypeIoOperation;
 import org.isf.generaldata.MessageBundle;
 import org.isf.utils.exception.OHDataIntegrityViolationException;
-import org.isf.utils.exception.OHServiceException;
 import org.isf.utils.exception.OHDataValidationException;
+import org.isf.utils.exception.OHServiceException;
 import org.isf.utils.exception.model.OHExceptionMessage;
 import org.isf.utils.exception.model.OHSeverityLevel;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 @Component
 public class ExamTypeBrowserManager {
 
-	private final Logger logger = LoggerFactory.getLogger(ExamTypeBrowserManager.class);
-	
 	@Autowired
 	private ExamTypeIoOperation ioOperations;
 
 	/**
 	 * Verify if the object is valid for CRUD and return a list of errors, if any
+	 *
 	 * @param examType
 	 * @param insert <code>true</code> or updated <code>false</code>
-	 * @throws OHServiceException 
+	 * @throws OHServiceException
 	 */
 	protected void validateExamType(ExamType examType, boolean insert) throws OHServiceException {
 		String key = examType.getCode();
 		String description = examType.getDescription();
-        List<OHExceptionMessage> errors = new ArrayList<OHExceptionMessage>();
-        if(key.isEmpty() ){
-	        errors.add(new OHExceptionMessage("codeEmptyError", 
-	        		MessageBundle.getMessage("angal.exatype.pleaseinsertacode"), 
-	        		OHSeverityLevel.ERROR));
-        }
-        if(key.length()>2){
-	        errors.add(new OHExceptionMessage("codeTooLongError", 
-	        		MessageBundle.getMessage("angal.exatype.codetoolongmaxchar"), 
-	        		OHSeverityLevel.ERROR));
-        }
-        if(description.isEmpty() ){
-            errors.add(new OHExceptionMessage("descriptionEmptyError", 
-            		MessageBundle.getMessage("angal.exatype.pleaseinsertavaliddescription"), 
-            		OHSeverityLevel.ERROR));
-        }
-        if (insert) {
-        	if (codeControl(examType.getCode())){
-				throw new OHDataIntegrityViolationException(new OHExceptionMessage(null, 
-						MessageBundle.getMessage("angal.common.codealreadyinuse"), 
+		List<OHExceptionMessage> errors = new ArrayList<>();
+		if (key.isEmpty()) {
+			errors.add(new OHExceptionMessage("codeEmptyError",
+					MessageBundle.getMessage("angal.exatype.pleaseinsertacode"),
+					OHSeverityLevel.ERROR));
+		}
+		if (key.length() > 2) {
+			errors.add(new OHExceptionMessage("codeTooLongError",
+					MessageBundle.getMessage("angal.exatype.codetoolongmaxchar"),
+					OHSeverityLevel.ERROR));
+		}
+		if (description.isEmpty()) {
+			errors.add(new OHExceptionMessage("descriptionEmptyError",
+					MessageBundle.getMessage("angal.exatype.pleaseinsertavaliddescription"),
+					OHSeverityLevel.ERROR));
+		}
+		if (insert) {
+			if (codeControl(examType.getCode())) {
+				throw new OHDataIntegrityViolationException(new OHExceptionMessage(null,
+						MessageBundle.getMessage("angal.common.codealreadyinuse"),
 						OHSeverityLevel.ERROR));
 			}
-        }
-        if (!errors.isEmpty()){
-	        throw new OHDataValidationException(errors);
-	    }
-    }
-	
+		}
+		if (!errors.isEmpty()) {
+			throw new OHDataValidationException(errors);
+		}
+	}
+
 	/**
 	 * Return the list of {@link ExamType}s.
+	 *
 	 * @return the list of {@link ExamType}s. It could be <code>null</code>
-	 * @throws OHServiceException 
+	 * @throws OHServiceException
 	 */
 	public ArrayList<ExamType> getExamType() throws OHServiceException {
 		return ioOperations.getExamType();
@@ -93,10 +91,10 @@ public class ExamTypeBrowserManager {
 
 	/**
 	 * Insert a new {@link ExamType} in the DB.
-	 * 
+	 *
 	 * @param examType - the {@link ExamType} to insert.
 	 * @return <code>true</code> if the examType has been inserted, <code>false</code> otherwise.
-	 * @throws OHServiceException 
+	 * @throws OHServiceException
 	 */
 	public boolean newExamType(ExamType examType) throws OHServiceException {
 		validateExamType(examType, true);
@@ -105,9 +103,10 @@ public class ExamTypeBrowserManager {
 
 	/**
 	 * Update an already existing {@link ExamType}.
+	 *
 	 * @param examType - the {@link ExamType} to update
 	 * @return <code>true</code> if the examType has been updated, <code>false</code> otherwise.
-	 * @throws OHServiceException 
+	 * @throws OHServiceException
 	 */
 	public boolean updateExamType(ExamType examType) throws OHServiceException {
 		validateExamType(examType, false);
@@ -117,9 +116,10 @@ public class ExamTypeBrowserManager {
 	/**
 	 * This function controls the presence of a record with the same code as in
 	 * the parameter.
+	 *
 	 * @param code - the code
 	 * @return <code>true</code> if the code is present, <code>false</code> otherwise.
-	 * @throws OHServiceException 
+	 * @throws OHServiceException
 	 */
 	public boolean codeControl(String code) throws OHServiceException {
 		return ioOperations.isCodePresent(code);
@@ -127,9 +127,9 @@ public class ExamTypeBrowserManager {
 
 	/**
 	 * Delete the passed {@link ExamType}.
+	 *
 	 * @param examType - the {@link ExamType} to delete.
 	 * @return <code>true</code> if the examType has been deleted, <code>false</code> otherwise.
-	 * @throws OHServiceException 
 	 * @throws OHServiceException
 	 */
 	public boolean deleteExamType(ExamType examType) throws OHServiceException {

--- a/src/test/java/org/isf/exa/test/Tests.java
+++ b/src/test/java/org/isf/exa/test/Tests.java
@@ -22,11 +22,16 @@
 package org.isf.exa.test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.assertj.core.api.Condition;
 import org.isf.OHCoreTestCase;
+import org.isf.exa.manager.ExamBrowsingManager;
+import org.isf.exa.manager.ExamRowBrowsingManager;
 import org.isf.exa.model.Exam;
 import org.isf.exa.model.ExamRow;
 import org.isf.exa.service.ExamIoOperationRepository;
@@ -36,7 +41,10 @@ import org.isf.exa.service.ExamRowIoOperations;
 import org.isf.exatype.model.ExamType;
 import org.isf.exatype.service.ExamTypeIoOperationRepository;
 import org.isf.exatype.test.TestExamType;
+import org.isf.utils.exception.OHDataIntegrityViolationException;
+import org.isf.utils.exception.OHDataValidationException;
 import org.isf.utils.exception.OHException;
+import org.isf.utils.exception.OHServiceException;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -58,6 +66,10 @@ public class Tests extends OHCoreTestCase {
 	ExamRowIoOperationRepository examRowIoOperationRepository;
 	@Autowired
 	ExamTypeIoOperationRepository examTypeIoOperationRepository;
+	@Autowired
+	ExamBrowsingManager examBrowsingManager;
+	@Autowired
+	ExamRowBrowsingManager examRowBrowsingManager;
 
 	@BeforeClass
 	public static void setUpClass() {
@@ -96,10 +108,45 @@ public class Tests extends OHCoreTestCase {
 	}
 
 	@Test
-	public void testIoGetExamRow() throws Exception {
+	public void testIoGetExamRowZero() throws Exception {
 		int code = _setupTestExamRow(false);
 		ExamRow foundExamRow = examRowIoOperationRepository.findOne(code);
 		ArrayList<ExamRow> examRows = examRowIoOperation.getExamRow(0, null);
+		assertThat(examRows.get(examRows.size() - 1).getDescription()).isEqualTo(foundExamRow.getDescription());
+	}
+
+	@Test
+	public void testIoGetExamRowNoDescription() throws Exception {
+		int code = _setupTestExamRow(false);
+		ExamRow foundExamRow = examRowIoOperationRepository.findOne(code);
+		ArrayList<ExamRow> examRows = examRowIoOperation.getExamRow(foundExamRow.getCode(), null);
+		assertThat(examRows.get(examRows.size() - 1).getDescription()).isEqualTo(foundExamRow.getDescription());
+	}
+
+	@Test
+	public void testIoGetExamRowWithDescription() throws Exception {
+		int code = _setupTestExamRow(false);
+		ExamRow foundExamRow = examRowIoOperationRepository.findOne(code);
+		ArrayList<ExamRow> examRows = examRowIoOperation.getExamRow(foundExamRow.getCode(), foundExamRow.getDescription());
+		assertThat(examRows.get(examRows.size() - 1).getDescription()).isEqualTo(foundExamRow.getDescription());
+	}
+
+	@Test
+	public void testIoGetExamRows() throws Exception {
+		int code = _setupTestExamRow(false);
+		ExamRow foundExamRow = examRowIoOperationRepository.findOne(code);
+		ArrayList<ExamRow> examRows = examRowIoOperation.getExamRows();
+		assertThat(examRows.get(examRows.size() - 1).getDescription()).isEqualTo(foundExamRow.getDescription());
+		// deprecated method
+		examRows = examRowIoOperation.getExamrows();
+		assertThat(examRows.get(examRows.size() - 1).getDescription()).isEqualTo(foundExamRow.getDescription());
+	}
+
+	@Test
+	public void testIoGetExamsRowByDesc() throws Exception {
+		int code = _setupTestExamRow(false);
+		ExamRow foundExamRow = examRowIoOperationRepository.findOne(code);
+		ArrayList<ExamRow> examRows = examRowIoOperation.getExamsRowByDesc(foundExamRow.getDescription());
 		assertThat(examRows.get(examRows.size() - 1).getDescription()).isEqualTo(foundExamRow.getDescription());
 	}
 
@@ -112,10 +159,18 @@ public class Tests extends OHCoreTestCase {
 	}
 
 	@Test
-	public void testIoGetExamType() throws Exception {
+	public void testIoGetExamTypeExam() throws Exception {
 		String code = _setupTestExamType(false);
 		ExamType foundExamType = examTypeIoOperationRepository.findOne(code);
 		ArrayList<ExamType> examTypes = examIoOperation.getExamType();
+		assertThat(examTypes).contains(foundExamType);
+	}
+
+	@Test
+	public void testIoGetExamTypeExamRow() throws Exception {
+		String code = _setupTestExamType(false);
+		ExamType foundExamType = examTypeIoOperationRepository.findOne(code);
+		ArrayList<ExamType> examTypes = examRowIoOperation.getExamType();
 		assertThat(examTypes).contains(foundExamType);
 	}
 
@@ -153,6 +208,17 @@ public class Tests extends OHCoreTestCase {
 	}
 
 	@Test
+	public void testIoUpdateExamRow() throws Exception {
+		int code = _setupTestExamRow(false);
+		ExamRow examRow = examRowIoOperationRepository.findOne(code);
+		examRow.setDescription("Update");
+		boolean result = examRowIoOperation.updateExamRow(examRow);
+		assertThat(result).isTrue();
+		ExamRow updateExamRow = examRowIoOperationRepository.findOne(code);
+		assertThat(updateExamRow.getDescription()).isEqualTo("Update");
+	}
+
+	@Test
 	public void testIoDeleteExam() throws Exception {
 		String code = _setupTestExam(false);
 		Exam foundExam = examIoOperationRepository.findOne(code);
@@ -180,6 +246,310 @@ public class Tests extends OHCoreTestCase {
 		examIoOperationRepository.saveAndFlush(exam);
 		boolean result = examIoOperation.isKeyPresent(exam);
 		assertThat(result).isTrue();
+	}
+
+	@Test
+	public void testIoIsKeyPresentExamRow() throws Exception {
+		int code = _setupTestExamRow(false);
+		ExamRow examRow = examRowIoOperationRepository.findOne(code);
+		boolean result = examRowIoOperation.isKeyPresent(examRow);
+		assertThat(result).isTrue();
+		// fail
+		examRow.setCode(-1);
+		result = examRowIoOperation.isKeyPresent(examRow);
+		assertThat(result).isFalse();
+	}
+
+	@Test
+	public void testIoIsCodePresent() throws Exception {
+		int code = _setupTestExamRow(false);
+		ExamRow examRow = examRowIoOperationRepository.findOne(code);
+		assertThat(examRowIoOperation.isCodePresent(examRow.getCode())).isTrue();
+	}
+
+	@Test
+	public void testIoIsRowPresent() throws Exception {
+		int code = _setupTestExamRow(false);
+		ExamRow examRow = examRowIoOperationRepository.findOne(code);
+		assertThat(examRowIoOperation.isRowPresent(examRow.getCode())).isTrue();
+	}
+
+	@Test
+	public void testIoGetExamRowByExamCode() throws Exception {
+		ExamType examType = testExamType.setup(false);
+		Exam exam = testExam.setup(examType, 2, false);
+		ExamRow examRow = testExamRow.setup(exam, false);
+		examTypeIoOperationRepository.saveAndFlush(examType);
+		examIoOperationRepository.saveAndFlush(exam);
+		examRowIoOperationRepository.saveAndFlush(examRow);
+		ArrayList<ExamRow> examRows = examRowIoOperation.getExamRowByExamCode(String.valueOf(exam.getCode()));
+		assertThat(examRows.get(examRows.size() - 1).getDescription()).isEqualTo(examRow.getDescription());
+	}
+
+	@Test
+	public void testMgrGetExamRowByExamCode() throws Exception {
+		ExamType examType = testExamType.setup(false);
+		Exam exam = testExam.setup(examType, 2, false);
+		ExamRow examRow = testExamRow.setup(exam, false);
+		examTypeIoOperationRepository.saveAndFlush(examType);
+		examIoOperationRepository.saveAndFlush(exam);
+		examRowIoOperationRepository.saveAndFlush(examRow);
+		ArrayList<ExamRow> examRows = examRowBrowsingManager.getExamRowByExamCode(String.valueOf(exam.getCode()));
+		assertThat(examRows.get(examRows.size() - 1).getDescription()).isEqualTo(examRow.getDescription());
+	}
+
+	@Test
+	public void testMgrGetExamRow() throws Exception {
+		int code = _setupTestExamRow(false);
+		ExamRow foundExamRow = examRowIoOperationRepository.findOne(code);
+		ArrayList<ExamRow> examRows = examRowBrowsingManager.getExamRow(0, null);
+		assertThat(examRows.get(examRows.size() - 1).getDescription()).isEqualTo(foundExamRow.getDescription());
+	}
+
+	@Test
+	public void testMgrGetExams() throws Exception {
+		String code = _setupTestExam(false);
+		Exam foundExam = examIoOperationRepository.findOne(code);
+		List<Exam> exams = examBrowsingManager.getExams();
+		assertThat(exams.get(exams.size() - 1).getDescription()).isEqualTo(foundExam.getDescription());
+
+		exams = examBrowsingManager.getExamsbyDesc();
+		assertThat(exams.get(exams.size() - 1).getDescription()).isEqualTo(foundExam.getDescription());
+
+		exams = examBrowsingManager.getExamsByTypeDescription("xxxx");
+		assertThat(exams).isEmpty();
+
+		exams = examBrowsingManager.getExamsByTypeDescription("TestDescription");
+		assertThat(exams.get(exams.size() - 1).getDescription()).isEqualTo(foundExam.getDescription());
+
+		exams = examBrowsingManager.getExamsByTypeDescription(null);
+		assertThat(exams.get(exams.size() - 1).getDescription()).isEqualTo(foundExam.getDescription());
+
+		exams = examBrowsingManager.getExams("TestDescription");
+		assertThat(exams.get(exams.size() - 1).getDescription()).isEqualTo(foundExam.getDescription());
+	}
+
+	@Test
+	public void testMgrGetExamType() throws Exception {
+		String code = _setupTestExamType(false);
+		ExamType foundExamType = examTypeIoOperationRepository.findOne(code);
+		ArrayList<ExamType> examTypes = examBrowsingManager.getExamType();
+		assertThat(examTypes).contains(foundExamType);
+	}
+
+	@Test
+	public void testMgrNewExamRow() throws Exception {
+		ExamType examType = testExamType.setup(false);
+		Exam exam = testExam.setup(examType, 2, false);
+		ExamRow examRow = testExamRow.setup(exam, true);
+		examTypeIoOperationRepository.saveAndFlush(examType);
+		examIoOperationRepository.saveAndFlush(exam);
+		boolean result = examRowBrowsingManager.newExamRow(examRow);
+		assertThat(result).isTrue();
+		_checkExamRowIntoDb(examRow.getCode());
+	}
+
+	@Test
+	public void testMgrNewExam() throws Exception {
+		ExamType examType = testExamType.setup(false);
+		examTypeIoOperationRepository.saveAndFlush(examType);
+		Exam exam = testExam.setup(examType, 1, false);
+		boolean result = examBrowsingManager.newExam(exam);
+		assertThat(result).isTrue();
+		_checkExamIntoDb(exam.getCode());
+	}
+
+	@Test
+	public void testMgrUpdateExam() throws Exception {
+		String code = _setupTestExam(false);
+		Exam foundExam = examIoOperationRepository.findOne(code);
+		foundExam.setDescription("Update");
+		boolean result = examBrowsingManager.updateExam(foundExam);
+		assertThat(result).isTrue();
+		Exam updateExam = examIoOperationRepository.findOne(code);
+		assertThat(updateExam.getDescription()).isEqualTo("Update");
+	}
+
+	@Test
+	public void testMgrDeleteExam() throws Exception {
+		String code = _setupTestExam(false);
+		Exam foundExam = examIoOperationRepository.findOne(code);
+		boolean result = examBrowsingManager.deleteExam(foundExam);
+		assertThat(result).isTrue();
+		result = examIoOperation.isCodePresent(code);
+		assertThat(result).isFalse();
+	}
+
+	@Test
+	public void testMgrDeleteExamRow() throws Exception {
+		int code = _setupTestExamRow(false);
+		ExamRow foundExamRow = examRowIoOperationRepository.findOne(code);
+		boolean result = examRowBrowsingManager.deleteExamRow(foundExamRow);
+		assertThat(result).isTrue();
+		result = examIoOperation.isRowPresent(code);
+		assertThat(result).isFalse();
+	}
+
+	@Test
+	public void testMgrIsKeyPresent() throws Exception {
+		ExamType examType = testExamType.setup(false);
+		Exam exam = testExam.setup(examType, 1, false);
+		examTypeIoOperationRepository.saveAndFlush(examType);
+		examIoOperationRepository.saveAndFlush(exam);
+		boolean result = examBrowsingManager.isKeyPresent(exam);
+		assertThat(result).isTrue();
+	}
+
+	@Test
+	public void testMgrGetExamRowZero() throws Exception {
+		int code = _setupTestExamRow(false);
+		ExamRow foundExamRow = examRowIoOperationRepository.findOne(code);
+		ArrayList<ExamRow> examRows = examRowBrowsingManager.getExamRow(0, null);
+		assertThat(examRows.get(examRows.size() - 1).getDescription()).isEqualTo(foundExamRow.getDescription());
+
+		examRows = examRowBrowsingManager.getExamRow();
+		assertThat(examRows.get(examRows.size() - 1).getDescription()).isEqualTo(foundExamRow.getDescription());
+	}
+
+	@Test
+	public void testMgrGetExamRowNoDescription() throws Exception {
+		int code = _setupTestExamRow(false);
+		ExamRow foundExamRow = examRowIoOperationRepository.findOne(code);
+		ArrayList<ExamRow> examRows = examRowBrowsingManager.getExamRow(foundExamRow.getCode(), null);
+		assertThat(examRows.get(examRows.size() - 1).getDescription()).isEqualTo(foundExamRow.getDescription());
+
+		examRows = examRowBrowsingManager.getExamRow(foundExamRow.getCode());
+		assertThat(examRows.get(examRows.size() - 1).getDescription()).isEqualTo(foundExamRow.getDescription());
+	}
+
+	@Test
+	public void testMgrGetExamRowWithDescription() throws Exception {
+		int code = _setupTestExamRow(false);
+		ExamRow foundExamRow = examRowIoOperationRepository.findOne(code);
+		ArrayList<ExamRow> examRows = examRowBrowsingManager.getExamRow(foundExamRow.getCode(), foundExamRow.getDescription());
+		assertThat(examRows.get(examRows.size() - 1).getDescription()).isEqualTo(foundExamRow.getDescription());
+	}
+
+	@Test
+	public void testMgrExamValidationUpdate() throws Exception {
+		ExamType examType = new ExamType("ZZ", "TestDescription");
+		Exam exam = testExam.setup(examType, 1, false);
+		String code = exam.getCode();
+		// code = ""
+		exam.setCode("");
+		assertThatThrownBy(() -> examBrowsingManager.updateExam(exam))
+				.isInstanceOf(OHDataValidationException.class)
+				.has(
+						new Condition<Throwable>(
+								(e -> ((OHServiceException) e).getMessages().size() == 1), "Expecting single validation error")
+				);
+		// description = ""
+		exam.setCode(code);
+		exam.setDescription("");
+		assertThatThrownBy(() -> examBrowsingManager.updateExam(exam))
+				.isInstanceOf(OHDataValidationException.class)
+				.has(
+						new Condition<Throwable>(
+								(e -> ((OHServiceException) e).getMessages().size() == 1), "Expecting single validation error")
+				);
+	}
+
+	@Test
+	public void testMgrExamValidationInsert() throws Exception {
+		String code = _setupTestExam(false);
+		Exam exam = examIoOperationRepository.findOne(code);
+		// code already exists
+		ExamType examType = new ExamType("ZZ", "TestDescription");
+		Exam exam2 = testExam.setup(examType, 1, false);
+		exam2.setCode(code);
+		assertThatThrownBy(() -> examBrowsingManager.newExam(exam2))
+				.isInstanceOf(OHDataIntegrityViolationException.class)
+				.has(
+						new Condition<Throwable>(
+								(e -> ((OHServiceException) e).getMessages().size() == 1), "Expecting single validation error")
+				);
+	}
+
+	@Test
+	public void testMgrExamRowValidationUpdate() throws Exception {
+		ExamType examType = new ExamType("ZZ", "TestDescription");
+		Exam exam = testExam.setup(examType, 2, false);
+		ExamRow examRow = testExamRow.setup(exam, false);
+		// description = ""
+		examRow.setDescription("");
+		assertThatThrownBy(() -> examRowBrowsingManager.newExamRow(examRow))
+				.isInstanceOf(OHDataValidationException.class)
+				.has(
+						new Condition<Throwable>(
+								(e -> ((OHServiceException) e).getMessages().size() == 1), "Expecting single validation error")
+				);
+	}
+
+	@Test
+	public void testExamEqualHashToString() throws Exception {
+		String code = _setupTestExam(false);
+		Exam exam = examIoOperationRepository.findOne(code);
+		ExamType examType = testExamType.setup(false);
+		Exam exam2 = new Exam("XXX", "TestDescription", examType, 1, "TestDefaultResult");
+		assertThat(exam.equals(exam)).isTrue();
+		assertThat(exam.equals(exam2)).isFalse();
+		assertThat(exam.equals(new String("xyzzy"))).isFalse();
+		exam2.setCode(exam.getCode());
+		exam2.setDescription(exam.getDescription());
+		exam2.setExamtype(exam.getExamtype());
+		assertThat(exam.equals(exam2)).isTrue();
+
+		assertThat(exam.hashCode()).isPositive();
+
+		assertThat(exam2.toString()).isEqualTo(exam.getDescription());
+	}
+
+	@Test
+	public void testExamRowEqualHashToString() throws Exception {
+		int code = _setupTestExamRow(false);
+		ExamRow examRow = examRowIoOperationRepository.findOne(code);
+		ExamType examType = testExamType.setup(false);
+		Exam exam2 = new Exam("XXX", "TestDescription", examType, 1, "TestDefaultResult");
+		ExamRow examRow2 = new ExamRow(exam2, "NewDescription");
+		assertThat(examRow.equals(examRow)).isTrue();
+		assertThat(examRow.equals(examRow2)).isFalse();
+		assertThat(examRow.equals(new String("xyzzy"))).isFalse();
+		examRow2.setCode(examRow.getCode());
+		examRow2.setExamCode(examRow.getExamCode());
+		examRow2.setDescription(examRow.getDescription());
+		assertThat(examRow.equals(examRow2)).isTrue();
+
+		assertThat(examRow.hashCode()).isPositive();
+
+		assertThat(examRow.toString()).isEqualTo(examRow.getDescription());
+	}
+
+	@Test
+	public void testExamGetterSetter() throws Exception {
+		String code = _setupTestExam(false);
+		Exam exam = examIoOperationRepository.findOne(code);
+		exam.setLock(-99);
+		assertThat(exam.getLock()).isEqualTo(-99);
+
+		assertThat(exam.getSearchString()).isEqualTo("zztestdescription");
+	}
+
+	@Test
+	public void testIoExamSanitize() throws Exception {
+		Method method = examIoOperation.getClass().getDeclaredMethod("sanitize", String.class);
+		method.setAccessible(true);
+		assertThat((String) method.invoke(examIoOperation, "abc'de'f")).isEqualTo("abc''de''f");
+		assertThat((String) method.invoke(examIoOperation, (String) null)).isNull();
+		assertThat((String) method.invoke(examIoOperation, "abcdef")).isEqualTo("abcdef");
+	}
+
+	@Test
+	public void testIoExamRowSanitize() throws Exception {
+		Method method = examRowIoOperation.getClass().getDeclaredMethod("sanitize", String.class);
+		method.setAccessible(true);
+		assertThat((String) method.invoke(examRowIoOperation, "abc'de'f")).isEqualTo("abc''de''f");
+		assertThat((String) method.invoke(examRowIoOperation, (String) null)).isNull();
+		assertThat((String) method.invoke(examRowIoOperation, "abcdef")).isEqualTo("abcdef");
 	}
 
 	private String _setupTestExam(boolean usingSet) throws OHException {

--- a/src/test/java/org/isf/exatype/test/Tests.java
+++ b/src/test/java/org/isf/exatype/test/Tests.java
@@ -22,14 +22,20 @@
 package org.isf.exatype.test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.ArrayList;
 
+import org.assertj.core.api.Condition;
 import org.isf.OHCoreTestCase;
+import org.isf.exatype.manager.ExamTypeBrowserManager;
 import org.isf.exatype.model.ExamType;
 import org.isf.exatype.service.ExamTypeIoOperation;
 import org.isf.exatype.service.ExamTypeIoOperationRepository;
+import org.isf.utils.exception.OHDataIntegrityViolationException;
+import org.isf.utils.exception.OHDataValidationException;
 import org.isf.utils.exception.OHException;
+import org.isf.utils.exception.OHServiceException;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -43,6 +49,8 @@ public class Tests extends OHCoreTestCase {
 	ExamTypeIoOperation examTypeIoOperation;
 	@Autowired
 	ExamTypeIoOperationRepository examTypeIoOperationRepository;
+	@Autowired
+	ExamTypeBrowserManager examTypeBrowserManager;
 
 	@BeforeClass
 	public static void setUpClass() {
@@ -108,6 +116,104 @@ public class Tests extends OHCoreTestCase {
 		assertThat(result).isTrue();
 		result = examTypeIoOperation.isCodePresent(code);
 		assertThat(result).isFalse();
+	}
+
+	@Test
+	public void testMgrGetExamType() throws Exception {
+		String code = _setupTestExamType(false);
+		ExamType foundExamType = examTypeIoOperationRepository.findOne(code);
+		ArrayList<ExamType> examTypes = examTypeBrowserManager.getExamType();
+		assertThat(examTypes).contains(foundExamType);
+	}
+
+	@Test
+	public void testMgrUpdateExamType() throws Exception {
+		String code = _setupTestExamType(false);
+		ExamType foundExamType = examTypeIoOperationRepository.findOne(code);
+		foundExamType.setDescription("Update");
+		boolean result = examTypeBrowserManager.updateExamType(foundExamType);
+		assertThat(result).isTrue();
+		ExamType updateExamType = examTypeIoOperationRepository.findOne(code);
+		assertThat(updateExamType.getDescription()).isEqualTo("Update");
+	}
+
+	@Test
+	public void testMgrNewExamType() throws Exception {
+		ExamType examType = testExamType.setup(true);
+		boolean result = examTypeBrowserManager.newExamType(examType);
+		assertThat(result).isTrue();
+		_checkExamTypeIntoDb(examType.getCode());
+	}
+
+	@Test
+	public void testMgrIsCodePresent() throws Exception {
+		String code = _setupTestExamType(false);
+		boolean result = examTypeBrowserManager.codeControl(code);
+		assertThat(result).isTrue();
+	}
+
+	@Test
+	public void testMgrDeleteExamType() throws Exception {
+		String code = _setupTestExamType(false);
+		ExamType foundExamType = examTypeIoOperationRepository.findOne(code);
+		boolean result = examTypeBrowserManager.deleteExamType(foundExamType);
+		assertThat(result).isTrue();
+		result = examTypeBrowserManager.codeControl(code);
+		assertThat(result).isFalse();
+	}
+
+	@Test
+	public void testMgrExamTypeValidation() throws Exception {
+		String code = _setupTestExamType(false);
+		ExamType foundExamType = examTypeIoOperationRepository.findOne(code);
+
+		// code is empty
+		foundExamType.setCode("");
+		assertThatThrownBy(() -> examTypeBrowserManager.updateExamType(foundExamType))
+				.isInstanceOf(OHDataValidationException.class)
+				.has(
+						new Condition<Throwable>(
+								(e -> ((OHServiceException) e).getMessages().size() == 1), "Expecting single validation error")
+				);
+
+		// code too long
+		foundExamType.setCode("abcdefghijk");
+		assertThatThrownBy(() -> examTypeBrowserManager.updateExamType(foundExamType))
+				.isInstanceOf(OHDataValidationException.class)
+				.has(
+						new Condition<Throwable>(
+								(e -> ((OHServiceException) e).getMessages().size() == 1), "Expecting single validation error")
+				);
+
+		// description is empty
+		foundExamType.setCode(code);
+		String description = foundExamType.getDescription();
+		foundExamType.setDescription("");
+		assertThatThrownBy(() -> examTypeBrowserManager.updateExamType(foundExamType))
+				.isInstanceOf(OHDataValidationException.class)
+				.has(
+						new Condition<Throwable>(
+								(e -> ((OHServiceException) e).getMessages().size() == 1), "Expecting single validation error")
+				);
+
+		// duplicate key on insert
+		foundExamType.setDescription(description);
+		assertThatThrownBy(() -> examTypeBrowserManager.newExamType(foundExamType))
+				.isInstanceOf(OHDataIntegrityViolationException.class)
+				.has(
+						new Condition<Throwable>(
+								(e -> ((OHServiceException) e).getMessages().size() == 1), "Expecting single validation error")
+				);
+	}
+
+	@Test
+	public void testPatientExamTypeHashToString() throws Exception {
+		String code = _setupTestExamType(false);
+		ExamType foundExamType = examTypeIoOperationRepository.findOne(code);
+
+		assertThat(foundExamType.hashCode()).isPositive();
+
+		assertThat(foundExamType.toString()).isEqualTo(foundExamType.getDescription());
 	}
 
 	private String _setupTestExamType(boolean usingSet) throws OHException {


### PR DESCRIPTION
Increase test coverage for `exa`, `examination` and `exatype` packages.
Also reformat `Manager` classes to meet project standards and remove unused `logger` variables.

All tests pass locally.

Coverage before:
![image](https://user-images.githubusercontent.com/1105445/101154891-5b995580-35f4-11eb-866e-50aa5cf11349.png)

Coverage after:
![image](https://user-images.githubusercontent.com/1105445/101154919-68b64480-35f4-11eb-9dec-61f6b74d8eca.png)
