### PR TITLE
Chore: Use StandardCharsets.UFT_8

### DIFF
--- a/src/main/java/org/isf/utils/db/CSV2SQL.java
+++ b/src/main/java/org/isf/utils/db/CSV2SQL.java
@@ -31,9 +31,9 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.OutputStreamWriter;
 import java.io.UnsupportedEncodingException;
-import java.nio.charset.Charset;
 import java.nio.charset.CharsetEncoder;
 import java.nio.charset.CodingErrorAction;
+import java.nio.charset.StandardCharsets;
 import java.text.NumberFormat;
 import java.text.ParseException;
 import java.util.ArrayList;
@@ -43,10 +43,6 @@ import java.util.Random;
 
 import org.isf.utils.exception.OHException;
 import org.isf.utils.time.TimeTools;
-
-/**
- *
- */
 
 /**
  * @author Mwithi
@@ -94,7 +90,7 @@ public class CSV2SQL {
 	public void pharmacyStartCVS(File fileIn, File fileOut) throws IOException, OHException {
 		NumberFormat numFormat = NumberFormat.getInstance(Locale.getDefault());
 
-		CharsetEncoder encoder = Charset.forName("UTF-8").newEncoder();
+		CharsetEncoder encoder = StandardCharsets.UTF_8.newEncoder();
 		encoder.onMalformedInput(CodingErrorAction.REPORT);
 		encoder.onUnmappableCharacter(CodingErrorAction.REPORT);
 

--- a/src/main/java/org/isf/utils/db/ImportTranslatedProperties.java
+++ b/src/main/java/org/isf/utils/db/ImportTranslatedProperties.java
@@ -34,6 +34,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
+import java.nio.charset.StandardCharsets;
 import java.util.Enumeration;
 import java.util.Properties;
 
@@ -84,7 +85,7 @@ public class ImportTranslatedProperties {
 
 				//in = new FileInputStream(pathOriginal + filename);
 				inputStream = new FileInputStream(pathOriginal + filename);
-				in = new InputStreamReader(inputStream, "UTF-8");
+				in = new InputStreamReader(inputStream, StandardCharsets.UTF_8);
 				Properties propsOri = new Properties();
 				propsOri.load(in);
 				in.close();
@@ -92,7 +93,7 @@ public class ImportTranslatedProperties {
 
 				//in = new FileInputStream(pathIn + filename);
 				inputStream = new FileInputStream(pathIn + filename);
-				in = new InputStreamReader(inputStream, "UTF-8");
+				in = new InputStreamReader(inputStream, StandardCharsets.UTF_8);
 				Properties propsIn = new Properties();
 				propsIn.load(in);
 				in.close();

--- a/src/main/java/org/isf/utils/db/UTF8Control.java
+++ b/src/main/java/org/isf/utils/db/UTF8Control.java
@@ -26,6 +26,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.URL;
 import java.net.URLConnection;
+import java.nio.charset.StandardCharsets;
 import java.util.Locale;
 import java.util.PropertyResourceBundle;
 import java.util.ResourceBundle;
@@ -56,7 +57,7 @@ public class UTF8Control extends Control {
         if (stream != null) {
             try {
                 // Only this line is changed to make it to read properties files as UTF-8.
-                bundle = new PropertyResourceBundle(new InputStreamReader(stream, "UTF-8"));
+                bundle = new PropertyResourceBundle(new InputStreamReader(stream, StandardCharsets.UTF_8));
             } finally {
                 stream.close();
             }

--- a/src/main/java/org/isf/utils/excel/ExcelExporter.java
+++ b/src/main/java/org/isf/utils/excel/ExcelExporter.java
@@ -32,6 +32,7 @@ import java.math.BigDecimal;
 import java.nio.charset.Charset;
 import java.nio.charset.CharsetEncoder;
 import java.nio.charset.CodingErrorAction;
+import java.nio.charset.StandardCharsets;
 import java.sql.Date;
 import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
@@ -79,7 +80,7 @@ public class ExcelExporter {
 	private CreationHelper createHelper;
 
 	public ExcelExporter() {
-		encoder = Charset.forName("UTF-8").newEncoder();
+		encoder = StandardCharsets.UTF_8.newEncoder();
 		encoder.onMalformedInput(CodingErrorAction.REPORT);
 		encoder.onUnmappableCharacter(CodingErrorAction.REPORT);
 		currentLocale = Locale.getDefault();


### PR DESCRIPTION
Replace constant charset String literal  (like "UTF-8")  with a predefined Charset object like StandardCharsets.UTF_8. This may work a little bit faster, because charset lookup becomes unnecessary.

Found with IntelliJ's Analyze plugin.