### PR TITLE
OP-397 increase coverage in opetype; format Manager file

### DIFF
--- a/src/main/java/org/isf/opetype/manager/OperationTypeBrowserManager.java
+++ b/src/main/java/org/isf/opetype/manager/OperationTypeBrowserManager.java
@@ -27,8 +27,8 @@ import java.util.List;
 import org.isf.generaldata.MessageBundle;
 import org.isf.opetype.model.OperationType;
 import org.isf.opetype.service.OperationTypeIoOperation;
-import org.isf.utils.exception.OHServiceException;
 import org.isf.utils.exception.OHDataValidationException;
+import org.isf.utils.exception.OHServiceException;
 import org.isf.utils.exception.model.OHExceptionMessage;
 import org.isf.utils.exception.model.OHSeverityLevel;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -36,96 +36,99 @@ import org.springframework.stereotype.Component;
 
 @Component
 public class OperationTypeBrowserManager {
-	
+
 	@Autowired
 	private OperationTypeIoOperation ioOperations;
-	
+
 	/**
 	 * Return the list of {@link OperationType}s
-	 * 
+	 *
 	 * @return the list of {@link OperationType}s. It could be <code>empty</code> or <code>null</code>.
-	 * @throws OHServiceException 
+	 * @throws OHServiceException
 	 */
 	public ArrayList<OperationType> getOperationType() throws OHServiceException {
-        return ioOperations.getOperationType();
+		return ioOperations.getOperationType();
 	}
-	
+
 	/**
 	 * Insert an {@link OperationType} in the DB
-	 * 
+	 *
 	 * @param operationType - the {@link OperationType} to insert
 	 * @return <code>true</code> if the {@link OperationType} has been inserted, <code>false</code> otherwise.
-	 * @throws OHServiceException 
+	 * @throws OHServiceException
 	 */
 	public boolean newOperationType(OperationType operationType) throws OHServiceException {
-        List<OHExceptionMessage> errors = validateOperationType(operationType, true);
-        if(!errors.isEmpty()){
-            throw new OHDataValidationException(errors);
-        }
-        return ioOperations.newOperationType(operationType);
+		List<OHExceptionMessage> errors = validateOperationType(operationType, true);
+		if (!errors.isEmpty()) {
+			throw new OHDataValidationException(errors);
+		}
+		return ioOperations.newOperationType(operationType);
 	}
 
 	/**
 	 * Update an {@link OperationType}
-	 * 
+	 *
 	 * @param operationType - the {@link OperationType} to update
 	 * @return <code>true</code> if the {@link OperationType} has been updated, <code>false</code> otherwise.
-	 * @throws OHServiceException 
+	 * @throws OHServiceException
 	 */
 	public boolean updateOperationType(OperationType operationType) throws OHServiceException {
-        List<OHExceptionMessage> errors = validateOperationType(operationType, false);
-        if(!errors.isEmpty()){
-            throw new OHDataValidationException(errors);
-        }
-        return ioOperations.updateOperationType(operationType);
-	}
-	
-	/**
-	 * Delete an {@link OperationType}
-	 * 
-	 * @param operationType - the {@link OperationType} to delete
-	 * @return <code>true</code> if the {@link OperationType} has been delete, <code>false</code> otherwise.
-	 * @throws OHServiceException 
-	 */
-	public boolean deleteOperationType(OperationType operationType) throws OHServiceException {
-        return ioOperations.deleteOperationType(operationType);
-	}
-	
-	/**
-	 * Checks if an {@link OperationType} code has already been used
-	 * @param code - the code
-	 * @return <code>true</code> if the code is already in use, <code>false</code> otherwise.
-	 * @throws OHServiceException 
-	 */
-	public boolean codeControl(String code) throws OHServiceException {
-        return ioOperations.isCodePresent(code);
+		List<OHExceptionMessage> errors = validateOperationType(operationType, false);
+		if (!errors.isEmpty()) {
+			throw new OHDataValidationException(errors);
+		}
+		return ioOperations.updateOperationType(operationType);
 	}
 
-    protected List<OHExceptionMessage> validateOperationType(OperationType operationType, boolean insert) throws OHServiceException {
-        String key = operationType.getCode();
-        String description = operationType.getDescription();
-        List<OHExceptionMessage> errors = new ArrayList<OHExceptionMessage>();
-        if(key == null || key.isEmpty() ){
-            errors.add(new OHExceptionMessage("codeEmptyError",
-                    MessageBundle.getMessage("angal.opetype.pleaseinsertacode"),
-                    OHSeverityLevel.ERROR));
-        }
-        if(key.length()>2){
-            errors.add(new OHExceptionMessage("codeTooLongError",
-                    MessageBundle.getMessage("angal.opetype.codetoolongmaxchars"),
-                    OHSeverityLevel.ERROR));
-        }
-        if(insert){
-            if (codeControl(key)){
-                errors.add(new OHExceptionMessage(MessageBundle.getMessage("angal.hospital"),MessageBundle.getMessage("angal.common.codealreadyinuse"),
-                        OHSeverityLevel.ERROR));
-            }
-        }
-        if(description == null || description.isEmpty() ){
-            errors.add(new OHExceptionMessage("descriptionEmptyError",
-                    MessageBundle.getMessage("angal.opetype.pleaseinsertavaliddescription"),
-                    OHSeverityLevel.ERROR));
-        }
-        return errors;
-    }
+	/**
+	 * Delete an {@link OperationType}
+	 *
+	 * @param operationType - the {@link OperationType} to delete
+	 * @return <code>true</code> if the {@link OperationType} has been delete, <code>false</code> otherwise.
+	 * @throws OHServiceException
+	 */
+	public boolean deleteOperationType(OperationType operationType) throws OHServiceException {
+		return ioOperations.deleteOperationType(operationType);
+	}
+
+	/**
+	 * Checks if an {@link OperationType} code has already been used
+	 *
+	 * @param code - the code
+	 * @return <code>true</code> if the code is already in use, <code>false</code> otherwise.
+	 * @throws OHServiceException
+	 */
+	public boolean codeControl(String code) throws OHServiceException {
+		return ioOperations.isCodePresent(code);
+	}
+
+	protected List<OHExceptionMessage> validateOperationType(OperationType operationType, boolean insert) throws OHServiceException {
+		String key = operationType.getCode();
+		String description = operationType.getDescription();
+		List<OHExceptionMessage> errors = new ArrayList<OHExceptionMessage>();
+		if (key == null || key.isEmpty()) {
+			errors.add(new OHExceptionMessage("codeEmptyError",
+					MessageBundle.getMessage("angal.opetype.pleaseinsertacode"),
+					OHSeverityLevel.ERROR));
+		}
+		else {
+			if (key.length() > 2) {
+				errors.add(new OHExceptionMessage("codeTooLongError",
+						MessageBundle.getMessage("angal.opetype.codetoolongmaxchars"),
+						OHSeverityLevel.ERROR));
+			}
+		}
+		if (insert) {
+			if (codeControl(key)) {
+				errors.add(new OHExceptionMessage(MessageBundle.getMessage("angal.hospital"), MessageBundle.getMessage("angal.common.codealreadyinuse"),
+						OHSeverityLevel.ERROR));
+			}
+		}
+		if (description == null || description.isEmpty()) {
+			errors.add(new OHExceptionMessage("descriptionEmptyError",
+					MessageBundle.getMessage("angal.opetype.pleaseinsertavaliddescription"),
+					OHSeverityLevel.ERROR));
+		}
+		return errors;
+	}
 }

