### PR TITLE
Chore: remove unused imports

### DIFF
--- a/src/main/java/org/isf/medicalstock/service/MedicalStockIoOperations.java
+++ b/src/main/java/org/isf/medicalstock/service/MedicalStockIoOperations.java
@@ -21,7 +21,6 @@
  */
 package org.isf.medicalstock.service;
 
-import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.GregorianCalendar;
 import java.util.List;

--- a/src/main/java/org/isf/opd/service/OpdIoOperationRepositoryImpl.java
+++ b/src/main/java/org/isf/opd/service/OpdIoOperationRepositoryImpl.java
@@ -22,7 +22,6 @@
 package org.isf.opd.service;
 
 import java.util.ArrayList;
-import java.util.Calendar;
 import java.util.Date;
 import java.util.GregorianCalendar;
 import java.util.List;

--- a/src/main/java/org/isf/opd/service/OpdIoOperations.java
+++ b/src/main/java/org/isf/opd/service/OpdIoOperations.java
@@ -22,7 +22,6 @@
 package org.isf.opd.service;
 
 import java.util.ArrayList;
-import java.util.Calendar;
 import java.util.GregorianCalendar;
 import java.util.List;
 

--- a/src/main/java/org/isf/patvac/service/PatVacIoOperations.java
+++ b/src/main/java/org/isf/patvac/service/PatVacIoOperations.java
@@ -31,7 +31,6 @@ package org.isf.patvac.service;
  *------------------------------------------*/
 
 import java.util.ArrayList;
-import java.util.Calendar;
 import java.util.GregorianCalendar;
 import java.util.List;
 

--- a/src/test/java/org/isf/medicalstock/test/TestLot.java
+++ b/src/test/java/org/isf/medicalstock/test/TestLot.java
@@ -25,7 +25,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.data.Offset.offset;
 
 import java.math.BigDecimal;
-import java.util.Calendar;
 import java.util.GregorianCalendar;
 
 import org.isf.medicalstock.model.Lot;

--- a/src/test/java/org/isf/medicalstock/test/TestMovement.java
+++ b/src/test/java/org/isf/medicalstock/test/TestMovement.java
@@ -23,7 +23,6 @@ package org.isf.medicalstock.test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.util.Calendar;
 import java.util.GregorianCalendar;
 
 import org.isf.medicals.model.Medical;

--- a/src/test/java/org/isf/medicalstock/test/Tests.java
+++ b/src/test/java/org/isf/medicalstock/test/Tests.java
@@ -26,7 +26,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.math.BigDecimal;
 import java.util.ArrayList;
-import java.util.Calendar;
 import java.util.GregorianCalendar;
 import java.util.List;
 


### PR DESCRIPTION
These instances were found using IntelliJ's Analyze plugin looking for unused import statements.