### PR TITLE
Chore: Remove NPE in logging statement

### DIFF
--- a/src/main/java/org/isf/serviceprinting/manager/PrintReceipt.java
+++ b/src/main/java/org/isf/serviceprinting/manager/PrintReceipt.java
@@ -108,7 +108,6 @@ public class PrintReceipt {
 				}
 			} else {
 				logger.debug("printer was not found.");
-				logger.debug(defaultPrintService.toString());
 			}
 		} catch (Exception e) {
 			e.printStackTrace();


### PR DESCRIPTION
In the logging statement the else clause is reached only when `defaultPrinterService` is null.   Attempting to `toString()` on a null value results in a NPE.  Just removed the statement as the other logging statement indicates the problem.

Found with SpotBugs.