### PR TITLE
OP-383 increase coverage Hospital and Lab; reformat managers

### DIFF
--- a/src/main/java/org/isf/hospital/manager/HospitalBrowsingManager.java
+++ b/src/main/java/org/isf/hospital/manager/HospitalBrowsingManager.java
@@ -24,39 +24,36 @@ package org.isf.hospital.manager;
 import org.isf.hospital.model.Hospital;
 import org.isf.hospital.service.HospitalIoOperations;
 import org.isf.utils.exception.OHServiceException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 /**
  * Class that provides gui separation from database operations and gives some
  * useful logic manipulations of the dynamic data (memory)
- * 
+ *
  * @author bob
- * 
  */
 @Component
 public class HospitalBrowsingManager {
-	
-	private final Logger logger = LoggerFactory.getLogger(HospitalBrowsingManager.class);
-	
+
 	@Autowired
 	private HospitalIoOperations ioOperations;
 
 	/**
 	 * Reads from database hospital information
-	 * 
+	 *
 	 * @return {@link Hospital} object
-	 * @throws OHServiceException 
+	 * @throws OHServiceException
 	 */
 	public Hospital getHospital() throws OHServiceException {
 		return ioOperations.getHospital();
 	}
+
 	/**
 	 * Reads from database currency cod
+	 *
 	 * @return currency cod
-	 * @throws OHServiceException 
+	 * @throws OHServiceException
 	 */
 	public String getHospitalCurrencyCod() throws OHServiceException {
 		return ioOperations.getHospitalCurrencyCod();
@@ -64,12 +61,12 @@ public class HospitalBrowsingManager {
 
 	/**
 	 * Updates hospital information
-	 * 
+	 *
 	 * @return <code>true</code> if the hospital informations have been updated, <code>false</code> otherwise
-	 * @throws OHServiceException 
+	 * @throws OHServiceException
 	 */
 	public Hospital updateHospital(Hospital hospital) throws OHServiceException {
 		return ioOperations.updateHospital(hospital);
-    }	
+	}
 }
 	

--- a/src/main/java/org/isf/lab/manager/LabManager.java
+++ b/src/main/java/org/isf/lab/manager/LabManager.java
@@ -58,7 +58,6 @@ public class LabManager {
 
 
 	protected HashMap<String, String> materialHashMap;
-	protected String abcdefg;
 
 	/**
 	 * Verify if the object is valid for CRUD and return a list of errors, if any

--- a/src/main/java/org/isf/lab/manager/LabManager.java
+++ b/src/main/java/org/isf/lab/manager/LabManager.java
@@ -25,7 +25,7 @@ package org.isf.lab.manager;
  * LabManager - laboratory exam manager class
  * -----------------------------------------
  * modification history
- * 10/11/2006 - ross - added editing capability 
+ * 10/11/2006 - ross - added editing capability
  *------------------------------------------*/
 
 import java.util.ArrayList;
@@ -41,8 +41,8 @@ import org.isf.lab.model.LaboratoryForPrint;
 import org.isf.lab.model.LaboratoryRow;
 import org.isf.lab.service.LabIoOperations;
 import org.isf.patient.model.Patient;
-import org.isf.utils.exception.OHServiceException;
 import org.isf.utils.exception.OHDataValidationException;
+import org.isf.utils.exception.OHServiceException;
 import org.isf.utils.exception.model.OHExceptionMessage;
 import org.isf.utils.exception.model.OHSeverityLevel;
 import org.isf.utils.validator.DefaultSorter;
@@ -55,106 +55,92 @@ public class LabManager {
 
 	@Autowired
 	private LabIoOperations ioOperations;
-	
-	public void setIoOperations(LabIoOperations ioOperations) {
-		this.ioOperations = ioOperations;
-	}
-	
+
+
 	protected HashMap<String, String> materialHashMap;
-	
-	/**
-	 * For JUnitTest org.isf.lab.test.Tests.testManagerNewLaboratoryTransaction()
-	 * @param ioOperations
-	 */
-	public LabManager(LabIoOperations ioOperations) {
-		if (ioOperations != null)
-			this.ioOperations = ioOperations;
-	}
-	
+	protected String abcdefg;
+
 	/**
 	 * Verify if the object is valid for CRUD and return a list of errors, if any
+	 *
 	 * @param laboratory
-	 * @throws OHDataValidationException 
+	 * @throws OHDataValidationException
 	 */
 	protected void validateLaboratory(Laboratory laboratory) throws OHDataValidationException {
-        List<OHExceptionMessage> errors = new ArrayList<OHExceptionMessage>();
-        if (laboratory.getDate() == null) laboratory.setDate(new GregorianCalendar());
-        if (laboratory.getExam().getProcedure() == 2) 
-		{
+		List<OHExceptionMessage> errors = new ArrayList<OHExceptionMessage>();
+		if (laboratory.getDate() == null)
+			laboratory.setDate(new GregorianCalendar());
+		if (laboratory.getExam() != null && laboratory.getExam().getProcedure() == 2) {
 			laboratory.setResult(MessageBundle.getMessage("angal.lab.multipleresults"));
 		}
-        
-        //Check Exam Date
-  		if (laboratory.getExamDate() == null) {
-  			errors.add(new OHExceptionMessage("noExamDateError", 
-  	        		MessageBundle.getMessage("angal.lab.pleaseinsertavalidexamdate"), 
-  	        		OHSeverityLevel.ERROR));
-  		}
-  		//Check Patient
-		if (GeneralData.LABEXTENDED && laboratory.getPatient() == null) 
-		{
-			errors.add(new OHExceptionMessage("patientNullError", 
-	        		MessageBundle.getMessage("angal.lab.pleaseselectapatient"), 
-	        		OHSeverityLevel.ERROR));
+
+		//Check Exam Date
+		if (laboratory.getExamDate() == null) {
+			errors.add(new OHExceptionMessage("noExamDateError",
+					MessageBundle.getMessage("angal.lab.pleaseinsertavalidexamdate"),
+					OHSeverityLevel.ERROR));
 		}
-		else if (GeneralData.LABEXTENDED && laboratory.getPatient() != null) 
-		{
+		//Check Patient
+		if (GeneralData.LABEXTENDED && laboratory.getPatient() == null) {
+			errors.add(new OHExceptionMessage("patientNullError",
+					MessageBundle.getMessage("angal.lab.pleaseselectapatient"),
+					OHSeverityLevel.ERROR));
+		} else if (GeneralData.LABEXTENDED && laboratory.getPatient() != null) {
 			/*
-			 * Age and Sex has not to be updated 
+			 * Age and Sex has not to be updated
 			 * for reporting purposes
 			 */
 			laboratory.setPatName(laboratory.getPatient().getName());
 			laboratory.setAge(laboratory.getPatient().getAge());
 			laboratory.setSex(String.valueOf(laboratory.getPatient().getSex()));
-		} 
-		else if (laboratory.getPatient() == null) 
-		{
+		} else if (laboratory.getPatient() == null) {
 			String sex = laboratory.getSex().toUpperCase();
 			if (!(sex.equals("M") || sex.equals("F"))) {
-				errors.add(new OHExceptionMessage("invalidSexError", 
-		        		MessageBundle.getMessage("angal.lab.pleaseinsertmformaleorfforfemale"), 
-		        		OHSeverityLevel.ERROR));
+				errors.add(new OHExceptionMessage("invalidSexError",
+						MessageBundle.getMessage("angal.lab.pleaseinsertmformaleorfforfemale"),
+						OHSeverityLevel.ERROR));
 			}
-			if (laboratory.getAge()<0) {
-				errors.add(new OHExceptionMessage("invalidAgeError", 
-		        		MessageBundle.getMessage("angal.lab.insertvalidage"), 
-		        		OHSeverityLevel.ERROR));
+			if (laboratory.getAge() < 0) {
+				errors.add(new OHExceptionMessage("invalidAgeError",
+						MessageBundle.getMessage("angal.lab.insertvalidage"),
+						OHSeverityLevel.ERROR));
 			}
 		}
-		if(laboratory.getExam() == null){
-	        errors.add(new OHExceptionMessage("examNullOrEmptyError", 
-	        		MessageBundle.getMessage("angal.lab.pleaseselectanexam"), 
-	        		OHSeverityLevel.ERROR));
-        }
-		if (laboratory.getResult().isEmpty()){
-	        errors.add(new OHExceptionMessage("labRowNullOrEmptyError", 
-	        		MessageBundle.getMessage("angal.labnew.someexamswithoutresultpleasecheck"), 
-	        		OHSeverityLevel.ERROR));
-        }
-        if(laboratory.getMaterial().isEmpty() ){
-	        errors.add(new OHExceptionMessage("materialEmptyError", 
-	        		MessageBundle.getMessage("angal.lab.pleaseselectamaterial"), 
-	        		OHSeverityLevel.ERROR));
-        }
-        if(laboratory.getExamDate() == null){
-	        errors.add(new OHExceptionMessage("examDateNullError", 
-	        		MessageBundle.getMessage("angal.lab.pleaseinsertexamdate"), 
-	        		OHSeverityLevel.ERROR));
-        }
-        if(laboratory.getInOutPatient().isEmpty()){
-	        errors.add(new OHExceptionMessage("ipdOPDEmptyError", 
-	        		MessageBundle.getMessage("angal.lab.pleaseinsertiforipdoroforopd"), 
-	        		OHSeverityLevel.ERROR));
-        }
-        if (!errors.isEmpty()){
-	        throw new OHDataValidationException(errors);
-	    }
-    }
+		if (laboratory.getExam() == null) {
+			errors.add(new OHExceptionMessage("examNullOrEmptyError",
+					MessageBundle.getMessage("angal.lab.pleaseselectanexam"),
+					OHSeverityLevel.ERROR));
+		}
+		if (laboratory.getResult().isEmpty()) {
+			errors.add(new OHExceptionMessage("labRowNullOrEmptyError",
+					MessageBundle.getMessage("angal.labnew.someexamswithoutresultpleasecheck"),
+					OHSeverityLevel.ERROR));
+		}
+		if (laboratory.getMaterial().isEmpty()) {
+			errors.add(new OHExceptionMessage("materialEmptyError",
+					MessageBundle.getMessage("angal.lab.pleaseselectamaterial"),
+					OHSeverityLevel.ERROR));
+		}
+		if (laboratory.getExamDate() == null) {
+			errors.add(new OHExceptionMessage("examDateNullError",
+					MessageBundle.getMessage("angal.lab.pleaseinsertexamdate"),
+					OHSeverityLevel.ERROR));
+		}
+		if (laboratory.getInOutPatient().isEmpty()) {
+			errors.add(new OHExceptionMessage("ipdOPDEmptyError",
+					MessageBundle.getMessage("angal.lab.pleaseinsertiforipdoroforopd"),
+					OHSeverityLevel.ERROR));
+		}
+		if (!errors.isEmpty()) {
+			throw new OHDataValidationException(errors);
+		}
+	}
 
 	/**
 	 * Return the whole list of exams ({@link Laboratory}s) within last year.
+	 *
 	 * @return the list of {@link Laboratory}s. It could be <code>empty</code>.
-	 * @throws OHServiceException 
+	 * @throws OHServiceException
 	 */
 	public ArrayList<Laboratory> getLaboratory() throws OHServiceException {
 		return ioOperations.getLaboratory();
@@ -162,10 +148,10 @@ public class LabManager {
 
 	/**
 	 * Return a list of exams ({@link Laboratory}s) related to a {@link Patient}.
-	 * 
+	 *
 	 * @param aPatient - the {@link Patient}.
 	 * @return the list of {@link Laboratory}s related to the {@link Patient}. It could be <code>empty</code>.
-	 * @throws OHServiceException 
+	 * @throws OHServiceException
 	 */
 	public ArrayList<Laboratory> getLaboratory(Patient aPatient) throws OHServiceException {
 		return ioOperations.getLaboratory(aPatient);
@@ -173,67 +159,70 @@ public class LabManager {
 
 	/*
 	 * NO LONGER USED
-	 * 
+	 *
 	 * public ArrayList<Laboratory> getLaboratory(String aCode){ return
 	 * ioOperations.getLaboratory(); }
 	 */
 
 	/**
 	 * Return a list of exams ({@link Laboratory}s) between specified dates and matching passed exam name
+	 *
 	 * @param exam - the exam name as <code>String</code>
 	 * @param dateFrom - the lower date for the range
 	 * @param dateTo - the highest date for the range
 	 * @return the list of {@link Laboratory}s. It could be <code>empty</code>.
-	 * @throws OHServiceException 
+	 * @throws OHServiceException
 	 */
 	public ArrayList<Laboratory> getLaboratory(String exam, GregorianCalendar dateFrom, GregorianCalendar dateTo) throws OHServiceException {
 		return ioOperations.getLaboratory(exam, dateFrom, dateTo);
 	}
 
 	/**
-	 * Return a list of exams suitable for printing ({@link LaboratoryForPrint}s) 
-	 * between specified dates and matching passed exam name. If a lab has multiple 
+	 * Return a list of exams suitable for printing ({@link LaboratoryForPrint}s)
+	 * between specified dates and matching passed exam name. If a lab has multiple
 	 * results, these are concatenated and added to the result string
+	 *
 	 * @param exam - the exam name as <code>String</code>
 	 * @param dateFrom - the lower date for the range
 	 * @param dateTo - the highest date for the range
 	 * @return the list of {@link LaboratoryForPrint}s . It could be <code>empty</code>.
-	 * @throws OHServiceException 
+	 * @throws OHServiceException
 	 */
 	public ArrayList<LaboratoryForPrint> getLaboratoryForPrint(String exam, GregorianCalendar dateFrom, GregorianCalendar dateTo) throws OHServiceException {
 		ArrayList<LaboratoryForPrint> labs = ioOperations.getLaboratoryForPrint(exam, dateFrom, dateTo);
 		setLabMultipleResults(labs);
-			
+
 		return labs;
 	}
 
 	/**
 	 * Inserts one Laboratory exam {@link Laboratory} (All Procedures)
+	 *
 	 * @param laboratory - the laboratory with its result (Procedure 1)
 	 * @param labRow - the list of results (Procedure 2) - it can be <code>null</code>
 	 * @return <code>true</code> if the exam has been inserted, <code>false</code> otherwise
-	 * @throws OHServiceException 
+	 * @throws OHServiceException
 	 */
 	public boolean newLaboratory(Laboratory laboratory, ArrayList<String> labRow) throws OHServiceException {
 		validateLaboratory(laboratory);
 		if (laboratory.getExam().getProcedure() == 1) {
 			return ioOperations.newLabFirstProcedure(laboratory);
-		}
-		else if (laboratory.getExam().getProcedure() == 2) {
+		} else if (laboratory.getExam().getProcedure() == 2) {
 			if (labRow == null || labRow.isEmpty())
-				throw new OHDataValidationException(new OHExceptionMessage("labRowNullOrEmptyError", 
-		        		MessageBundle.getMessage("angal.labnew.someexamswithoutresultpleasecheck"), 
-		        		OHSeverityLevel.ERROR));
+				throw new OHDataValidationException(new OHExceptionMessage("labRowNullOrEmptyError",
+						MessageBundle.getMessage("angal.labnew.someexamswithoutresultpleasecheck"),
+						OHSeverityLevel.ERROR));
 			return ioOperations.newLabSecondProcedure(laboratory, labRow);
-		}
-		else {
-			throw new OHDataValidationException(new OHExceptionMessage("unknownProcedureError", 
-	        		MessageBundle.getMessage("angal.lab.unknownprocedure"), 
-	        		OHSeverityLevel.ERROR));
+		} else {
+			throw new OHDataValidationException(new OHExceptionMessage("unknownProcedureError",
+					MessageBundle.getMessage("angal.lab.unknownprocedure"),
+					OHSeverityLevel.ERROR));
 		}
 	}
+
 	/**
 	 * Inserts one Laboratory exam {@link Laboratory} (All Procedures)
+	 *
 	 * @param laboratory - the laboratory with its result (Procedure 1)
 	 * @param labRow - the list of results (Procedure 2) - it can be <code>null</code>
 	 * @return <code>true</code> if the exam has been inserted, <code>false</code> otherwise
@@ -243,24 +232,23 @@ public class LabManager {
 		validateLaboratory(laboratory);
 		if (laboratory.getExam().getProcedure() == 1) {
 			return ioOperations.newLabFirstProcedure(laboratory);
-		}
-		else if (laboratory.getExam().getProcedure() == 2) {
+		} else if (laboratory.getExam().getProcedure() == 2) {
 			if (labRow == null || labRow.isEmpty())
-				throw new OHDataValidationException(new OHExceptionMessage("labRowNullOrEmptyError", 
-		        		MessageBundle.getMessage("angal.labnew.someexamswithoutresultpleasecheck"), 
-		        		OHSeverityLevel.ERROR));
+				throw new OHDataValidationException(new OHExceptionMessage("labRowNullOrEmptyError",
+						MessageBundle.getMessage("angal.labnew.someexamswithoutresultpleasecheck"),
+						OHSeverityLevel.ERROR));
 			return ioOperations.newLabSecondProcedure2(laboratory, labRow);
-		}else if (laboratory.getExam().getProcedure() == 3) {
+		} else if (laboratory.getExam().getProcedure() == 3) {
 			return ioOperations.newLabFirstProcedure(laboratory);
-		}
-		else 
-			throw new OHDataValidationException(new OHExceptionMessage("unknownProcedureError", 
-	        		MessageBundle.getMessage("angal.lab.unknownprocedure"), 
-	        		OHSeverityLevel.ERROR));
+		} else
+			throw new OHDataValidationException(new OHExceptionMessage("unknownProcedureError",
+					MessageBundle.getMessage("angal.lab.unknownprocedure"),
+					OHSeverityLevel.ERROR));
 	}
-	
+
 	/**
 	 * Inserts one Laboratory exam {@link Laboratory} (All Procedures)
+	 *
 	 * @param laboratory - the laboratory with its result (Procedure 1)
 	 * @param labRow - the list of results (Procedure 2) - it can be <code>null</code>
 	 * @return <code>true</code> if the exam has been inserted, <code>false</code> otherwise
@@ -270,87 +258,89 @@ public class LabManager {
 		validateLaboratory(laboratory);
 		if (laboratory.getExam().getProcedure() == 1) {
 			return ioOperations.updateLabFirstProcedure(laboratory);
-		}
-		else if (laboratory.getExam().getProcedure() == 2) {
+		} else if (laboratory.getExam().getProcedure() == 2) {
 			if (labRow == null || labRow.isEmpty())
-				throw new OHDataValidationException(new OHExceptionMessage("labRowNullOrEmptyError", 
-		        		MessageBundle.getMessage("angal.labnew.someexamswithoutresultpleasecheck"), 
-		        		OHSeverityLevel.ERROR));
+				throw new OHDataValidationException(new OHExceptionMessage("labRowNullOrEmptyError",
+						MessageBundle.getMessage("angal.labnew.someexamswithoutresultpleasecheck"),
+						OHSeverityLevel.ERROR));
 			return ioOperations.updateLabSecondProcedure(laboratory, labRow);
-		}else if (laboratory.getExam().getProcedure() == 3) {
+		} else if (laboratory.getExam().getProcedure() == 3) {
 			//TODO: is it enough to call FirstProcedure?
 			return ioOperations.updateLabFirstProcedure(laboratory);
-		}
-		else 
-			throw new OHDataValidationException(new OHExceptionMessage("unknownProcedureError", 
-	        		MessageBundle.getMessage("angal.lab.unknownprocedure"), 
-	        		OHSeverityLevel.ERROR));
+		} else
+			throw new OHDataValidationException(new OHExceptionMessage("unknownProcedureError",
+					MessageBundle.getMessage("angal.lab.unknownprocedure"),
+					OHSeverityLevel.ERROR));
 	}
-	
+
 	/**
 	 * Inserts list of Laboratory exams {@link Laboratory} (All Procedures)
+	 *
 	 * @param labList - the laboratory list with results
 	 * @param labRowList - the list of results, it can be <code>null</code>
 	 * @return <code>true</code> if the exam has been inserted, <code>false</code> otherwise
 	 * @throws OHServiceException
 	 */
-	@Transactional(rollbackFor=OHServiceException.class)
+	@Transactional(rollbackFor = OHServiceException.class)
 	public boolean newLaboratory(List<Laboratory> labList, ArrayList<ArrayList<String>> labRowList) throws OHServiceException {
 		if (labList.size() == 0)
-			throw new OHDataValidationException(new OHExceptionMessage("emptyListError", 
-		    		MessageBundle.getMessage("angal.labnew.noexamsinserted"), 
-		    		OHSeverityLevel.ERROR));
+			throw new OHDataValidationException(new OHExceptionMessage("emptyListError",
+					MessageBundle.getMessage("angal.labnew.noexamsinserted"),
+					OHSeverityLevel.ERROR));
 		if (labList.size() != labRowList.size())
-			throw new OHDataValidationException(new OHExceptionMessage("labRowNullOrEmptyError", 
-		    		MessageBundle.getMessage("angal.labnew.someexamswithoutresultpleasecheck"), 
-		    		OHSeverityLevel.ERROR));
+			throw new OHDataValidationException(new OHExceptionMessage("labRowNullOrEmptyError",
+					MessageBundle.getMessage("angal.labnew.someexamswithoutresultpleasecheck"),
+					OHSeverityLevel.ERROR));
 		boolean result = true;
 		for (int i = 0; i < labList.size(); i++) {
 			result = result && newLaboratory(labList.get(i), labRowList.get(i));
 		}
 		return result;
 	}
-        
-        /**
+
+	/**
 	 * Inserts list of Laboratory exams {@link Laboratory} (All Procedures)
+	 *
 	 * @param labList - the laboratory list with results
 	 * @param labRowList - the list of results, it can be <code>null</code>
 	 * @return <code>true</code> if the exam has been inserted, <code>false</code> otherwise
 	 * @throws OHServiceException
 	 */
-	@Transactional(rollbackFor=OHServiceException.class)
+	@Transactional(rollbackFor = OHServiceException.class)
 	public boolean newLaboratory2(List<Laboratory> labList, ArrayList<ArrayList<LaboratoryRow>> labRowList) throws OHServiceException {
 		if (labList.size() == 0)
-			throw new OHDataValidationException(new OHExceptionMessage("emptyListError", 
-		    		MessageBundle.getMessage("angal.labnew.noexamsinserted"), 
-		    		OHSeverityLevel.ERROR));
+			throw new OHDataValidationException(new OHExceptionMessage("emptyListError",
+					MessageBundle.getMessage("angal.labnew.noexamsinserted"),
+					OHSeverityLevel.ERROR));
 		if (labList.size() != labRowList.size())
-			throw new OHDataValidationException(new OHExceptionMessage("labRowNullOrEmptyError", 
-		    		MessageBundle.getMessage("angal.labnew.someexamswithoutresultpleasecheck"), 
-		    		OHSeverityLevel.ERROR));
+			throw new OHDataValidationException(new OHExceptionMessage("labRowNullOrEmptyError",
+					MessageBundle.getMessage("angal.labnew.someexamswithoutresultpleasecheck"),
+					OHSeverityLevel.ERROR));
 		boolean result = true;
 		for (int i = 0; i < labList.size(); i++) {
 			result = result && newLaboratory2(labList.get(i), labRowList.get(i));
 		}
 		return result;
 	}
-	
+
 	/**
 	 * Inserts one Laboratory exam {@link Laboratory} (Procedure One)
+	 *
 	 * @param laboratory - the {@link Laboratory} to insert
 	 * @return <code>true</code> if the exam has been inserted, <code>false</code> otherwise
-	 * @throws OHServiceException 
+	 * @throws OHServiceException
 	 */
 	protected boolean newLabFirstProcedure(Laboratory laboratory) throws OHServiceException {
 		return ioOperations.newLabFirstProcedure(laboratory);
 	}
 
 	/**
-	 * Inserts one Laboratory exam {@link Laboratory} with multiple results (Procedure Two) 
+	 * Inserts one Laboratory exam {@link Laboratory} with multiple results (Procedure Two)
+	 *
 	 * @param laboratory - the {@link Laboratory} to insert
 	 * @param labRow - the list of results ({@link String}s)
 	 * @return <code>true</code> if the exam has been inserted with all its results, <code>false</code> otherwise
-	 * @throws OHServiceException 
+	 * @throws OHServiceException
 	 */
 	protected boolean newLabSecondProcedure(Laboratory laboratory, ArrayList<String> labRow) throws OHServiceException {
 		return ioOperations.newLabSecondProcedure(laboratory, labRow);
@@ -359,6 +349,7 @@ public class LabManager {
 	/**
 	 * Update an already existing Laboratory exam {@link Laboratory} (Procedure One).
 	 * If old exam was Procedure Two all its releated result are deleted.
+	 *
 	 * @param laboratory - the {@link Laboratory} to update
 	 * @return <code>true</code> if the exam has been updated, <code>false</code> otherwise
 	 * @throws OHServiceException
@@ -372,9 +363,10 @@ public class LabManager {
 	/**
 	 * Update an already existing Laboratory exam {@link Laboratory} (Procedure Two).
 	 * Previous results are deleted and replaced with new ones.
+	 *
 	 * @param laboratory - the {@link Laboratory} to update
 	 * @return <code>true</code> if the exam has been updated with all its results, <code>false</code> otherwise
-	 * @throws OHServiceException 
+	 * @throws OHServiceException
 	 * @deprecated use updateLaboratory() for all procedures
 	 */
 	@Deprecated
@@ -385,27 +377,28 @@ public class LabManager {
 	/**
 	 * Delete a Laboratory exam {@link Laboratory} (Procedure One or Two).
 	 * Previous results, if any, are deleted as well.
+	 *
 	 * @param laboratory - the {@link Laboratory} to delete
 	 * @return <code>true</code> if the exam has been deleted with all its results, if any. <code>false</code> otherwise
-	 * @throws OHServiceException 
+	 * @throws OHServiceException
 	 */
 	public boolean deleteLaboratory(Laboratory laboratory) throws OHServiceException {
 		return ioOperations.deleteLaboratory(laboratory);
 	}
 
 	private void setLabMultipleResults(List<LaboratoryForPrint> labs) throws OHServiceException {
-		
+
 		List<LaboratoryRow> rows = null;
-		
+
 		for (LaboratoryForPrint lab : labs) {
 			String labResult = lab.getResult();
 			if (labResult.equalsIgnoreCase(MessageBundle.getMessage("angal.lab.multipleresults"))) {
 				rows = ioOperations.getLabRow(lab.getCode());
-				
+
 				if (rows == null || rows.size() == 0) {
 					lab.setResult(MessageBundle.getMessage("angal.lab.allnegative"));
 				} else {
-					lab.setResult(MessageBundle.getMessage("angal.lab.positive")+" : "+rows.get(0).getDescription());
+					lab.setResult(MessageBundle.getMessage("angal.lab.positive") + " : " + rows.get(0).getDescription());
 					for (LaboratoryRow row : rows) {
 						labResult += ("," + row.getDescription());
 					}
@@ -414,16 +407,19 @@ public class LabManager {
 			}
 		}
 	}
-	
+
 	public String getMaterialTranslated(String materialKey) {
-		if (materialHashMap == null) buildMaterialHashMap();
-		if (materialKey == null || !materialHashMap.containsKey(materialKey)) 
-			return MessageBundle.getMessage("angal.lab.undefined"); 
-		else return materialHashMap.get(materialKey);
+		if (materialHashMap == null)
+			buildMaterialHashMap();
+		if (materialKey == null || !materialHashMap.containsKey(materialKey))
+			return MessageBundle.getMessage("angal.lab.undefined");
+		else
+			return materialHashMap.get(materialKey);
 	}
-	
+
 	public String getMaterialKey(String description) {
-		if (materialHashMap == null) buildMaterialHashMap();
+		if (materialHashMap == null)
+			buildMaterialHashMap();
 		String key = "undefined";
 		for (String value : materialHashMap.keySet()) {
 			if (materialHashMap.get(value).equals(description)) {
@@ -433,7 +429,7 @@ public class LabManager {
 		}
 		return key;
 	}
-	
+
 	private void buildMaterialHashMap() {
 		materialHashMap = new HashMap<String, String>();
 		materialHashMap.put("undefined", MessageBundle.getMessage("angal.lab.undefined"));
@@ -446,7 +442,7 @@ public class LabManager {
 		materialHashMap.put("tissues", MessageBundle.getMessage("angal.lab.tissues"));
 		materialHashMap.put("film", MessageBundle.getMessage("angal.lab.film"));
 	}
-	
+
 	/**
 	 * return a list of material descriptions (default: undefined):
 	 * undefined,
@@ -458,22 +454,24 @@ public class LabManager {
 	 * swabs,
 	 * tissues,
 	 * film
+	 *
 	 * @return
 	 */
 	public ArrayList<String> getMaterialList() {
-		if (materialHashMap == null) buildMaterialHashMap();
+		if (materialHashMap == null)
+			buildMaterialHashMap();
 		ArrayList<String> materialDescriptionList = new ArrayList<String>(materialHashMap.values());
-		Collections.sort(materialDescriptionList,  new DefaultSorter(MessageBundle.getMessage("angal.lab.undefined")));
+		Collections.sort(materialDescriptionList, new DefaultSorter(MessageBundle.getMessage("angal.lab.undefined")));
 		return materialDescriptionList;
 	}
-	
-    /**
-    * Returns the max progressive number within specified month of specified year.
-    * 
-    * @param lab
-    * @return <code>int</code> - the progressive number in the month
-     * @throws org.isf.utils.exception.OHServiceException
-    */
+
+	/**
+	 * Returns the max progressive number within specified month of specified year.
+	 *
+	 * @param lab
+	 * @return <code>int</code> - the progressive number in the month
+	 * @throws org.isf.utils.exception.OHServiceException
+	 */
    /*public int getProgMonth(int month, int year)  throws OHServiceException {
         return ioOperations.getProgMonth(month, year);
    }*/

--- a/src/main/java/org/isf/lab/manager/LabRowManager.java
+++ b/src/main/java/org/isf/lab/manager/LabRowManager.java
@@ -27,26 +27,23 @@ import org.isf.lab.model.Laboratory;
 import org.isf.lab.model.LaboratoryRow;
 import org.isf.lab.service.LabIoOperations;
 import org.isf.utils.exception.OHServiceException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 @Component
 public class LabRowManager {
 
-	private final Logger logger = LoggerFactory.getLogger(LabRowManager.class);
-	
 	@Autowired
 	private LabIoOperations ioOperations;
-	
+
 	/**
 	 * Return a list of results ({@link LaboratoryRow}s) for passed lab entry.
+	 *
 	 * @param code - the {@link Laboratory} record ID.
 	 * @return the list of {@link LaboratoryRow}s. It could be <code>empty</code>
-	 * @throws OHServiceException 
+	 * @throws OHServiceException
 	 */
-	public ArrayList<LaboratoryRow> getLabRowByLabId(Integer code) throws OHServiceException{
+	public ArrayList<LaboratoryRow> getLabRowByLabId(Integer code) throws OHServiceException {
 		return ioOperations.getLabRow(code);
 	}
 }

--- a/src/test/java/org/isf/hospital/test/Tests.java
+++ b/src/test/java/org/isf/hospital/test/Tests.java
@@ -23,7 +23,10 @@ package org.isf.hospital.test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.lang.reflect.Method;
+
 import org.isf.OHCoreTestCase;
+import org.isf.hospital.manager.HospitalBrowsingManager;
 import org.isf.hospital.model.Hospital;
 import org.isf.hospital.service.HospitalIoOperationRepository;
 import org.isf.hospital.service.HospitalIoOperations;
@@ -41,6 +44,8 @@ public class Tests extends OHCoreTestCase {
 	HospitalIoOperations hospitalIoOperation;
 	@Autowired
 	HospitalIoOperationRepository hospitalIoOperationRepository;
+	@Autowired
+	HospitalBrowsingManager hospitalBrowsingManager;
 
 	@BeforeClass
 	public static void setUpClass() {
@@ -65,12 +70,90 @@ public class Tests extends OHCoreTestCase {
 	}
 
 	@Test
+	public void testIoGetHospital() throws Exception {
+		String code = _setupTestHospital(false);
+		Hospital foundHospital = hospitalIoOperationRepository.findOne(code);
+		Hospital getHospital = hospitalIoOperation.getHospital();
+		assertThat(getHospital).isEqualTo(foundHospital);
+	}
+
+	@Test
 	public void testIoUpdateHospital() throws Exception {
 		String code = _setupTestHospital(false);
 		Hospital foundHospital = hospitalIoOperationRepository.findOne(code);
 		foundHospital.setDescription("Update");
 		Hospital updateHospital = hospitalIoOperation.updateHospital(foundHospital);
 		assertThat(updateHospital.getDescription()).isEqualTo("Update");
+	}
+
+	@Test
+	public void testIoGetHospitalCurrencyCod() throws Exception {
+		String code = _setupTestHospital(false);
+		Hospital foundHospital = hospitalIoOperationRepository.findOne(code);
+		String cod = hospitalIoOperation.getHospitalCurrencyCod();
+		assertThat(foundHospital.getCurrencyCod()).isEqualTo(cod);
+
+		foundHospital.setCurrencyCod(null);
+		Hospital updateHospital = hospitalIoOperation.updateHospital(foundHospital);
+		assertThat(updateHospital.getCurrencyCod()).isNull();
+	}
+
+	@Test
+	public void testIoHospitalSanitize() throws Exception {
+		Method method = hospitalIoOperation.getClass().getDeclaredMethod("sanitize", String.class);
+		method.setAccessible(true);
+		assertThat((String) method.invoke(hospitalIoOperation, "abc'de'f")).isEqualTo("abc''de''f");
+		assertThat((String) method.invoke(hospitalIoOperation, (String) null)).isNull();
+		assertThat((String) method.invoke(hospitalIoOperation, "abcdef")).isEqualTo("abcdef");
+	}
+
+	@Test
+	public void testMgrGetHospital() throws Exception {
+		String code = _setupTestHospital(false);
+		Hospital foundHospital = hospitalIoOperationRepository.findOne(code);
+		Hospital getHospital = hospitalBrowsingManager.getHospital();
+		assertThat(getHospital).isEqualTo(foundHospital);
+	}
+
+	@Test
+	public void testMgrUpdateHospital() throws Exception {
+		String code = _setupTestHospital(false);
+		Hospital foundHospital = hospitalIoOperationRepository.findOne(code);
+		foundHospital.setDescription("Update");
+		Hospital updateHospital = hospitalBrowsingManager.updateHospital(foundHospital);
+		assertThat(updateHospital.getDescription()).isEqualTo("Update");
+	}
+
+	@Test
+	public void testMgrGetHospitalCurrencyCod() throws Exception {
+		String code = _setupTestHospital(false);
+		Hospital foundHospital = hospitalIoOperationRepository.findOne(code);
+		String cod = hospitalBrowsingManager.getHospitalCurrencyCod();
+		assertThat(foundHospital.getCurrencyCod()).isEqualTo(cod);
+
+		foundHospital.setCurrencyCod(null);
+		Hospital updateHospital = hospitalBrowsingManager.updateHospital(foundHospital);
+		assertThat(updateHospital.getCurrencyCod()).isNull();
+	}
+
+	@Test
+	public void testHospitalGetterSetter() throws Exception {
+		String code = _setupTestHospital(false);
+		Hospital hospital = hospitalIoOperationRepository.findOne(code);
+
+		Integer lock = hospital.getLock();
+		hospital.setLock(-1);
+		assertThat(hospital.getLock()).isEqualTo(-1);
+	}
+
+	@Test
+	public void testHospitalHashToString() throws Exception {
+		String code = _setupTestHospital(false);
+		Hospital hospital = hospitalIoOperationRepository.findOne(code);
+
+		assertThat(hospital.hashCode()).isPositive();
+
+		assertThat(hospital.toString()).isEqualTo(hospital.getDescription());
 	}
 
 	private String _setupTestHospital(boolean usingSet) throws OHException {

--- a/src/test/java/org/isf/lab/test/TestLaboratory.java
+++ b/src/test/java/org/isf/lab/test/TestLaboratory.java
@@ -37,7 +37,7 @@ public class TestLaboratory {
 	private String material = "TestMaterial";
 	private GregorianCalendar now = new GregorianCalendar();
 	private GregorianCalendar registrationDate = new GregorianCalendar(now.get(Calendar.YEAR), 1, 1);
-	private GregorianCalendar examDate = new GregorianCalendar(now.get(Calendar.YEAR), 10, 11);
+	private GregorianCalendar examDate = new GregorianCalendar(now.get(Calendar.YEAR), now.get(Calendar.MONTH), now.get(Calendar.DAY_OF_MONTH));
 	private String result = "TestResult";
 	private String note = "TestNote";
 	private String patName = "TestPatientName";

--- a/src/test/java/org/isf/lab/test/Tests.java
+++ b/src/test/java/org/isf/lab/test/Tests.java
@@ -22,8 +22,12 @@
 package org.isf.lab.test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.lang.reflect.Method;
 import java.util.ArrayList;
+import java.util.GregorianCalendar;
+import java.util.List;
 
 import org.isf.OHCoreTestCase;
 import org.isf.exa.model.Exam;
@@ -32,7 +36,9 @@ import org.isf.exa.test.TestExam;
 import org.isf.exatype.model.ExamType;
 import org.isf.exatype.service.ExamTypeIoOperationRepository;
 import org.isf.exatype.test.TestExamType;
+import org.isf.generaldata.GeneralData;
 import org.isf.lab.manager.LabManager;
+import org.isf.lab.manager.LabRowManager;
 import org.isf.lab.model.Laboratory;
 import org.isf.lab.model.LaboratoryForPrint;
 import org.isf.lab.model.LaboratoryRow;
@@ -43,6 +49,7 @@ import org.isf.patient.model.Patient;
 import org.isf.patient.model.PatientMergedEvent;
 import org.isf.patient.service.PatientIoOperationRepository;
 import org.isf.patient.test.TestPatient;
+import org.isf.utils.exception.OHDataValidationException;
 import org.isf.utils.exception.OHException;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -63,15 +70,17 @@ public class Tests extends OHCoreTestCase {
 	@Autowired
 	LabIoOperationRepository labIoOperationRepository;
 	@Autowired
+	LabManager labManager;
+	@Autowired
 	LabRowIoOperationRepository labRowIoOperationRepository;
+	@Autowired
+	LabRowManager labRowManager;
 	@Autowired
 	ExamIoOperationRepository examIoOperationRepository;
 	@Autowired
 	ExamTypeIoOperationRepository examTypeIoOperationRepository;
 	@Autowired
 	PatientIoOperationRepository patientIoOperationRepository;
-	@Autowired
-	private LabManager labManager;
 	@Autowired
 	private ApplicationEventPublisher applicationEventPublisher;
 
@@ -125,6 +134,14 @@ public class Tests extends OHCoreTestCase {
 	public void testIoGetLaboratory() throws Exception {
 		int id = _setupTestLaboratory(false);
 		Laboratory foundLaboratory = labIoOperationRepository.findOne(id);
+		ArrayList<Laboratory> laboratories = labIoOperation.getLaboratory();
+		assertThat(laboratories.get(0).getCode()).isEqualTo(foundLaboratory.getCode());
+	}
+
+	@Test
+	public void testIoGetLaboratoryWithDates() throws Exception {
+		int id = _setupTestLaboratory(false);
+		Laboratory foundLaboratory = labIoOperationRepository.findOne(id);
 		ArrayList<Laboratory> laboratories = labIoOperation
 				.getLaboratory(foundLaboratory.getExam().getDescription(), foundLaboratory.getExamDate(), foundLaboratory.getExamDate());
 		assertThat(laboratories.get(0).getCode()).isEqualTo(foundLaboratory.getCode());
@@ -153,6 +170,14 @@ public class Tests extends OHCoreTestCase {
 
 	@Test
 	public void testIoGetLaboratoryForPrint() throws Exception {
+		Integer id = _setupTestLaboratory(false);
+		Laboratory foundLaboratory = labIoOperationRepository.findOne(id);
+		ArrayList<LaboratoryForPrint> laboratories = labIoOperation.getLaboratoryForPrint();
+		assertThat(laboratories.get(0).getCode()).isEqualTo(foundLaboratory.getCode());
+	}
+
+	@Test
+	public void testIoGetLaboratoryForPrintWithDates() throws Exception {
 		Integer id = _setupTestLaboratory(false);
 		Laboratory foundLaboratory = labIoOperationRepository.findOne(id);
 		ArrayList<LaboratoryForPrint> laboratories = labIoOperation
@@ -237,35 +262,20 @@ public class Tests extends OHCoreTestCase {
 	}
 
 	@Test
-	public void testManagerNewLaboratoryTransaction() throws Exception {
-		ArrayList<Laboratory> laboratories = new ArrayList<>();
-		ArrayList<ArrayList<String>> labRowList = new ArrayList<>();
+	public void testIoNewLabSecondProcedure2() throws Exception {
+		ArrayList<LaboratoryRow> labRow = new ArrayList<>();
 		ExamType examType = testExamType.setup(false);
-		Exam exam = testExam.setup(examType, 1, false);
-		Exam exam2 = testExam.setup(examType, 2, false);
-		exam2.setCode("ZZZ");
+		Exam exam = testExam.setup(examType, 2, false);
 		Patient patient = testPatient.setup(false);
+		Laboratory laboratory = testLaboratory.setup(exam, patient, false);
 		examTypeIoOperationRepository.saveAndFlush(examType);
 		examIoOperationRepository.saveAndFlush(exam);
-		examIoOperationRepository.saveAndFlush(exam2);
 		patientIoOperationRepository.saveAndFlush(patient);
-
-		// laboratory 1, Procedure One
-		ArrayList<String> labRow = new ArrayList<>();
-		Laboratory laboratory = testLaboratory.setup(exam, patient, false);
-		laboratories.add(laboratory);
-		labRowList.add(labRow);
-
-		// laboratory 2, Procedure Two
-		Laboratory laboratory2 = testLaboratory.setup(exam2, patient, false);
-		laboratories.add(laboratory2);
-		labRow.add("TestLabRow");
-		labRow.add("TestLabRowTestLabRowTestLabRowTestLabRowTestLabRowTestLabRow"); // Causing rollback
-		labRowList.add(labRow);
-
-		labManager.setIoOperations(labIoOperation);
-		boolean result = labManager.newLaboratory(laboratories, labRowList);
-
+		labIoOperationRepository.saveAndFlush(laboratory);
+		LaboratoryRow laboratoryRow = testLaboratoryRow.setup(laboratory, false);
+		labRowIoOperationRepository.saveAndFlush(laboratoryRow);
+		labRow.add(laboratoryRow);
+		boolean result = labIoOperation.newLabSecondProcedure2(laboratory, labRow);
 		assertThat(result).isTrue();
 		_checkLaboratoryIntoDb(laboratory.getCode());
 	}
@@ -304,6 +314,968 @@ public class Tests extends OHCoreTestCase {
 	}
 
 	@Test
+	public void testIoDeleteLaboratoryProcedureEquals2() throws Exception {
+		ExamType examType = testExamType.setup(false);
+		Exam exam = testExam.setup(examType, 2, false);
+		Patient patient = testPatient.setup(false);
+		Laboratory laboratory = testLaboratory.setup(exam, patient, false);
+		examTypeIoOperationRepository.saveAndFlush(examType);
+		examIoOperationRepository.saveAndFlush(exam);
+		patientIoOperationRepository.saveAndFlush(patient);
+		labIoOperationRepository.saveAndFlush(laboratory);
+		boolean result = labIoOperation.deleteLaboratory(laboratory);
+		assertThat(result).isTrue();
+		result = labIoOperation.isCodePresent(laboratory.getCode());
+		assertThat(result).isFalse();
+	}
+
+	@Test
+	public void testMgrGetLaboratory() throws Exception {
+		int id = _setupTestLaboratory(false);
+		Laboratory foundLaboratory = labIoOperationRepository.findOne(id);
+		ArrayList<Laboratory> laboratories = labManager.getLaboratory();
+		assertThat(laboratories.get(0).getCode()).isEqualTo(foundLaboratory.getCode());
+	}
+
+	@Test
+	public void testRowMgrGetLabRowByLabId() throws Exception {
+		Integer id = _setupTestLaboratoryRow(false);
+		LaboratoryRow foundLaboratoryRow = labRowIoOperationRepository.findOne(id);
+		ArrayList<LaboratoryRow> laboratoryRows = labRowManager.getLabRowByLabId(foundLaboratoryRow.getLabId().getCode());
+		assertThat(laboratoryRows).contains(foundLaboratoryRow);
+	}
+
+	@Test
+	public void testMgrGetLaboratoryRelatedToPatient() throws Exception {
+		int id = _setupTestLaboratoryRow(false);
+		LaboratoryRow foundLaboratoryRow = labRowIoOperationRepository.findOne(id);
+		ArrayList<Laboratory> laboratories = labManager.getLaboratory(foundLaboratoryRow.getLabId().getPatient());
+		assertThat(laboratories.get(0).getCode()).isEqualTo(foundLaboratoryRow.getLabId().getCode());
+	}
+
+	@Test
+	public void testMgrGetLaboratoryWithDatesAndExam() throws Exception {
+		int id = _setupTestLaboratory(false);
+		Laboratory foundLaboratory = labIoOperationRepository.findOne(id);
+		ArrayList<Laboratory> laboratories = labManager
+				.getLaboratory(foundLaboratory.getExam().getDescription(), foundLaboratory.getExamDate(), foundLaboratory.getExamDate());
+		assertThat(laboratories.get(0).getCode()).isEqualTo(foundLaboratory.getCode());
+	}
+
+	@Test
+	public void testMgrGetLaboratoryWithoutExamName() throws Exception {
+		// given:
+		int id = _setupTestLaboratory(false);
+		Laboratory foundLaboratory = labIoOperationRepository.findOne(id);
+
+		// when:
+		ArrayList<Laboratory> laboratories = labManager.getLaboratory(null, foundLaboratory.getExamDate(), foundLaboratory.getExamDate());
+
+		// then:
+		assertThat(laboratories.get(0).getCode()).isEqualTo(foundLaboratory.getCode());
+	}
+
+	@Test
+	public void testMgrGetLaboratoryForPrintWithDates() throws Exception {
+		Integer id = _setupTestLaboratory(false);
+		Laboratory foundLaboratory = labIoOperationRepository.findOne(id);
+		ArrayList<LaboratoryForPrint> laboratories = labManager
+				.getLaboratoryForPrint(foundLaboratory.getExam().getDescription(), foundLaboratory.getExamDate(), foundLaboratory.getExamDate());
+		assertThat(laboratories.get(0).getCode()).isEqualTo(foundLaboratory.getCode());
+	}
+
+	@Test
+	public void testMgrGetLaboratoryForPrintWithExamDescriptionLikePersistedOne() throws Exception {
+		// given:
+		Integer id = _setupTestLaboratory(false);
+		Laboratory foundLaboratory = labIoOperationRepository.findOne(id);
+		String description = foundLaboratory.getExam().getDescription();
+		String firstCharsOfDescription = description.substring(0, description.length() - 1);
+
+		// when:
+		ArrayList<LaboratoryForPrint> laboratories = labManager
+				.getLaboratoryForPrint(firstCharsOfDescription, foundLaboratory.getExamDate(), foundLaboratory.getExamDate());
+
+		// then:
+		assertThat(laboratories.get(0).getCode()).isEqualTo(foundLaboratory.getCode());
+	}
+
+	@Test
+	public void testMgrGetLaboratoryForPrintWithNullExamDescription() throws Exception {
+		// given:
+		Integer id = _setupTestLaboratory(false);
+		Laboratory foundLaboratory = labIoOperationRepository.findOne(id);
+
+		// when:
+		ArrayList<LaboratoryForPrint> laboratories = labManager.getLaboratoryForPrint(null, foundLaboratory.getExamDate(), foundLaboratory.getExamDate());
+
+		// then:
+		assertThat(laboratories.get(0).getCode()).isEqualTo(foundLaboratory.getCode());
+	}
+
+	@Test
+	public void testMgrGetLaboratoryForPrintMultipeResultsNoRows() throws Exception {
+		// given:
+		Integer id = _setupTestLaboratory(false);
+		Laboratory foundLaboratory = labIoOperationRepository.findOne(id);
+		// TODO: if resource bundles are made available this setResults() needs to change
+		foundLaboratory.setResult("angal.lab.multipleresults");
+		ArrayList<String> labRow = new ArrayList<>();
+		labManager.updateLaboratory(foundLaboratory, labRow);
+		String description = foundLaboratory.getExam().getDescription();
+		String firstCharsOfDescription = description.substring(0, description.length() - 1);
+
+		// when:
+		List<LaboratoryForPrint> laboratories = labManager
+				.getLaboratoryForPrint(firstCharsOfDescription, foundLaboratory.getExamDate(), foundLaboratory.getExamDate());
+
+		// then:
+		assertThat(laboratories.get(0).getCode()).isEqualTo(foundLaboratory.getCode());
+		// TODO: if resource bundles are made available this value needs to change
+		assertThat(laboratories.get(0).getResult()).isEqualTo("angal.lab.allnegative");
+	}
+
+	@Test
+	public void testMgrGetLaboratoryForPrintMultipeResultsRows() throws Exception {
+		ArrayList<String> labRow = new ArrayList<>();
+		ExamType examType = testExamType.setup(false);
+		Exam exam = testExam.setup(examType, 2, false);
+		Patient patient = testPatient.setup(false);
+		examTypeIoOperationRepository.saveAndFlush(examType);
+		examIoOperationRepository.saveAndFlush(exam);
+		patientIoOperationRepository.saveAndFlush(patient);
+		Laboratory laboratory = testLaboratory.setup(exam, patient, false);
+		// TODO: if resource bundles are made available this setResults() needs to change
+		laboratory.setResult("angal.lab.multipleresults");
+		labIoOperationRepository.saveAndFlush(laboratory);
+		LaboratoryRow laboratoryRow = testLaboratoryRow.setup(laboratory, false);
+		labRow.add("TestDescription");
+		labRowIoOperationRepository.saveAndFlush(laboratoryRow);
+		String description = laboratory.getExam().getDescription();
+		String firstCharsOfDescription = description.substring(0, description.length() - 1);
+
+		// when:
+		List<LaboratoryForPrint> laboratories = labManager
+				.getLaboratoryForPrint(firstCharsOfDescription, laboratory.getExamDate(), laboratory.getExamDate());
+
+		// then:
+		assertThat(laboratories.get(0).getCode()).isEqualTo(laboratory.getCode());
+		// TODO: if resource bundles are made available this value needs to change
+		assertThat(laboratories.get(0).getResult()).isEqualTo("angal.lab.multipleresults,TestDescription");
+	}
+
+	@Test
+	public void testMgrnewLaboratoryProcedureEquals1() throws Exception {
+		ExamType examType = testExamType.setup(false);
+		Exam exam = testExam.setup(examType, 1, false);
+		Patient patient = testPatient.setup(false);
+		examTypeIoOperationRepository.saveAndFlush(examType);
+		examIoOperationRepository.saveAndFlush(exam);
+		patientIoOperationRepository.saveAndFlush(patient);
+		Laboratory laboratory = testLaboratory.setup(exam, patient, false);
+		// method is protected not public thus use of reflection
+		Method method = labManager.getClass().getDeclaredMethod("newLabFirstProcedure", Laboratory.class);
+		method.setAccessible(true);
+		assertThat((Boolean) method.invoke(labManager, laboratory)).isTrue();
+		_checkLaboratoryIntoDb(laboratory.getCode());
+	}
+
+	@Test
+	public void testMgrnewLaboratoryProcedureEquals2() throws Exception {
+		ArrayList<String> labRow = new ArrayList<>();
+		ExamType examType = testExamType.setup(false);
+		Exam exam = testExam.setup(examType, 2, false);
+		Patient patient = testPatient.setup(false);
+		examTypeIoOperationRepository.saveAndFlush(examType);
+		examIoOperationRepository.saveAndFlush(exam);
+		patientIoOperationRepository.saveAndFlush(patient);
+		Laboratory laboratory = testLaboratory.setup(exam, patient, false);
+		labRow.add("TestLabRow");
+		// method is protected not public thus use of reflection
+		Method method = labManager.getClass().getDeclaredMethod("newLabSecondProcedure", Laboratory.class, ArrayList.class);
+		method.setAccessible(true);
+		assertThat((Boolean) method.invoke(labManager, laboratory, labRow)).isTrue();
+		_checkLaboratoryIntoDb(laboratory.getCode());
+	}
+
+	@Test
+	public void testMgrNewLaboratoryProcedureEquals2EmptyLabRows() throws Exception {
+		assertThatThrownBy(() ->
+		{
+			ArrayList<String> labRow = new ArrayList<>();
+			ExamType examType = testExamType.setup(false);
+			Exam exam = testExam.setup(examType, 2, false);
+			Patient patient = testPatient.setup(false);
+			Laboratory laboratory = testLaboratory.setup(exam, patient, false);
+			labManager.newLaboratory(laboratory, labRow);
+		})
+				.isInstanceOf(OHDataValidationException.class);
+	}
+
+	@Test
+	public void testMgrNewLaboratoryProcedureEquals2NullLabRows() throws Exception {
+		assertThatThrownBy(() ->
+		{
+			ExamType examType = testExamType.setup(false);
+			Exam exam = testExam.setup(examType, 2, false);
+			Patient patient = testPatient.setup(false);
+			Laboratory laboratory = testLaboratory.setup(exam, patient, false);
+			labManager.newLaboratory(laboratory, null);
+		})
+				.isInstanceOf(OHDataValidationException.class);
+	}
+
+	@Test
+	public void testMgrNewLaboratoryExceptionsBadProcedureNumber() throws Exception {
+		assertThatThrownBy(() ->
+		{
+			ArrayList<String> labRow = new ArrayList<>();
+			ExamType examType = testExamType.setup(false);
+			Exam exam = testExam.setup(examType, 99, false);
+			Patient patient = testPatient.setup(false);
+			Laboratory laboratory = testLaboratory.setup(exam, patient, false);
+			labManager.newLaboratory(laboratory, labRow);
+		})
+				.isInstanceOf(OHDataValidationException.class);
+	}
+
+	@Test
+	public void testMgrNewLaboratoryProcedureEquals2RollbackTransaction() throws Exception {
+		ArrayList<String> labRow = new ArrayList<>();
+		ExamType examType = testExamType.setup(false);
+		Exam exam = testExam.setup(examType, 2, false);
+		Patient patient = testPatient.setup(false);
+		examTypeIoOperationRepository.saveAndFlush(examType);
+		examIoOperationRepository.saveAndFlush(exam);
+		patientIoOperationRepository.saveAndFlush(patient);
+		Laboratory laboratory = testLaboratory.setup(exam, patient, false);
+		labRow.add("TestLabRow");
+		labRow.add("TestLabRowTestLabRowTestLabRowTestLabRowTestLabRowTestLabRow"); // Causing rollback
+		// method is protected not public thus use of reflection
+		Method method = labManager.getClass().getDeclaredMethod("newLabSecondProcedure", Laboratory.class, ArrayList.class);
+		method.setAccessible(true);
+		assertThat((Boolean) method.invoke(labManager, laboratory, labRow)).isTrue();
+		_checkLaboratoryIntoDb(laboratory.getCode());
+	}
+
+	@Test
+	public void testMgrNewLaboratory2ProcedureEquals1() throws Exception {
+		ArrayList<LaboratoryRow> labRow = new ArrayList<>();
+		ExamType examType = testExamType.setup(false);
+		Exam exam = testExam.setup(examType, 1, false);
+		Patient patient = testPatient.setup(false);
+		Laboratory laboratory = testLaboratory.setup(exam, patient, false);
+		examTypeIoOperationRepository.saveAndFlush(examType);
+		examIoOperationRepository.saveAndFlush(exam);
+		patientIoOperationRepository.saveAndFlush(patient);
+		labIoOperationRepository.saveAndFlush(laboratory);
+		LaboratoryRow laboratoryRow = testLaboratoryRow.setup(laboratory, false);
+		labRowIoOperationRepository.saveAndFlush(laboratoryRow);
+		labRow.add(laboratoryRow);
+		boolean result = labManager.newLaboratory2(laboratory, labRow);
+		assertThat(result).isTrue();
+		_checkLaboratoryIntoDb(laboratory.getCode());
+	}
+
+	@Test
+	public void testMgrNewLaboratory2ProcedureEquals2() throws Exception {
+		ArrayList<LaboratoryRow> labRow = new ArrayList<>();
+		ExamType examType = testExamType.setup(false);
+		Exam exam = testExam.setup(examType, 2, false);
+		Patient patient = testPatient.setup(false);
+		Laboratory laboratory = testLaboratory.setup(exam, patient, false);
+		examTypeIoOperationRepository.saveAndFlush(examType);
+		examIoOperationRepository.saveAndFlush(exam);
+		patientIoOperationRepository.saveAndFlush(patient);
+		labIoOperationRepository.saveAndFlush(laboratory);
+		LaboratoryRow laboratoryRow = testLaboratoryRow.setup(laboratory, false);
+		labRowIoOperationRepository.saveAndFlush(laboratoryRow);
+		labRow.add(laboratoryRow);
+		boolean result = labManager.newLaboratory2(laboratory, labRow);
+		assertThat(result).isTrue();
+		// TODO: if resource bundles are made available this must change
+		Laboratory foundLaboratory = labIoOperationRepository.findOne(laboratory.getCode());
+		assertThat(laboratory.getResult()).isEqualTo("angal.lab.multipleresults");
+	}
+
+	@Test
+	public void testMgrNewLaboratory2ProcedureEquals3() throws Exception {
+		ArrayList<LaboratoryRow> labRow = new ArrayList<>();
+		ExamType examType = testExamType.setup(false);
+		Exam exam = testExam.setup(examType, 3, false);
+		Patient patient = testPatient.setup(false);
+		Laboratory laboratory = testLaboratory.setup(exam, patient, false);
+		examTypeIoOperationRepository.saveAndFlush(examType);
+		examIoOperationRepository.saveAndFlush(exam);
+		patientIoOperationRepository.saveAndFlush(patient);
+		labIoOperationRepository.saveAndFlush(laboratory);
+		LaboratoryRow laboratoryRow = testLaboratoryRow.setup(laboratory, false);
+		labRowIoOperationRepository.saveAndFlush(laboratoryRow);
+		labRow.add(laboratoryRow);
+		boolean result = labManager.newLaboratory2(laboratory, labRow);
+		assertThat(result).isTrue();
+		_checkLaboratoryIntoDb(laboratory.getCode());
+	}
+
+	@Test
+	public void testMgrNewLaboratory2ProcedureEquals2EmptyLabRows() throws Exception {
+		assertThatThrownBy(() ->
+		{
+			ArrayList<LaboratoryRow> labRow = new ArrayList<>();
+			ExamType examType = testExamType.setup(false);
+			Exam exam = testExam.setup(examType, 2, false);
+			Patient patient = testPatient.setup(false);
+			Laboratory laboratory = testLaboratory.setup(exam, patient, false);
+			labManager.newLaboratory2(laboratory, labRow);
+		})
+				.isInstanceOf(OHDataValidationException.class);
+	}
+
+	@Test
+	public void testMgrNewLaboratory2ProcedureEquals2NullLabRows() throws Exception {
+		assertThatThrownBy(() ->
+		{
+			ExamType examType = testExamType.setup(false);
+			Exam exam = testExam.setup(examType, 2, false);
+			Patient patient = testPatient.setup(false);
+			Laboratory laboratory = testLaboratory.setup(exam, patient, false);
+			labManager.newLaboratory(laboratory, null);
+		})
+				.isInstanceOf(OHDataValidationException.class);
+	}
+
+	@Test
+	public void testMgrNewLaboratory2BadProcedureNumber() throws Exception {
+		assertThatThrownBy(() ->
+		{
+			ArrayList<LaboratoryRow> labRow = new ArrayList<>();
+			ExamType examType = testExamType.setup(false);
+			Exam exam = testExam.setup(examType, 99, false);
+			Patient patient = testPatient.setup(false);
+			Laboratory laboratory = testLaboratory.setup(exam, patient, false);
+			labManager.newLaboratory2(laboratory, labRow);
+		})
+				.isInstanceOf(OHDataValidationException.class);
+	}
+
+	// validation
+
+	@Test
+	public void testMgrValidationMissingDate() throws Exception {
+		ArrayList<Laboratory> laboratories = new ArrayList<>();
+		ArrayList<ArrayList<String>> labRowList = new ArrayList<>();
+		ExamType examType = testExamType.setup(false);
+		Exam exam = testExam.setup(examType, 1, false);
+		Patient patient = testPatient.setup(false);
+		examTypeIoOperationRepository.saveAndFlush(examType);
+		examIoOperationRepository.saveAndFlush(exam);
+		patientIoOperationRepository.saveAndFlush(patient);
+
+		ArrayList<String> labRow = new ArrayList<>();
+		Laboratory laboratory = testLaboratory.setup(exam, patient, false);
+		laboratories.add(laboratory);
+		labRowList.add(labRow);
+
+		laboratory.setDate(null);
+
+		boolean result = labManager.newLaboratory(laboratory, labRow);
+		assertThat(result).isTrue();
+	}
+
+	@Test
+	public void testMgrValidationMissingExamDate() throws Exception {
+		assertThatThrownBy(() ->
+		{
+			ArrayList<Laboratory> laboratories = new ArrayList<>();
+			ArrayList<ArrayList<String>> labRowList = new ArrayList<>();
+			ExamType examType = testExamType.setup(false);
+			Exam exam = testExam.setup(examType, 1, false);
+			Patient patient = testPatient.setup(false);
+			examTypeIoOperationRepository.saveAndFlush(examType);
+			examIoOperationRepository.saveAndFlush(exam);
+			patientIoOperationRepository.saveAndFlush(patient);
+
+			ArrayList<String> labRow = new ArrayList<>();
+			Laboratory laboratory = testLaboratory.setup(exam, patient, false);
+			laboratories.add(laboratory);
+			labRowList.add(labRow);
+
+			laboratory.setExamDate(null);
+
+			labManager.newLaboratory(laboratory, labRow);
+		})
+				.isInstanceOf(OHDataValidationException.class);
+	}
+
+	@Test
+	public void testMgrValidationLABEXTENDEDNoPatient() throws Exception {
+		boolean origLABEXTENDED = GeneralData.LABEXTENDED;
+		GeneralData.LABEXTENDED = true;
+		assertThatThrownBy(() ->
+		{
+			ArrayList<Laboratory> laboratories = new ArrayList<>();
+			ArrayList<ArrayList<String>> labRowList = new ArrayList<>();
+			ExamType examType = testExamType.setup(false);
+			Exam exam = testExam.setup(examType, 1, false);
+			Patient patient = testPatient.setup(false);
+			examTypeIoOperationRepository.saveAndFlush(examType);
+			examIoOperationRepository.saveAndFlush(exam);
+			patientIoOperationRepository.saveAndFlush(patient);
+
+			// laboratory 1, Procedure One
+			ArrayList<String> labRow = new ArrayList<>();
+			Laboratory laboratory = testLaboratory.setup(exam, patient, false);
+			laboratories.add(laboratory);
+			labRowList.add(labRow);
+
+			laboratory.setPatient(null);
+
+			labManager.newLaboratory(laboratory, labRow);
+		})
+				.isInstanceOf(OHDataValidationException.class);
+		GeneralData.LABEXTENDED = origLABEXTENDED;
+	}
+
+	@Test
+	public void testMgrValidationLABEXTENDEDPatient() throws Exception {
+		boolean origLABEXTENDED = GeneralData.LABEXTENDED;
+		GeneralData.LABEXTENDED = true;
+
+		ArrayList<Laboratory> laboratories = new ArrayList<>();
+		ArrayList<ArrayList<String>> labRowList = new ArrayList<>();
+		ExamType examType = testExamType.setup(false);
+		Exam exam = testExam.setup(examType, 1, false);
+		Patient patient = testPatient.setup(false);
+		examTypeIoOperationRepository.saveAndFlush(examType);
+		examIoOperationRepository.saveAndFlush(exam);
+		patientIoOperationRepository.saveAndFlush(patient);
+
+		// laboratory 1, Procedure One
+		ArrayList<String> labRow = new ArrayList<>();
+		Laboratory laboratory = testLaboratory.setup(exam, patient, false);
+		laboratories.add(laboratory);
+		labRowList.add(labRow);
+
+		labManager.newLaboratory(laboratory, labRow);
+
+		GeneralData.LABEXTENDED = origLABEXTENDED;
+
+		Laboratory foundLaboratory = labIoOperationRepository.findOne(laboratory.getCode());
+		assertThat(laboratory.getPatName()).isEqualTo(laboratory.getPatient().getName());
+		assertThat(laboratory.getAge()).isEqualTo(laboratory.getPatient().getAge());
+		assertThat(laboratory.getSex()).isEqualTo(String.valueOf(laboratory.getPatient().getSex()));
+	}
+
+	@Test
+	public void testMgrValidationLNoPatientBadSex() throws Exception {
+		assertThatThrownBy(() ->
+		{
+			ArrayList<Laboratory> laboratories = new ArrayList<>();
+			ArrayList<ArrayList<String>> labRowList = new ArrayList<>();
+			ExamType examType = testExamType.setup(false);
+			Exam exam = testExam.setup(examType, 1, false);
+			Patient patient = testPatient.setup(false);
+			examTypeIoOperationRepository.saveAndFlush(examType);
+			examIoOperationRepository.saveAndFlush(exam);
+			patientIoOperationRepository.saveAndFlush(patient);
+
+			// laboratory 1, Procedure One
+			ArrayList<String> labRow = new ArrayList<>();
+			Laboratory laboratory = testLaboratory.setup(exam, patient, false);
+			laboratories.add(laboratory);
+			labRowList.add(labRow);
+
+			laboratory.setPatient(null);
+			laboratory.setSex("?");
+
+			labManager.newLaboratory(laboratory, labRow);
+		})
+				.isInstanceOf(OHDataValidationException.class);
+	}
+
+	@Test
+	public void testMgrValidationLNoPatientBadAge() throws Exception {
+		assertThatThrownBy(() ->
+		{
+			ArrayList<Laboratory> laboratories = new ArrayList<>();
+			ArrayList<ArrayList<String>> labRowList = new ArrayList<>();
+			ExamType examType = testExamType.setup(false);
+			Exam exam = testExam.setup(examType, 1, false);
+			Patient patient = testPatient.setup(false);
+			examTypeIoOperationRepository.saveAndFlush(examType);
+			examIoOperationRepository.saveAndFlush(exam);
+			patientIoOperationRepository.saveAndFlush(patient);
+
+			// laboratory 1, Procedure One
+			ArrayList<String> labRow = new ArrayList<>();
+			Laboratory laboratory = testLaboratory.setup(exam, patient, false);
+			laboratories.add(laboratory);
+			labRowList.add(labRow);
+
+			laboratory.setPatient(null);
+			laboratory.setAge(-99);
+
+			labManager.newLaboratory(laboratory, labRow);
+		})
+				.isInstanceOf(OHDataValidationException.class);
+	}
+
+	@Test
+	public void testMgrValidationLNoExam() throws Exception {
+		assertThatThrownBy(() ->
+		{
+			ArrayList<Laboratory> laboratories = new ArrayList<>();
+			ArrayList<ArrayList<String>> labRowList = new ArrayList<>();
+			ExamType examType = testExamType.setup(false);
+			Exam exam = testExam.setup(examType, 1, false);
+			Patient patient = testPatient.setup(false);
+			examTypeIoOperationRepository.saveAndFlush(examType);
+			examIoOperationRepository.saveAndFlush(exam);
+			patientIoOperationRepository.saveAndFlush(patient);
+
+			// laboratory 1, Procedure One
+			ArrayList<String> labRow = new ArrayList<>();
+			Laboratory laboratory = testLaboratory.setup(exam, patient, false);
+			laboratories.add(laboratory);
+			labRowList.add(labRow);
+
+			laboratory.setExam(null);
+
+			labManager.newLaboratory(laboratory, labRow);
+		})
+				.isInstanceOf(OHDataValidationException.class);
+	}
+
+	@Test
+	public void testMgrValidationLNoResult() throws Exception {
+		assertThatThrownBy(() ->
+		{
+			ArrayList<Laboratory> laboratories = new ArrayList<>();
+			ArrayList<ArrayList<String>> labRowList = new ArrayList<>();
+			ExamType examType = testExamType.setup(false);
+			Exam exam = testExam.setup(examType, 1, false);
+			Patient patient = testPatient.setup(false);
+			examTypeIoOperationRepository.saveAndFlush(examType);
+			examIoOperationRepository.saveAndFlush(exam);
+			patientIoOperationRepository.saveAndFlush(patient);
+
+			// laboratory 1, Procedure One
+			ArrayList<String> labRow = new ArrayList<>();
+			Laboratory laboratory = testLaboratory.setup(exam, patient, false);
+			laboratories.add(laboratory);
+			labRowList.add(labRow);
+
+			laboratory.setResult("");
+
+			labManager.newLaboratory(laboratory, labRow);
+		})
+				.isInstanceOf(OHDataValidationException.class);
+	}
+
+	@Test
+	public void testMgrValidationLNoMaterial() throws Exception {
+		assertThatThrownBy(() ->
+		{
+			ArrayList<Laboratory> laboratories = new ArrayList<>();
+			ArrayList<ArrayList<String>> labRowList = new ArrayList<>();
+			ExamType examType = testExamType.setup(false);
+			Exam exam = testExam.setup(examType, 1, false);
+			Patient patient = testPatient.setup(false);
+			examTypeIoOperationRepository.saveAndFlush(examType);
+			examIoOperationRepository.saveAndFlush(exam);
+			patientIoOperationRepository.saveAndFlush(patient);
+
+			// laboratory 1, Procedure One
+			ArrayList<String> labRow = new ArrayList<>();
+			Laboratory laboratory = testLaboratory.setup(exam, patient, false);
+			laboratories.add(laboratory);
+			labRowList.add(labRow);
+
+			laboratory.setMaterial("");
+
+			labManager.newLaboratory(laboratory, labRow);
+		})
+				.isInstanceOf(OHDataValidationException.class);
+	}
+
+	@Test
+	public void testMgrValidationLNoInOutPatient() throws Exception {
+		assertThatThrownBy(() ->
+		{
+			ArrayList<Laboratory> laboratories = new ArrayList<>();
+			ArrayList<ArrayList<String>> labRowList = new ArrayList<>();
+			ExamType examType = testExamType.setup(false);
+			Exam exam = testExam.setup(examType, 1, false);
+			Patient patient = testPatient.setup(false);
+			examTypeIoOperationRepository.saveAndFlush(examType);
+			examIoOperationRepository.saveAndFlush(exam);
+			patientIoOperationRepository.saveAndFlush(patient);
+
+			// laboratory 1, Procedure One
+			ArrayList<String> labRow = new ArrayList<>();
+			Laboratory laboratory = testLaboratory.setup(exam, patient, false);
+			laboratories.add(laboratory);
+			labRowList.add(labRow);
+
+			laboratory.setInOutPatient("");
+
+			labManager.newLaboratory(laboratory, labRow);
+		})
+				.isInstanceOf(OHDataValidationException.class);
+	}
+
+	@Test
+	public void testMgrUpdateLaboratoryProcedure1() throws Exception {
+		Integer code = _setupTestLaboratory(false);
+		Laboratory foundlaboratory = labIoOperationRepository.findOne(code);
+		foundlaboratory.setNote("Update");
+		boolean result = labManager.updateLaboratory(foundlaboratory, null);
+		assertThat(result).isTrue();
+		Laboratory updateLaboratory = labIoOperationRepository.findOne(code);
+		assertThat(updateLaboratory.getNote()).isEqualTo("Update");
+	}
+
+	@Test
+	public void testMgrUpdateLaboratoryProcedure2() throws Exception {
+		ArrayList<String> labRow = new ArrayList<>();
+		ExamType examType = testExamType.setup(false);
+		Exam exam = testExam.setup(examType, 2, false);
+		Patient patient = testPatient.setup(false);
+		Laboratory laboratory = testLaboratory.setup(exam, patient, false);
+		examTypeIoOperationRepository.saveAndFlush(examType);
+		examIoOperationRepository.saveAndFlush(exam);
+		patientIoOperationRepository.saveAndFlush(patient);
+		labIoOperationRepository.saveAndFlush(laboratory);
+		Laboratory foundlaboratory = labIoOperationRepository.findOne(laboratory.getCode());
+		foundlaboratory.setNote("Update");
+		labRow.add("laboratoryRow");
+		boolean result = labManager.updateLaboratory(foundlaboratory, labRow);
+		assertThat(result).isTrue();
+		Laboratory updateLaboratory = labIoOperationRepository.findOne(foundlaboratory.getCode());
+		assertThat(updateLaboratory.getNote()).isEqualTo("Update");
+	}
+
+	@Test
+	public void testMgrUpdateLaboratoryProcedure3() throws Exception {
+		ArrayList<String> labRow = new ArrayList<>();
+		ExamType examType = testExamType.setup(false);
+		Exam exam = testExam.setup(examType, 3, false);
+		Patient patient = testPatient.setup(false);
+		Laboratory laboratory = testLaboratory.setup(exam, patient, false);
+		examTypeIoOperationRepository.saveAndFlush(examType);
+		examIoOperationRepository.saveAndFlush(exam);
+		patientIoOperationRepository.saveAndFlush(patient);
+		labIoOperationRepository.saveAndFlush(laboratory);
+		Laboratory foundlaboratory = labIoOperationRepository.findOne(laboratory.getCode());
+		foundlaboratory.setNote("Update");
+		boolean result = labManager.updateLaboratory(foundlaboratory, null);
+		assertThat(result).isTrue();
+		Laboratory updateLaboratory = labIoOperationRepository.findOne(foundlaboratory.getCode());
+		assertThat(updateLaboratory.getNote()).isEqualTo("Update");
+	}
+
+	@Test
+	public void testMgrUpdateLaboratoryExceptionEmptyLabRows() throws Exception {
+		assertThatThrownBy(() ->
+		{
+			ArrayList<String> labRow = new ArrayList<>();
+			ExamType examType = testExamType.setup(false);
+			Exam exam = testExam.setup(examType, 2, false);
+			Patient patient = testPatient.setup(false);
+			Laboratory laboratory = testLaboratory.setup(exam, patient, false);
+			labManager.updateLaboratory(laboratory, labRow);
+		})
+				.isInstanceOf(OHDataValidationException.class);
+	}
+
+	@Test
+	public void testMgrUpdateLaboratoryExceptionNullLablRows() throws Exception {
+		assertThatThrownBy(() ->
+		{
+			ExamType examType = testExamType.setup(false);
+			Exam exam = testExam.setup(examType, 2, false);
+			Patient patient = testPatient.setup(false);
+			Laboratory laboratory = testLaboratory.setup(exam, patient, false);
+			labManager.updateLaboratory(laboratory, null);
+		})
+				.isInstanceOf(OHDataValidationException.class);
+	}
+
+	@Test
+	public void testMgrUpdateLaboratoryExceptionBadProcedureNumber() throws Exception {
+		assertThatThrownBy(() ->
+		{
+			ArrayList<String> labRow = new ArrayList<>();
+			ExamType examType = testExamType.setup(false);
+			Exam exam = testExam.setup(examType, 99, false);
+			Patient patient = testPatient.setup(false);
+			Laboratory laboratory = testLaboratory.setup(exam, patient, false);
+			labManager.updateLaboratory(laboratory, labRow);
+		})
+				.isInstanceOf(OHDataValidationException.class);
+	}
+
+	@Test
+	public void testMgrNewLaboratoryTransaction() throws Exception {
+		ArrayList<Laboratory> laboratories = new ArrayList<>();
+		ArrayList<ArrayList<String>> labRowList = new ArrayList<>();
+		ExamType examType = testExamType.setup(false);
+		Exam exam = testExam.setup(examType, 1, false);
+		Exam exam2 = testExam.setup(examType, 2, false);
+		exam2.setCode("ZZZ");
+		Patient patient = testPatient.setup(false);
+		examTypeIoOperationRepository.saveAndFlush(examType);
+		examIoOperationRepository.saveAndFlush(exam);
+		examIoOperationRepository.saveAndFlush(exam2);
+		patientIoOperationRepository.saveAndFlush(patient);
+
+		// laboratory 1, Procedure One
+		ArrayList<String> labRow = new ArrayList<>();
+		Laboratory laboratory = testLaboratory.setup(exam, patient, false);
+		laboratories.add(laboratory);
+		labRowList.add(labRow);
+
+		// laboratory 2, Procedure Two
+		Laboratory laboratory2 = testLaboratory.setup(exam2, patient, false);
+		laboratories.add(laboratory2);
+		labRow.add("TestLabRow");
+		labRow.add("TestLabRowTestLabRowTestLabRowTestLabRowTestLabRowTestLabRow"); // Causing rollback
+		labRowList.add(labRow);
+
+		boolean result = labManager.newLaboratory(laboratories, labRowList);
+
+		assertThat(result).isTrue();
+		_checkLaboratoryIntoDb(laboratory.getCode());
+	}
+
+	@Test
+	public void testMgrNewLaboratoryTransactionNoLabList() throws Exception {
+		assertThatThrownBy(() ->
+		{
+			ArrayList<Laboratory> laboratories = new ArrayList<>();
+			ArrayList<ArrayList<String>> labRowList = new ArrayList<>();
+
+			labManager.newLaboratory(laboratories, labRowList);
+		})
+				.isInstanceOf(OHDataValidationException.class);
+	}
+
+	@Test
+	public void testMgrNewLaboratoryTransactionLabListNotEqualLabRowList() throws Exception {
+		assertThatThrownBy(() ->
+		{
+			ArrayList<Laboratory> laboratories = new ArrayList<>();
+			ArrayList<ArrayList<String>> labRowList = new ArrayList<>();
+			ExamType examType = testExamType.setup(false);
+			Exam exam = testExam.setup(examType, 1, false);
+			Patient patient = testPatient.setup(false);
+			examTypeIoOperationRepository.saveAndFlush(examType);
+			examIoOperationRepository.saveAndFlush(exam);
+			patientIoOperationRepository.saveAndFlush(patient);
+
+			// laboratory 1, Procedure One
+			ArrayList<String> labRow = new ArrayList<>();
+			Laboratory laboratory = testLaboratory.setup(exam, patient, false);
+			laboratories.add(laboratory);
+			labRowList.add(labRow);
+
+			// laboratory 2, Procedure Two
+			labRow.add("TestLabRow");
+			labRowList.add(labRow);
+
+			labManager.newLaboratory(laboratories, labRowList);
+		})
+				.isInstanceOf(OHDataValidationException.class);
+	}
+
+	@Test
+	public void testMgrNewLaboratory2Transaction() throws Exception {
+		List<Laboratory> labList = new ArrayList<>();
+		ArrayList<ArrayList<LaboratoryRow>> labRowList = new ArrayList<>();
+		ExamType examType = testExamType.setup(false);
+		Exam exam = testExam.setup(examType, 1, false);
+		Exam exam2 = testExam.setup(examType, 2, false);
+		exam2.setCode("ZZZ");
+		Patient patient = testPatient.setup(false);
+		examTypeIoOperationRepository.saveAndFlush(examType);
+		examIoOperationRepository.saveAndFlush(exam);
+		examIoOperationRepository.saveAndFlush(exam2);
+		patientIoOperationRepository.saveAndFlush(patient);
+
+		// laboratory 1, Procedure One
+		ArrayList<LaboratoryRow> labRow = new ArrayList<>();
+		Laboratory laboratory = testLaboratory.setup(exam, patient, false);
+		labList.add(laboratory);
+		labRowList.add(labRow);
+		labIoOperationRepository.saveAndFlush(laboratory);
+
+		// laboratory 2, Procedure Two
+		Laboratory laboratory2 = testLaboratory.setup(exam2, patient, false);
+		labList.add(laboratory2);
+		LaboratoryRow laboratoryRow = testLaboratoryRow.setup(laboratory2, false);
+		labIoOperationRepository.saveAndFlush(laboratory2);
+		labRowIoOperationRepository.saveAndFlush(laboratoryRow);
+
+		labRow.add(laboratoryRow);
+		labRow.add(laboratoryRow); // Causing rollback
+		labRowList.add(labRow);
+
+		boolean result = labManager.newLaboratory2(labList, labRowList);
+
+		assertThat(result).isTrue();
+		_checkLaboratoryIntoDb(laboratory.getCode());
+	}
+
+	@Test
+	public void testMgrNewLaboratory2TransactionNoLabList() throws Exception {
+		assertThatThrownBy(() ->
+		{
+			List<Laboratory> labList = new ArrayList<>();
+			ArrayList<ArrayList<LaboratoryRow>> labRowList = new ArrayList<>();
+
+			ExamType examType = testExamType.setup(false);
+			Exam exam = testExam.setup(examType, 1, false);
+			Patient patient = testPatient.setup(false);
+			examTypeIoOperationRepository.saveAndFlush(examType);
+			examIoOperationRepository.saveAndFlush(exam);
+			patientIoOperationRepository.saveAndFlush(patient);
+
+			ArrayList<LaboratoryRow> labRow = new ArrayList<>();
+			Laboratory laboratory = testLaboratory.setup(exam, patient, false);
+			labIoOperationRepository.saveAndFlush(laboratory);
+
+			labManager.newLaboratory2(labList, labRowList);
+		})
+				.isInstanceOf(OHDataValidationException.class);
+	}
+
+	@Test
+	public void testMgrNewLaboratory2TransactionLabListNotEqualLabRowList() throws Exception {
+		assertThatThrownBy(() ->
+		{
+			List<Laboratory> labList = new ArrayList<>();
+			ArrayList<ArrayList<LaboratoryRow>> labRowList = new ArrayList<>();
+
+			ExamType examType = testExamType.setup(false);
+			Exam exam = testExam.setup(examType, 1, false);
+			Patient patient = testPatient.setup(false);
+			examTypeIoOperationRepository.saveAndFlush(examType);
+			examIoOperationRepository.saveAndFlush(exam);
+			patientIoOperationRepository.saveAndFlush(patient);
+
+			// laboratory 1, Procedure One
+			ArrayList<LaboratoryRow> labRow = new ArrayList<>();
+			Laboratory laboratory = testLaboratory.setup(exam, patient, false);
+			labIoOperationRepository.saveAndFlush(laboratory);
+			labList.add(laboratory);
+			labRowList.add(labRow);
+
+			// laboratory 2, Procedure Two
+			LaboratoryRow laboratoryRow = testLaboratoryRow.setup(laboratory, false);
+			labRowIoOperationRepository.saveAndFlush(laboratoryRow);
+			labRow.add(laboratoryRow);
+			labRowList.add(labRow);
+
+			labManager.newLaboratory2(labList, labRowList);
+		})
+				.isInstanceOf(OHDataValidationException.class);
+	}
+
+	@Test
+	public void testMgrEditLabFirstProcedure() throws Exception {
+		Integer code = _setupTestLaboratory(false);
+		Laboratory foundlaboratory = labIoOperationRepository.findOne(code);
+		foundlaboratory.setNote("Update");
+		// method is protected not public
+		Method method = labManager.getClass().getDeclaredMethod("editLabFirstProcedure", Laboratory.class);
+		method.setAccessible(true);
+		assertThat((boolean) method.invoke(labManager, foundlaboratory)).isTrue();
+		List<Laboratory> updateLaboratory = labIoOperationRepository.findAll();
+		assertThat(updateLaboratory).hasSize(1);
+		assertThat(updateLaboratory.get(0).getNote()).isEqualTo("Update");
+	}
+
+	@Test
+	public void testMgrEditLabSecondProcedure() throws Exception {
+		ArrayList<String> labRow = new ArrayList<>();
+		Integer code = _setupTestLaboratory(false);
+		Laboratory laboratory = labIoOperationRepository.findOne(code);
+		labRow.add("Update");
+		// method is protected not public
+		Method method = labManager.getClass().getDeclaredMethod("editLabSecondProcedure", Laboratory.class, ArrayList.class);
+		method.setAccessible(true);
+		assertThat((Boolean) method.invoke(labManager, laboratory, labRow)).isTrue();
+		List<LaboratoryRow> updateLaboratoryRow = labRowIoOperationRepository.findAll();
+		assertThat(updateLaboratoryRow).hasSize(1);
+		assertThat(updateLaboratoryRow.get(0).getDescription()).isEqualTo("Update");
+	}
+
+	@Test
+	public void testMgrDeleteLaboratory() throws Exception {
+		Integer code = _setupTestLaboratory(false);
+		Laboratory foundLaboratory = labIoOperationRepository.findOne(code);
+		boolean result = labManager.deleteLaboratory(foundLaboratory);
+		assertThat(result).isTrue();
+		result = labIoOperation.isCodePresent(code);
+		assertThat(result).isFalse();
+	}
+
+	@Test
+	public void testMgrDeleteLaboratoryProcedure2() throws Exception {
+		ExamType examType = testExamType.setup(false);
+		Exam exam = testExam.setup(examType, 2, false);
+		Patient patient = testPatient.setup(false);
+		Laboratory laboratory = testLaboratory.setup(exam, patient, false);
+		examTypeIoOperationRepository.saveAndFlush(examType);
+		examIoOperationRepository.saveAndFlush(exam);
+		patientIoOperationRepository.saveAndFlush(patient);
+		labIoOperationRepository.saveAndFlush(laboratory);
+		boolean result = labManager.deleteLaboratory(laboratory);
+		assertThat(result).isTrue();
+		result = labIoOperation.isCodePresent(laboratory.getCode());
+		assertThat(result).isFalse();
+	}
+
+	@Test
+	public void testMgrGetMaterialKeyUndefined() throws Exception {
+		assertThat(labManager.getMaterialKey("notThere")).isEqualTo("undefined");
+	}
+
+	@Test
+	public void testMgrGetMaterialKeyFound() throws Exception {
+		// TODO: if resource bundles are made available this needs to change
+		assertThat(labManager.getMaterialKey("angal.lab.film")).isEqualTo("film");
+	}
+
+	@Test
+	public void testMgrGetMaterialTranslatedNotThere() throws Exception {
+		// TODO: if resource bundles are made available this needs to change
+		assertThat(labManager.getMaterialTranslated("notThere")).isEqualTo("angal.lab.undefined");
+	}
+
+	@Test
+	public void testMgrGetMaterialTranslatedNull() throws Exception {
+		// TODO: if resource bundles are made available this needs to change
+		assertThat(labManager.getMaterialTranslated(null)).isEqualTo("angal.lab.undefined");
+	}
+
+	@Test
+	public void testMgrGetMaterialTranslatedFound() throws Exception {
+		// TODO: if resource bundles are made available this needs to change
+		assertThat(labManager.getMaterialTranslated("film")).isEqualTo("angal.lab.film");
+	}
+
+	@Test
+	public void testMgrGetMaterialLIst() throws Exception {
+		assertThat(labManager.getMaterialList()).hasSize(9);
+		ArrayList materailList = labManager.getMaterialList();
+		// TODO: if resource bundles are made available this needs to change
+		assertThat(materailList.get(0)).isEqualTo("angal.lab.undefined");
+		materailList.remove(0);   // Remove the default value that is placed first in the list even if out of order
+		assertThat(materailList).isSorted();
+	}
+
+	@Test
 	public void testListenerShouldUpdatePatientToMergedWhenPatientMergedEventArrive() throws Exception {
 		// given:
 		int id = _setupTestLaboratory(false);
@@ -319,6 +1291,98 @@ public class Tests extends OHCoreTestCase {
 		assertThat(result.getPatName()).isEqualTo(mergedPatient.getName());
 		assertThat(Long.valueOf(result.getAge())).isEqualTo(Long.valueOf(mergedPatient.getAge()));
 		assertThat(result.getSex()).isEqualTo(String.valueOf(mergedPatient.getSex()));
+	}
+
+	@Test
+	public void testNewLaboratoryGetterSetters() throws Exception {
+		Integer code = 0;
+		String result = "TestResult";
+		String note = "TestNote";
+		ExamType examType = testExamType.setup(false);
+		Exam exam = testExam.setup(examType, 1, false);
+		Patient patient = testPatient.setup(false);
+		Laboratory laboratory = new Laboratory(code, exam, new GregorianCalendar(), result, note, patient, patient.getName());
+		assertThat(laboratory).isNotNull();
+		assertThat(laboratory.getCode()).isEqualTo(code);
+		assertThat(laboratory.getExam()).isEqualTo(exam);
+		assertThat(laboratory.getResult()).isEqualTo(result);
+		assertThat(laboratory.getNote()).isEqualTo(note);
+		assertThat(laboratory.getPatName()).isEqualTo(patient.getName());
+
+		laboratory.setCode(-1);
+		assertThat(laboratory.getCode()).isEqualTo(-1);
+		laboratory.setLock(-2);
+		assertThat(laboratory.getLock()).isEqualTo(-2);
+	}
+
+	@Test
+	public void testLaboratoryEqualsHashToString() throws Exception {
+		int code = _setupTestLaboratory(false);
+		Laboratory laboratory = labIoOperationRepository.findOne(code);
+		Laboratory laboratory2 = new Laboratory(code + 1, null, new GregorianCalendar(), "result", "note", null, "name");
+		assertThat(laboratory.equals(laboratory)).isTrue();
+		assertThat(laboratory.equals(laboratory2)).isFalse();
+		assertThat(laboratory.equals(new String("xyzzy"))).isFalse();
+		laboratory2.setCode(code);
+		assertThat(laboratory.equals(laboratory2)).isTrue();
+
+		assertThat(laboratory.hashCode()).isPositive();
+
+		assertThat(laboratory.toString()).isNotEmpty();
+	}
+
+	@Test
+	public void testNewLaboratoryRowGetterSetters() throws Exception {
+		Integer code = 0;
+		String result = "TestResult";
+		String note = "TestNote";
+		ExamType examType = testExamType.setup(false);
+		Exam exam = testExam.setup(examType, 1, false);
+		Patient patient = testPatient.setup(false);
+		Laboratory laboratory = new Laboratory(code, exam, new GregorianCalendar(), result, note, patient, patient.getName());
+		LaboratoryRow laboratoryRow = new LaboratoryRow(code, laboratory, "description");
+		assertThat(laboratoryRow).isNotNull();
+
+		laboratoryRow.setCode(-1);
+		assertThat(laboratoryRow.getCode()).isEqualTo(-1);
+	}
+
+	@Test
+	public void testLaboratoryRowEqualsHash() throws Exception {
+		int code = _setupTestLaboratoryRow(false);
+		LaboratoryRow laboratoryRow = labRowIoOperationRepository.findOne(code);
+		LaboratoryRow laboratoryRow2 = new LaboratoryRow(code + 1, null, "description");
+		assertThat(laboratoryRow.equals(laboratoryRow)).isTrue();
+		assertThat(laboratoryRow.equals(laboratoryRow2)).isFalse();
+		assertThat(laboratoryRow.equals(new String("xyzzy"))).isFalse();
+		laboratoryRow2.setCode(code);
+		assertThat(laboratoryRow.equals(laboratoryRow2)).isTrue();
+
+		laboratoryRow.setCode(null);
+		laboratoryRow2.setCode(null);
+		assertThat(laboratoryRow.equals(laboratoryRow2)).isFalse();
+		laboratoryRow.setDescription("description");
+		assertThat(laboratoryRow.equals(laboratoryRow)).isTrue();
+
+		assertThat(laboratoryRow.hashCode()).isPositive();
+	}
+
+	@Test
+	public void testLaboratoryForPrintGetterSetter() throws Exception {
+		Integer id = _setupTestLaboratory(false);
+		Laboratory foundLaboratory = labIoOperationRepository.findOne(id);
+		ArrayList<LaboratoryForPrint> laboratories = labIoOperation.getLaboratoryForPrint();
+
+		LaboratoryForPrint laboratoryForPrint = laboratories.get(0);
+
+		laboratoryForPrint.setCode(-1);
+		assertThat(laboratoryForPrint.getCode()).isEqualTo(-1);
+		laboratoryForPrint.setDate("dateString");
+		assertThat(laboratoryForPrint.getDate()).isEqualTo("dateString");
+		laboratoryForPrint.setExam("examString");
+		assertThat(laboratoryForPrint.getExam()).isEqualTo("examString");
+		laboratoryForPrint.setResult("resultString");
+		assertThat(laboratoryForPrint.getResult()).isEqualTo("resultString");
 	}
 
 	private Patient _setupTestPatient(boolean usingSet) throws OHException {


### PR DESCRIPTION
Coverage before:
![image](https://user-images.githubusercontent.com/1105445/102534997-9203b580-4075-11eb-8344-329a5835d22b.png)

Coverage after:
![image](https://user-images.githubusercontent.com/1105445/102535012-99c35a00-4075-11eb-9ba1-d38841cc61a1.png)

I could not get 100% coverage of `LabManager` because the private field `materialHashMap` was not accessible through Java reflection as I've done in other packages.   The reason is that the `@Transactional` annotation is used on two methods causing the class to generate a proxy class to handle the rollback.  So when I tried to `getDefinedFields` through reflection all I got was the proxy class methods and not the protected fields in the base class.  I tried a few options like `getSuperClass()` where I could get the variable but not set it to any new value.  Thus only 98% coverage for that class.