--- a/src/test/java/org/isf/opetype/test/Tests.java
+++ b/src/test/java/org/isf/opetype/test/Tests.java
@@ -22,13 +22,16 @@
 package org.isf.opetype.test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.ArrayList;
 
 import org.isf.OHCoreTestCase;
+import org.isf.opetype.manager.OperationTypeBrowserManager;
 import org.isf.opetype.model.OperationType;
 import org.isf.opetype.service.OperationTypeIoOperation;
 import org.isf.opetype.service.OperationTypeIoOperationRepository;
+import org.isf.utils.exception.OHDataValidationException;
 import org.isf.utils.exception.OHException;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -43,6 +46,8 @@ public class Tests extends OHCoreTestCase {
 	OperationTypeIoOperation operationTypeIoOperation;
 	@Autowired
 	OperationTypeIoOperationRepository operationTypeIoOperationRepository;
+	@Autowired
+	OperationTypeBrowserManager operationTypeBrowserManager;
 
 	@BeforeClass
 	public static void setUpClass() {
@@ -110,6 +115,144 @@ public class Tests extends OHCoreTestCase {
 		assertThat(result).isFalse();
 	}
 
+	@Test
+	public void testMgrGetOperationType() throws Exception {
+		String code = _setupTestOperationType(false);
+		OperationType foundOperationType = operationTypeIoOperationRepository.findOne(code);
+		ArrayList<OperationType> operationTypes = operationTypeBrowserManager.getOperationType();
+		assertThat(operationTypes.get(operationTypes.size() - 1).getDescription()).isEqualTo(foundOperationType.getDescription());
+	}
+
+	@Test
+	public void testMgrUpdateOperationType() throws Exception {
+		String code = _setupTestOperationType(false);
+		OperationType foundOperationType = operationTypeIoOperationRepository.findOne(code);
+		foundOperationType.setDescription("Update");
+		assertThat(operationTypeBrowserManager.updateOperationType(foundOperationType)).isTrue();
+		OperationType updateOperationType = operationTypeIoOperationRepository.findOne(code);
+		assertThat(updateOperationType.getDescription()).isEqualTo("Update");
+	}
+
+	@Test
+	public void testMgrNewOperationType() throws Exception {
+		OperationType operationType = testOperationType.setup(true);
+		assertThat(operationTypeBrowserManager.newOperationType(operationType)).isTrue();
+		_checkOperationTypeIntoDb(operationType.getCode());
+	}
+
+	@Test
+	public void testMgrCodeControl() throws Exception {
+		String code = _setupTestOperationType(false);
+		assertThat(operationTypeBrowserManager.codeControl(code)).isTrue();
+	}
+
+	@Test
+	public void testMgrDeleteOperationType() throws Exception {
+		String code = _setupTestOperationType(false);
+		OperationType foundOperationType = operationTypeIoOperationRepository.findOne(code);
+		assertThat(operationTypeBrowserManager.deleteOperationType(foundOperationType)).isTrue();
+		assertThat(operationTypeBrowserManager.codeControl(code)).isFalse();
+	}
+
+	@Test
+	public void testMgrValidationKeyNull() throws Exception {
+		assertThatThrownBy(() ->
+		{
+			OperationType operationType = new OperationType("Z", "description");
+			operationType.setCode(null);
+			operationTypeBrowserManager.updateOperationType(operationType);
+		})
+				.isInstanceOf(OHDataValidationException.class);
+	}
+
+	@Test
+	public void testMgrValidationKeyEmpty() throws Exception {
+		assertThatThrownBy(() ->
+		{
+			OperationType operationType = new OperationType("Z", "description");
+			operationType.setCode("");
+			operationTypeBrowserManager.updateOperationType(operationType);
+		})
+				.isInstanceOf(OHDataValidationException.class);
+	}
+
+	@Test
+	public void testMgrValidationKeyTooLong() throws Exception {
+		assertThatThrownBy(() ->
+		{
+			OperationType operationType = new OperationType("Z", "description");
+			operationType.setCode("keyIsTooLong");
+			operationTypeBrowserManager.updateOperationType(operationType);
+		})
+				.isInstanceOf(OHDataValidationException.class);
+	}
+
+	@Test
+	public void testMgrValidationDescriptionNull() throws Exception {
+		assertThatThrownBy(() ->
+		{
+			OperationType operationType = new OperationType("Z", "description");
+			operationType.setDescription(null);
+			operationTypeBrowserManager.updateOperationType(operationType);
+		})
+				.isInstanceOf(OHDataValidationException.class);
+	}
+
+	@Test
+	public void testMgrValidationDescriptionEmpty() throws Exception {
+		assertThatThrownBy(() ->
+		{
+			OperationType operationType = new OperationType("Z", "description");
+			operationType.setDescription("");
+			operationTypeBrowserManager.updateOperationType(operationType);
+		})
+				.isInstanceOf(OHDataValidationException.class);
+	}
+
+	@Test
+	public void testMgrValidationCodeAlreadyInUse() throws Exception {
+		assertThatThrownBy(() ->
+		{
+			OperationType operationType = new OperationType("Z", "description");
+			operationTypeBrowserManager.newOperationType(operationType);
+			operationTypeBrowserManager.newOperationType(operationType);
+		})
+				.isInstanceOf(OHDataValidationException.class);
+	}
+
+	@Test
+	public void testOperationTypeEquals() throws Exception {
+		OperationType operationType = new OperationType("Z", "description");
+
+		assertThat(operationType.equals(operationType)).isTrue();
+		assertThat(operationType).isNotEqualTo(null);
+		assertThat(operationType).isNotEqualTo("someString");
+
+		OperationType operationType1 = new OperationType("Z", "description");
+		assertThat(operationType).isEqualTo(operationType1);
+
+		operationType1.setCode("A");
+		assertThat(operationType).isNotEqualTo(operationType1);
+
+		operationType1.setCode(operationType.getCode());
+		operationType1.setDescription("some other description");
+		assertThat(operationType).isNotEqualTo(operationType1);
+	}
+
+	@Test
+	public void testOperationTypeHashCode() throws Exception {
+		OperationType operationType = new OperationType("Z", "description");
+		int hashCode = operationType.hashCode();
+		// used computed value
+		assertThat(operationType.hashCode()).isEqualTo(hashCode);
+	}
+
+	@Test
+	public void testOperationTypeToString() throws Exception {
+		OperationType operationType = new OperationType("Z", "description");
+		assertThat(operationType).hasToString("description");
+	}
+
 	private String _setupTestOperationType(boolean usingSet) throws OHException {
 		OperationType operationType = testOperationType.setup(usingSet);
 		operationTypeIoOperationRepository.saveAndFlush(operationType);
@@ -117,8 +260,7 @@ public class Tests extends OHCoreTestCase {
 	}
 
 	private void _checkOperationTypeIntoDb(String code) throws OHException {
-		OperationType foundOperationType;
-		foundOperationType = operationTypeIoOperationRepository.findOne(code);
+		OperationType foundOperationType = operationTypeIoOperationRepository.findOne(code);
 		testOperationType.check(foundOperationType);
 	}
 }


### PR DESCRIPTION
Coverage before:
![image](https://user-images.githubusercontent.com/1105445/103463893-b611f880-4cfd-11eb-9727-f9abeb282cd1.png)

Coverage after:
![image](https://user-images.githubusercontent.com/1105445/103463903-c4601480-4cfd-11eb-98e1-07be327f7355.png)

Also fixed an NPE in `validateOperationType()` if the key value was null.


