### PR TITLE
[WIP] OP-387 MedicalType with testing  for OHServiceException and Null during MedicalTypeIoOperation.updateMedicalType

### DIFF
--- a/src/main/java/org/isf/medtype/manager/MedicalTypeBrowserManager.java
+++ b/src/main/java/org/isf/medtype/manager/MedicalTypeBrowserManager.java
@@ -21,75 +21,72 @@
  */
 package org.isf.medtype.manager;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.isf.generaldata.MessageBundle;
 import org.isf.medtype.model.MedicalType;
 import org.isf.medtype.service.MedicalTypeIoOperation;
 import org.isf.utils.exception.OHDataIntegrityViolationException;
-import org.isf.utils.exception.OHServiceException;
 import org.isf.utils.exception.OHDataValidationException;
+import org.isf.utils.exception.OHServiceException;
 import org.isf.utils.exception.model.OHExceptionMessage;
 import org.isf.utils.exception.model.OHSeverityLevel;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
-import java.util.ArrayList;
-import java.util.List;
-
 /**
  * Manager class for the medical type module.
- *
  */
 @Component
 public class MedicalTypeBrowserManager {
 
-	private final Logger logger = LoggerFactory.getLogger(MedicalTypeBrowserManager.class);
-
 	@Autowired
 	private MedicalTypeIoOperation ioOperations;
-	
+
 	/**
 	 * Verify if the object is valid for CRUD and return a list of errors, if any
+	 *
 	 * @param medicalType
 	 * @param insert <code>true</code> or updated <code>false</code>
-	 * @throws OHServiceException 
+	 * @throws OHServiceException
 	 */
 	protected void validateMedicalType(MedicalType medicalType, boolean insert) throws OHServiceException {
 		String key = medicalType.getCode();
 		String description = medicalType.getDescription();
-        List<OHExceptionMessage> errors = new ArrayList<OHExceptionMessage>();
-        if(key.isEmpty() ){
-	        errors.add(new OHExceptionMessage("codeEmptyError", 
-	        		MessageBundle.getMessage("angal.medtype.pleaseinsertacode"), 
-	        		OHSeverityLevel.ERROR));
-        }
-        if(key.length()>1){
-	        errors.add(new OHExceptionMessage("codeTooLongError", 
-	        		MessageBundle.getMessage("angal.medtype.codetoolongmaxchars"), 
-	        		OHSeverityLevel.ERROR));
-        }
-        if(description.isEmpty() ){
-            errors.add(new OHExceptionMessage("descriptionEmptyError", 
-            		MessageBundle.getMessage("angal.medtype.pleaseinsertavaliddescription"), 
-            		OHSeverityLevel.ERROR));
-        }
-        if (insert) {
-        	if (codeControl(medicalType.getCode())){
-    			throw new OHDataIntegrityViolationException(new OHExceptionMessage(null, 
-    					MessageBundle.getMessage("angal.common.codealreadyinuse"), 
-    					OHSeverityLevel.ERROR));
-    		}
-        }
-        if (!errors.isEmpty()){
-	        throw new OHDataValidationException(errors);
-	    }
-    }
+		List<OHExceptionMessage> errors = new ArrayList<>();
+		if (key.isEmpty()) {
+			errors.add(new OHExceptionMessage("codeEmptyError",
+					MessageBundle.getMessage("angal.medtype.pleaseinsertacode"),
+					OHSeverityLevel.ERROR));
+		}
+		if (key.length() > 1) {
+			errors.add(new OHExceptionMessage("codeTooLongError",
+					MessageBundle.getMessage("angal.medtype.codetoolongmaxchars"),
+					OHSeverityLevel.ERROR));
+		}
+		if (description.isEmpty()) {
+			errors.add(new OHExceptionMessage("descriptionEmptyError",
+					MessageBundle.getMessage("angal.medtype.pleaseinsertavaliddescription"),
+					OHSeverityLevel.ERROR));
+		}
+		if (insert) {
+			if (codeControl(medicalType.getCode())) {
+				throw new OHDataIntegrityViolationException(new OHExceptionMessage(null,
+						MessageBundle.getMessage("angal.common.codealreadyinuse"),
+						OHSeverityLevel.ERROR));
+			}
+		}
+		if (!errors.isEmpty()) {
+			throw new OHDataValidationException(errors);
+		}
+	}
 
 	/**
 	 * Retrieves all the medical types.
+	 *
 	 * @return all the medical types.
-	 * @throws OHServiceException 
+	 * @throws OHServiceException
 	 */
 	public ArrayList<MedicalType> getMedicalType() throws OHServiceException {
 		return ioOperations.getMedicalTypes();
@@ -97,9 +94,10 @@ public class MedicalTypeBrowserManager {
 
 	/**
 	 * Saves the specified medical type.
+	 *
 	 * @param medicalType the medical type to save.
 	 * @return <code>true</code> if the medical type has been saved, <code>false</code> otherwise.
-	 * @throws OHServiceException 
+	 * @throws OHServiceException
 	 */
 	public boolean newMedicalType(MedicalType medicalType) throws OHServiceException {
 		validateMedicalType(medicalType, true);
@@ -108,9 +106,10 @@ public class MedicalTypeBrowserManager {
 
 	/**
 	 * Updates the specified medical type.
+	 *
 	 * @param medicalType the medical type to update.
 	 * @return <code>true</code> if the medical type has been updated, <code>false</code> otherwise.
-	 * @throws OHServiceException 
+	 * @throws OHServiceException
 	 */
 	public boolean updateMedicalType(MedicalType medicalType) throws OHServiceException {
 		validateMedicalType(medicalType, false);
@@ -119,9 +118,10 @@ public class MedicalTypeBrowserManager {
 
 	/**
 	 * Checks if the specified medical type code is already used.
+	 *
 	 * @param code the code to check.
 	 * @return <code>true</code> if the code is used, <code>false</code> otherwise.
-	 * @throws OHServiceException 
+	 * @throws OHServiceException
 	 */
 	public boolean codeControl(String code) throws OHServiceException {
 		return ioOperations.isCodePresent(code);
@@ -130,9 +130,10 @@ public class MedicalTypeBrowserManager {
 	/**
 	 * Deletes the specified medical type.
 	 * In case of error a message error is shown and a <code>false</code> value is returned.
+	 *
 	 * @param medicalType the medical type to delete.
 	 * @return <code>true</code> if the medical type has been deleted, <code>false</code> otherwise.
-	 * @throws OHServiceException 
+	 * @throws OHServiceException
 	 */
 	public boolean deleteMedicalType(MedicalType medicalType) throws OHServiceException {
 		return ioOperations.deleteMedicalType(medicalType);

--- a/src/test/java/org/isf/medtype/test/TestsExceptionsAndNull.java
+++ b/src/test/java/org/isf/medtype/test/TestsExceptionsAndNull.java
@@ -1,0 +1,110 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.isf.medtype.test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.Assert.fail;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.when;
+
+import org.isf.OHCoreTestCase;
+import org.isf.medtype.model.MedicalType;
+import org.isf.medtype.service.MedicalTypeIoOperation;
+import org.isf.medtype.service.MedicalTypeIoOperationRepository;
+import org.isf.utils.exception.OHServiceException;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.dao.RecoverableDataAccessException;
+import org.springframework.test.util.ReflectionTestUtils;
+
+public class TestsExceptionsAndNull extends OHCoreTestCase {
+
+	@Autowired
+	MedicalTypeIoOperation medicalTypeIoOperation;
+
+	@Mock
+	MedicalTypeIoOperationRepository medicalTypeIoOperationRepositoryMock;
+
+	@Before
+	public void setUp() {
+		MockitoAnnotations.initMocks(this);
+		ReflectionTestUtils.setField(medicalTypeIoOperation, "repository", medicalTypeIoOperationRepositoryMock);
+	}
+
+	@Test
+	public void testIoUpdateMedicalType_when_OHServiceException() {
+		//see CrudRepository.save() potential exceptions https://stackoverflow.com/a/28650987/833336
+		String msg = "testing exception message";
+		when(medicalTypeIoOperationRepositoryMock.save(any(MedicalType.class)))
+		//.thenThrow(new OHServiceException(new OHExceptionMessage("title", "message", OHSeverityLevel.ERROR)));
+		//.thenThrow(new Exception("message"));
+		//.thenThrow(new DataAccessException("message"));
+		//.thenThrow(new NonTransientDataAccessException("testing message"));
+		//.thenThrow(new SQLNonTransientException("testing message"));
+		//.thenThrow(new TransientDataAccessException("testing message"));
+		//.thenThrow(new SQLTransientException("testing message"));
+		.thenThrow(new RecoverableDataAccessException(msg));
+				
+		MedicalType foundMedicalType = new MedicalType();
+		//foundMedicalType.setDescription("Update");
+		assertThatThrownBy( () ->
+		{
+			medicalTypeIoOperation.updateMedicalType(foundMedicalType);
+			fail("Missed OHServiceException");
+		})
+			.isInstanceOf(OHServiceException.class);
+		
+//		try {
+//			medicalTypeIoOperation.updateMedicalType(foundMedicalType);
+//			fail("Missed OHServiceException");
+//		} catch (OHServiceException e) {
+//			assertThat(e.getMessage()).contains(msg);
+//			assertThat(e.getMessages().get(0).getLevel()).isEqualTo(OHSeverityLevel.ERROR);
+//			//			e.getMessages().forEach( m -> {
+//			//				System.out.println(m.getTitle());
+//			//				System.out.println(m.getMessage());
+//			//				System.out.println(m.getLevel());
+//			//			});
+//		} catch (Exception e) {
+//			fail("Missed OHServiceException");
+//		}
+	}
+	
+	@Test
+	public void testIoUpdateMedicalType_when_null() throws Exception {
+		MockitoAnnotations.initMocks(this);
+		when(medicalTypeIoOperationRepositoryMock.save(any(MedicalType.class)))
+		.thenReturn(null);
+				
+		MedicalType foundMedicalType = new MedicalType();
+		foundMedicalType.setCode("test");
+		foundMedicalType.setDescription("Update");
+		boolean result = medicalTypeIoOperation.updateMedicalType(foundMedicalType);
+		assertThat(result).isFalse();
+
+	}
+
+}


### PR DESCRIPTION
TODO:

- [ ] Fix test failing only in IDE, but passing `mvn test`

### IDE Results:

![image](https://user-images.githubusercontent.com/849502/103155350-125ca180-476d-11eb-8a80-206aef3a6be1.png)

### mvn Results

```
[26/Dec/2020 10:49:50] [:] INFO - Closing JPA EntityManagerFactory for persistence unit 'default'

Results :

Tests run: 489, Failures: 0, Errors: 0, Skipped: 1

[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  01:44 min
[INFO] Finished at: 2020-12-26T10:49:51-05:00
[INFO] ------------------------------------------------------------------------
```

