### PR TITLE
Chore: rename file so maven knows it has tests in it

### DIFF
--- a/src/test/java/org/isf/patient/TestMergePatient.java
+++ b/src/test/java/org/isf/patient/TestMergePatient.java
@@ -40,7 +40,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
-public class MergePatientTests extends OHCoreTestCase {
+public class TestMergePatient extends OHCoreTestCase {
 
 	private static TestPatient testPatient;
 	private static TestPatientExamination testPatientExamination;


### PR DESCRIPTION
Maven selects files that start with "Test" as files to look inside for tests; had to rename this file.