### PR TITLE
Chore: update Dcm4Che Repository address to use https

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -431,7 +431,7 @@
 		<repository>
 			<id>dcm4che</id>
 			<name>Dcm4Che Repository</name>
-			<url>http://www.dcm4che.org/maven2/</url>
+			<url>https://www.dcm4che.org/maven2/</url>
 			<snapshots>
 				<enabled>false</enabled>
 			</snapshots>


### PR DESCRIPTION
Current address is secure: https://www.dcm4che.org/maven2/

