### PR TITLE
Chore: remove inefficient new String() constructor

### DIFF
--- a/src/test/java/org/isf/admission/test/Tests.java
+++ b/src/test/java/org/isf/admission/test/Tests.java
@@ -994,7 +994,7 @@ public class Tests extends OHCoreTestCase {
 		admission2.setId(id);   // no really legal but needed for these tests
 		assertThat(admission.equals(admission)).isTrue();
 		assertThat(admission.equals(admission2)).isTrue();
-		assertThat(admission.equals(new String("xyzzy"))).isFalse();
+		assertThat(admission.equals("xyzzy")).isFalse();
 		assertThat(admission.equals(admission2)).isTrue();
 
 		assertThat(admission.compareTo(admission2)).isZero();

--- a/src/test/java/org/isf/admtype/test/Tests.java
+++ b/src/test/java/org/isf/admtype/test/Tests.java
@@ -142,7 +142,7 @@ public class Tests extends OHCoreTestCase {
 		AdmissionType admissionType2 = new AdmissionType("someCode", "someDescription");
 		assertThat(admissionType.equals(admissionType)).isTrue();
 		assertThat(admissionType.equals(admissionType2)).isFalse();
-		assertThat(admissionType.equals(new String("xyzzy"))).isFalse();
+		assertThat(admissionType.equals("xyzzy")).isFalse();
 		admissionType2.setCode(code);
 		assertThat(admissionType.equals(admissionType2)).isTrue();
 

--- a/src/test/java/org/isf/agetype/test/Tests.java
+++ b/src/test/java/org/isf/agetype/test/Tests.java
@@ -160,7 +160,7 @@ public class Tests extends OHCoreTestCase {
 		ageType2.setTo(ageType.getTo());
 		assertThat(ageType.equals(ageType)).isTrue();
 		assertThat(ageType.equals(ageType2)).isTrue();
-		assertThat(ageType.equals(new String("xyzzy"))).isFalse();
+		assertThat(ageType.equals("xyzzy")).isFalse();
 		ageType2.setCode("xxxx");
 		assertThat(ageType.equals(ageType2)).isFalse();
 

--- a/src/test/java/org/isf/disctype/test/Tests.java
+++ b/src/test/java/org/isf/disctype/test/Tests.java
@@ -221,7 +221,7 @@ public class Tests extends OHCoreTestCase {
 		DischargeType dischargeType2 = new DischargeType("someCode", "someDescription");
 		assertThat(dischargeType.equals(dischargeType)).isTrue();
 		assertThat(dischargeType.equals(dischargeType2)).isFalse();
-		assertThat(dischargeType.equals(new String("xyzzy"))).isFalse();
+		assertThat(dischargeType.equals("xyzzy")).isFalse();
 		dischargeType2.setCode(code);
 		assertThat(dischargeType.equals(dischargeType2)).isTrue();
 

--- a/src/test/java/org/isf/disease/test/Tests.java
+++ b/src/test/java/org/isf/disease/test/Tests.java
@@ -311,7 +311,7 @@ public class Tests extends OHCoreTestCase {
 		Disease disease2 = new Disease("998", "someDescription", diseaseType2);
 		assertThat(disease.equals(disease)).isTrue();
 		assertThat(disease.equals(disease2)).isFalse();
-		assertThat(disease.equals(new String("xyzzy"))).isFalse();
+		assertThat(disease.equals("xyzzy")).isFalse();
 		disease2.setCode(disease.getCode());
 		disease2.setType(disease.getType());
 		disease2.setDescription(disease.getDescription());

--- a/src/test/java/org/isf/distype/test/Tests.java
+++ b/src/test/java/org/isf/distype/test/Tests.java
@@ -221,7 +221,7 @@ public class Tests extends OHCoreTestCase {
 		DiseaseType diseaseType2 = new DiseaseType("code", "description");
 		assertThat(diseaseType.equals(diseaseType)).isTrue();
 		assertThat(diseaseType.equals(diseaseType2)).isFalse();
-		assertThat(diseaseType.equals(new String("xyzzy"))).isFalse();
+		assertThat(diseaseType.equals("xyzzy")).isFalse();
 		diseaseType2.setCode(diseaseType.getCode());
 		diseaseType2.setDescription(diseaseType.getDescription());
 		assertThat(diseaseType.equals(diseaseType2)).isTrue();

--- a/src/test/java/org/isf/dlvrtype/test/Tests.java
+++ b/src/test/java/org/isf/dlvrtype/test/Tests.java
@@ -208,7 +208,7 @@ public class Tests extends OHCoreTestCase {
 		DeliveryType deliveryType2 = new DeliveryType("someCode", "someDescription");
 		assertThat(deliveryType.equals(deliveryType)).isTrue();
 		assertThat(deliveryType.equals(deliveryType2)).isFalse();
-		assertThat(deliveryType.equals(new String("xyzzy"))).isFalse();
+		assertThat(deliveryType.equals("xyzzy")).isFalse();
 		deliveryType2.setCode(code);
 		deliveryType2.setDescription(deliveryType.getDescription());
 		assertThat(deliveryType.equals(deliveryType2)).isTrue();

--- a/src/test/java/org/isf/exa/test/Tests.java
+++ b/src/test/java/org/isf/exa/test/Tests.java
@@ -493,7 +493,7 @@ public class Tests extends OHCoreTestCase {
 		Exam exam2 = new Exam("XXX", "TestDescription", examType, 1, "TestDefaultResult");
 		assertThat(exam.equals(exam)).isTrue();
 		assertThat(exam.equals(exam2)).isFalse();
-		assertThat(exam.equals(new String("xyzzy"))).isFalse();
+		assertThat(exam.equals("xyzzy")).isFalse();
 		exam2.setCode(exam.getCode());
 		exam2.setDescription(exam.getDescription());
 		exam2.setExamtype(exam.getExamtype());
@@ -513,7 +513,7 @@ public class Tests extends OHCoreTestCase {
 		ExamRow examRow2 = new ExamRow(exam2, "NewDescription");
 		assertThat(examRow.equals(examRow)).isTrue();
 		assertThat(examRow.equals(examRow2)).isFalse();
-		assertThat(examRow.equals(new String("xyzzy"))).isFalse();
+		assertThat(examRow.equals("xyzzy")).isFalse();
 		examRow2.setCode(examRow.getCode());
 		examRow2.setExamCode(examRow.getExamCode());
 		examRow2.setDescription(examRow.getDescription());

--- a/src/test/java/org/isf/examination/test/Tests.java
+++ b/src/test/java/org/isf/examination/test/Tests.java
@@ -342,7 +342,7 @@ public class Tests extends OHCoreTestCase {
 		patientExamination2.setPex_ID(-1);
 		assertThat(patientExamination.equals(patientExamination)).isTrue();
 		assertThat(patientExamination.equals(patientExamination2)).isFalse();
-		assertThat(patientExamination.equals(new String("xyzzy"))).isFalse();
+		assertThat(patientExamination.equals("xyzzy")).isFalse();
 		patientExamination2.setPex_ID(patientExamination.getPex_ID());
 		assertThat(patientExamination.equals(patientExamination2)).isTrue();
 		assertThat(patientExamination.compareTo(patientExamination2)).isZero();

--- a/src/test/java/org/isf/lab/test/Tests.java
+++ b/src/test/java/org/isf/lab/test/Tests.java
@@ -1322,7 +1322,7 @@ public class Tests extends OHCoreTestCase {
 		Laboratory laboratory2 = new Laboratory(code + 1, null, new GregorianCalendar(), "result", "note", null, "name");
 		assertThat(laboratory.equals(laboratory)).isTrue();
 		assertThat(laboratory.equals(laboratory2)).isFalse();
-		assertThat(laboratory.equals(new String("xyzzy"))).isFalse();
+		assertThat(laboratory.equals("xyzzy")).isFalse();
 		laboratory2.setCode(code);
 		assertThat(laboratory.equals(laboratory2)).isTrue();
 
@@ -1354,7 +1354,7 @@ public class Tests extends OHCoreTestCase {
 		LaboratoryRow laboratoryRow2 = new LaboratoryRow(code + 1, null, "description");
 		assertThat(laboratoryRow.equals(laboratoryRow)).isTrue();
 		assertThat(laboratoryRow.equals(laboratoryRow2)).isFalse();
-		assertThat(laboratoryRow.equals(new String("xyzzy"))).isFalse();
+		assertThat(laboratoryRow.equals("xyzzy")).isFalse();
 		laboratoryRow2.setCode(code);
 		assertThat(laboratoryRow.equals(laboratoryRow2)).isTrue();
 


### PR DESCRIPTION
This was found with SpotBugs.

The issue: Method invokes inefficient `new String(String)` constructor

Rationale: Using the` java.lang.String(String)` constructor wastes memory because the object so constructed will be functionally indistinguishable from the String passed as a parameter.  Just use the argument String directly.

I am ashamed to say that it was I who originally added the code being changed; I realized my mistake about half way through adding the new tests.

