### PR TITLE
Chore: Logger placeholder not available for `cause`

### DIFF
--- a/src/main/java/org/isf/utils/exception/OHException.java
+++ b/src/main/java/org/isf/utils/exception/OHException.java
@@ -25,9 +25,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class OHException extends Exception {
-	/**
-	 * 
-	 */
+
 	private static final long serialVersionUID = 1L;
 	
 	protected Logger logger = LoggerFactory.getLogger(OHException.class);
@@ -41,7 +39,7 @@ public class OHException extends Exception {
 		super(message, cause);
 		if (logger.isErrorEnabled()) {
 			logger.error(">> EXCEPTION: {}", sanitize(message));
-			logger.error(">> {}", cause);
+			logger.error(">> ", cause);
 		}
 	}
 	


### PR DESCRIPTION
Just use the ` void error(String var1, Throwable var2);` method of the `org.slf4j.Logger` class.

Found with IntelliJ's Analyze plugin