### PR TITLE
OP-433 set OPDEXTENDED true and false and increase coverage

### DIFF
--- a/src/main/java/org/isf/opd/manager/OpdBrowserManager.java
+++ b/src/main/java/org/isf/opd/manager/OpdBrowserManager.java
@@ -48,6 +48,16 @@ public class OpdBrowserManager {
 	@Autowired
 	private OpdIoOperations ioOperations;
 
+	protected void setPatientConsistency(Opd opd) {
+		if (GeneralData.OPDEXTENDED && opd.getPatient() != null) {
+			/*
+			 * Age and Sex has not to be updated for reporting purposes
+			 */
+			opd.setAge(opd.getPatient().getAge());
+			opd.setSex(opd.getPatient().getSex());
+		}
+	}
+
 	/**
 	 * Verify if the object is valid for CRUD and return a list of errors, if any
 	 *
@@ -65,7 +75,7 @@ public class OpdBrowserManager {
 		if (opd.getUserID() == null)
 			opd.setUserID(UserBrowsingManager.getCurrentUser());
 
-		List<OHExceptionMessage> errors = new ArrayList<OHExceptionMessage>();
+		List<OHExceptionMessage> errors = new ArrayList<>();
 		// Check Visit Date
 		if (opd.getVisitDate() == null) {
 			errors.add(new OHExceptionMessage("noVisitDateError",
@@ -77,16 +87,6 @@ public class OpdBrowserManager {
 			errors.add(new OHExceptionMessage("patientNullError",
 					MessageBundle.getMessage("angal.opd.pleaseselectapatient"),
 					OHSeverityLevel.ERROR));
-		}
-		if (GeneralData.OPDEXTENDED && opd.getPatient() != null) {
-			/*
-			 * Age and Sex has not to be updated
-			 * for reporting purposes
-			 */
-			if (insert) {
-				opd.setAge(opd.getPatient().getAge());
-				opd.setSex(opd.getPatient().getSex());
-			}
 		}
 		// Check Sex and Age
 		if (opd.getAge() < 0) {
@@ -178,6 +178,7 @@ public class OpdBrowserManager {
 	 */
 	public boolean newOpd(Opd opd) throws OHServiceException {
 		validateOpd(opd, true);
+		setPatientConsistency(opd);
 		return ioOperations.newOpd(opd);
 	}
 

--- a/src/main/java/org/isf/opd/manager/OpdBrowserManager.java
+++ b/src/main/java/org/isf/opd/manager/OpdBrowserManager.java
@@ -32,12 +32,10 @@ import org.isf.generaldata.MessageBundle;
 import org.isf.menu.manager.UserBrowsingManager;
 import org.isf.opd.model.Opd;
 import org.isf.opd.service.OpdIoOperations;
-import org.isf.utils.exception.OHServiceException;
 import org.isf.utils.exception.OHDataValidationException;
+import org.isf.utils.exception.OHServiceException;
 import org.isf.utils.exception.model.OHExceptionMessage;
 import org.isf.utils.exception.model.OHSeverityLevel;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -46,42 +44,43 @@ import org.springframework.stereotype.Component;
  */
 @Component
 public class OpdBrowserManager {
-	
-	private final Logger logger = LoggerFactory.getLogger(OpdBrowserManager.class);
-	
+
 	@Autowired
 	private OpdIoOperations ioOperations;
-	
+
 	/**
 	 * Verify if the object is valid for CRUD and return a list of errors, if any
+	 *
 	 * @param opd
 	 * @param insert <code>true</code> or updated <code>false</code>
-	 * @throws OHDataValidationException 
+	 * @throws OHDataValidationException
 	 */
 	protected void validateOpd(Opd opd, boolean insert) throws OHDataValidationException {
-		
-		Disease disease=opd.getDisease();
-		Disease disease2=opd.getDisease2();
-		Disease disease3=opd.getDisease3();
-		if (opd.getDate() == null) opd.setDate(new Date());
-		if (opd.getUserID() == null) opd.setUserID(UserBrowsingManager.getCurrentUser());
-		
+
+		Disease disease = opd.getDisease();
+		Disease disease2 = opd.getDisease2();
+		Disease disease3 = opd.getDisease3();
+		if (opd.getDate() == null)
+			opd.setDate(new Date());
+		if (opd.getUserID() == null)
+			opd.setUserID(UserBrowsingManager.getCurrentUser());
+
 		List<OHExceptionMessage> errors = new ArrayList<OHExceptionMessage>();
-		//Check Visit Date
-				if (opd.getVisitDate() == null) {
-					errors.add(new OHExceptionMessage("noVisitDateError", 
-			        		MessageBundle.getMessage("angal.opd.pleaseinsertattendancedate"), 
-			        		OHSeverityLevel.ERROR));
-				}
-		//Check Patient
+		// Check Visit Date
+		if (opd.getVisitDate() == null) {
+			errors.add(new OHExceptionMessage("noVisitDateError",
+					MessageBundle.getMessage("angal.opd.pleaseinsertattendancedate"),
+					OHSeverityLevel.ERROR));
+		}
+		// Check Patient
 		if (GeneralData.OPDEXTENDED && opd.getPatient() == null) {
-			errors.add(new OHExceptionMessage("patientNullError", 
-	        		MessageBundle.getMessage("angal.opd.pleaseselectapatient"), 
-	        		OHSeverityLevel.ERROR));
+			errors.add(new OHExceptionMessage("patientNullError",
+					MessageBundle.getMessage("angal.opd.pleaseselectapatient"),
+					OHSeverityLevel.ERROR));
 		}
 		if (GeneralData.OPDEXTENDED && opd.getPatient() != null) {
 			/*
-			 * Age and Sex has not to be updated 
+			 * Age and Sex has not to be updated
 			 * for reporting purposes
 			 */
 			if (insert) {
@@ -89,59 +88,59 @@ public class OpdBrowserManager {
 				opd.setSex(opd.getPatient().getSex());
 			}
 		}
-		//Check Sex and Age
+		// Check Sex and Age
 		if (opd.getAge() < 0) {
-			errors.add(new OHExceptionMessage("invalidAgeError", 
-	        		MessageBundle.getMessage("angal.opd.insertage"), 
-	        		OHSeverityLevel.ERROR));
+			errors.add(new OHExceptionMessage("invalidAgeError",
+					MessageBundle.getMessage("angal.opd.insertage"),
+					OHSeverityLevel.ERROR));
 		}
 		if (opd.getSex() == ' ') {
-			errors.add(new OHExceptionMessage("noSexError", 
-	        		MessageBundle.getMessage("angal.opd.selectsex"), 
-	        		OHSeverityLevel.ERROR));
+			errors.add(new OHExceptionMessage("noSexError",
+					MessageBundle.getMessage("angal.opd.selectsex"),
+					OHSeverityLevel.ERROR));
 		}
-		//Check Disease n.1
+		// Check Disease n.1
 		if (disease == null) {
-			errors.add(new OHExceptionMessage("disease1NullOrEmptyError", 
-	        		MessageBundle.getMessage("angal.opd.pleaseselectadisease"), 
-	        		OHSeverityLevel.ERROR));
+			errors.add(new OHExceptionMessage("disease1NullOrEmptyError",
+					MessageBundle.getMessage("angal.opd.pleaseselectadisease"),
+					OHSeverityLevel.ERROR));
 		} else {
-			//Check double diseases
+			// Check double diseases
 			if (disease2 != null && disease.getCode().equals(disease2.getCode())) {
-				errors.add(new OHExceptionMessage("disease2equals1Error", 
-		        		MessageBundle.getMessage("angal.opd.duplicatediseasesnotallowed"), 
-		        		OHSeverityLevel.ERROR));
+				errors.add(new OHExceptionMessage("disease2equals1Error",
+						MessageBundle.getMessage("angal.opd.duplicatediseasesnotallowed"),
+						OHSeverityLevel.ERROR));
 			}
 			if (disease3 != null && disease.getCode().equals(disease3.getCode())) {
-				errors.add(new OHExceptionMessage("disease3equals1Error", 
-		        		MessageBundle.getMessage("angal.opd.duplicatediseasesnotallowed"), 
-		        		OHSeverityLevel.ERROR));
+				errors.add(new OHExceptionMessage("disease3equals1Error",
+						MessageBundle.getMessage("angal.opd.duplicatediseasesnotallowed"),
+						OHSeverityLevel.ERROR));
 			}
 			if (disease2 != null && disease3 != null && disease2.getCode().equals(disease3.getCode())) {
-				errors.add(new OHExceptionMessage("disease3equals2Error", 
-		        		MessageBundle.getMessage("angal.opd.duplicatediseasesnotallowed"), 
-		        		OHSeverityLevel.ERROR));
+				errors.add(new OHExceptionMessage("disease3equals2Error",
+						MessageBundle.getMessage("angal.opd.duplicatediseasesnotallowed"),
+						OHSeverityLevel.ERROR));
 			}
 		}
-		if (!errors.isEmpty()){
-	        throw new OHDataValidationException(errors);
-	    }
-    }
-	
+		if (!errors.isEmpty()) {
+			throw new OHDataValidationException(errors);
+		}
+	}
+
 	/**
 	 * Return all Opds of today or since one week ago
-	 * 
+	 *
 	 * @param oneWeek - if <code>true</code> return the last week, only today otherwise.
 	 * @return the list of Opds. It could be <code>null</code>.
-	 * @throws OHServiceException 
+	 * @throws OHServiceException
 	 */
-	public ArrayList<Opd> getOpd(boolean oneWeek) throws OHServiceException{
+	public ArrayList<Opd> getOpd(boolean oneWeek) throws OHServiceException {
 		return ioOperations.getOpdList(oneWeek);
 	}
-	
+
 	/**
 	 * Return all Opds within specified dates
-	 * 
+	 *
 	 * @param diseaseTypeCode
 	 * @param diseaseCode
 	 * @param dateFrom
@@ -151,19 +150,20 @@ public class OpdBrowserManager {
 	 * @param sex
 	 * @param newPatient
 	 * @return the list of Opds. It could be <code>null</code>.
-	 * @throws OHServiceException 
+	 * @throws OHServiceException
 	 */
-	public ArrayList<Opd> getOpd(String diseaseTypeCode,String diseaseCode, GregorianCalendar dateFrom,GregorianCalendar dateTo,int ageFrom, int ageTo,char sex,char newPatient) throws OHServiceException {
-		return ioOperations.getOpdList(diseaseTypeCode,diseaseCode,dateFrom,dateTo,ageFrom,ageTo,sex,newPatient);
+	public ArrayList<Opd> getOpd(String diseaseTypeCode, String diseaseCode, GregorianCalendar dateFrom, GregorianCalendar dateTo, int ageFrom, int ageTo,
+			char sex, char newPatient) throws OHServiceException {
+		return ioOperations.getOpdList(diseaseTypeCode, diseaseCode, dateFrom, dateTo, ageFrom, ageTo, sex, newPatient);
 	}
-	
+
 	/**
 	 * Returns all {@link Opd}s associated to specified patient ID
-	 * 
+	 *
 	 * @param patientcode - the patient ID
 	 * @return the list of {@link Opd}s associated to specified patient ID.
-	 * 		   the whole list of {@link Opd}s if <code>0</code> is passed.
-	 * @throws OHServiceException 
+	 * the whole list of {@link Opd}s if <code>0</code> is passed.
+	 * @throws OHServiceException
 	 */
 	public ArrayList<Opd> getOpdList(int patientcode) throws OHServiceException {
 		return ioOperations.getOpdList(patientcode);
@@ -171,10 +171,10 @@ public class OpdBrowserManager {
 
 	/**
 	 * Insert a new item in the db
-	 * 
+	 *
 	 * @param opd an {@link Opd}
 	 * @return <code>true</code> if the item has been inserted
-	 * @throws OHServiceException 
+	 * @throws OHServiceException
 	 */
 	public boolean newOpd(Opd opd) throws OHServiceException {
 		validateOpd(opd, true);
@@ -183,55 +183,57 @@ public class OpdBrowserManager {
 
 	/**
 	 * Updates the specified {@link Opd} object.
+	 *
 	 * @param opd - the {@link Opd} object to update.
 	 * @return the updated {@link Opd}
-	 * @throws OHServiceException 
+	 * @throws OHServiceException
 	 */
-	public Opd updateOpd(Opd opd) throws OHServiceException{
+	public Opd updateOpd(Opd opd) throws OHServiceException {
 		validateOpd(opd, false);
 		return ioOperations.updateOpd(opd);
 	}
 
 	/**
 	 * Delete an {@link Opd} from the db
-	 * 
+	 *
 	 * @param opd - the {@link Opd} to delete
 	 * @return <code>true</code> if the item has been deleted. <code>false</code> otherwise.
-	 * @throws OHServiceException 
+	 * @throws OHServiceException
 	 */
 	public boolean deleteOpd(Opd opd) throws OHServiceException {
 		return ioOperations.deleteOpd(opd);
 	}
-	
+
 	/**
 	 * Returns the max progressive number within specified year or within current year if <code>0</code>.
-	 * 
+	 *
 	 * @param year
 	 * @return <code>int</code> - the progressive number in the year
-	 * @throws OHServiceException 
+	 * @throws OHServiceException
 	 */
 	public int getProgYear(int year) throws OHServiceException {
 		return ioOperations.getProgYear(year);
 	}
-	
+
 	/**
 	 * Return the last {@link Opd} in time associated with specified patient ID.
-	 * 
+	 *
 	 * @param patientcode - the patient ID
 	 * @return last Opd associated with specified patient ID or <code>null</code>
-	 * @throws OHServiceException 
+	 * @throws OHServiceException
 	 */
 	public Opd getLastOpd(int patientcode) throws OHServiceException {
 		return ioOperations.getLastOpd(patientcode);
 	}
-	
+
 	/**
 	 * Check if the given {@code opdNum} does already exist for the give {@code year}
+	 *
 	 * @param opdNum - the OPD progressive in year
 	 * @param year - the year
 	 * @return <code>true</code> if the given number exists in year, <code>false</code> otherwise
 	 */
-	public Boolean isExistOpdNum(int opdNum, int year)  throws OHServiceException {
+	public Boolean isExistOpdNum(int opdNum, int year) throws OHServiceException {
 		return ioOperations.isExistOpdNum(opdNum, year);
 	}
 }

--- a/src/main/java/org/isf/opd/model/Opd.java
+++ b/src/main/java/org/isf/opd/model/Opd.java
@@ -168,7 +168,7 @@ public class Opd extends Auditable<String>
 	}
 	
 	public String getFullName() {
-		return patient.getName();
+		return patient == null ? "" : patient.getName();
 	}
 
 	public Patient getPatient() {

--- a/src/test/java/org/isf/opd/test/TestOpd.java
+++ b/src/test/java/org/isf/opd/test/TestOpd.java
@@ -27,6 +27,7 @@ import java.util.Calendar;
 import java.util.GregorianCalendar;
 
 import org.isf.disease.model.Disease;
+import org.isf.generaldata.GeneralData;
 import org.isf.opd.model.Opd;
 import org.isf.patient.model.Patient;
 import org.isf.utils.exception.OHException;
@@ -84,8 +85,12 @@ public class TestOpd {
 
 	public void check(Opd opd) {
 		assertThat(opd.getVisitDate()).isEqualTo(visitDate);
-		assertThat(opd.getAge()).isEqualTo(age);
-		assertThat(opd.getSex()).isEqualTo(sex);
+		if (!(GeneralData.OPDEXTENDED && opd.getPatient() != null)) {
+			// skip checks as OpdBrowserManager sets values from patient
+			// thus only do checks when not OPDEXTENDED and patient == null
+			assertThat(opd.getAge()).isEqualTo(age);
+			assertThat(opd.getSex()).isEqualTo(sex);
+		}
 		assertThat(opd.getNote()).isEqualTo(note);
 		assertThat(opd.getProgYear()).isEqualTo(prog_year);
 		assertThat(opd.getNewPatient()).isEqualTo(newPatient);

--- a/src/test/java/org/isf/opd/test/Tests.java
+++ b/src/test/java/org/isf/opd/test/Tests.java
@@ -22,6 +22,7 @@
 package org.isf.opd.test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -30,6 +31,7 @@ import java.util.Collection;
 import java.util.Date;
 import java.util.GregorianCalendar;
 
+import org.assertj.core.api.Condition;
 import org.isf.OHCoreTestCase;
 import org.isf.disease.model.Disease;
 import org.isf.disease.service.DiseaseIoOperationRepository;
@@ -38,6 +40,7 @@ import org.isf.distype.model.DiseaseType;
 import org.isf.distype.service.DiseaseTypeIoOperationRepository;
 import org.isf.distype.test.TestDiseaseType;
 import org.isf.generaldata.GeneralData;
+import org.isf.opd.manager.OpdBrowserManager;
 import org.isf.opd.model.Opd;
 import org.isf.opd.service.OpdIoOperationRepository;
 import org.isf.opd.service.OpdIoOperations;
@@ -45,7 +48,9 @@ import org.isf.patient.model.Patient;
 import org.isf.patient.model.PatientMergedEvent;
 import org.isf.patient.service.PatientIoOperationRepository;
 import org.isf.patient.test.TestPatient;
+import org.isf.utils.exception.OHDataValidationException;
 import org.isf.utils.exception.OHException;
+import org.isf.utils.exception.OHServiceException;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
@@ -78,6 +83,8 @@ public class Tests extends OHCoreTestCase {
 	OpdIoOperationRepository opdIoOperationRepository;
 	@Autowired
 	PatientIoOperationRepository patientIoOperationRepository;
+	@Autowired
+	OpdBrowserManager opdBrowserManager;
 	@Autowired
 	DiseaseTypeIoOperationRepository diseaseTypeIoOperationRepository;
 	@Autowired
@@ -123,7 +130,7 @@ public class Tests extends OHCoreTestCase {
 	}
 
 	@Test
-	public void testIoGetOpd() throws Exception {
+	public void testIoGetOpdList() throws Exception {
 		int code = _setupTestOpd(false);
 		Opd foundOpd = opdIoOperationRepository.findOne(code);
 		ArrayList<Opd> opds = opdIoOperation.getOpdList(
@@ -136,6 +143,36 @@ public class Tests extends OHCoreTestCase {
 				foundOpd.getSex(),
 				foundOpd.getNewPatient());
 		assertThat(opds.get(opds.size() - 1).getCode()).isEqualTo(foundOpd.getCode());
+	}
+
+	@Test
+	public void testIoGetOpdListPatientId() throws Exception {
+		int code = _setupTestOpd(false);
+		Opd foundOpd = opdIoOperationRepository.findOne(code);
+		ArrayList<Opd> opds = opdIoOperation.getOpdList(foundOpd.getPatient().getCode());
+		assertThat(opds.get(opds.size() - 1).getCode()).isEqualTo(foundOpd.getCode());
+	}
+
+	@Test
+	public void testIoGetOpdListPatientIdZero() throws Exception {
+		Patient patient = testPatient.setup(false);
+		DiseaseType diseaseType = testDiseaseType.setup(false);
+
+		Disease disease = testDisease.setup(diseaseType, false);
+		disease.setCode("angal.opd.alldisease");
+		disease.getType().setCode("angal.opd.alltype");
+
+		Opd opd = testOpd.setup(patient, disease, true);
+		GregorianCalendar now = new GregorianCalendar();
+		opd.setVisitDate(now);
+
+		patientIoOperationRepository.saveAndFlush(patient);
+		diseaseTypeIoOperationRepository.saveAndFlush(diseaseType);
+		diseaseIoOperationRepository.saveAndFlush(disease);
+		opdIoOperationRepository.saveAndFlush(opd);
+
+		ArrayList<Opd> opds = opdIoOperation.getOpdList(0);
+		assertThat(opds.get(opds.size() - 1).getCode()).isEqualTo(opd.getCode());
 	}
 
 	@Test
@@ -220,11 +257,19 @@ public class Tests extends OHCoreTestCase {
 	}
 
 	@Test
-	public void testIoGetProgYear() throws Exception {
+	public void testIoGetProgYearZero() throws Exception {
 		int code = _setupTestOpd(false);
 		int progYear = opdIoOperation.getProgYear(0);
 		Opd foundOpd = opdIoOperationRepository.findOne(code);
 		assertThat(progYear).isEqualTo(foundOpd.getProgYear());
+	}
+
+	@Test
+	public void testIoGetProgYear() throws Exception {
+		int code = _setupTestOpd(false);
+		Opd opd = opdIoOperationRepository.findOne(code);
+		int progYear = opdIoOperation.getProgYear(opd.getVisitDate().get(Calendar.YEAR));
+		assertThat(progYear).isEqualTo(opd.getProgYear());
 	}
 
 	@Test
@@ -287,6 +332,465 @@ public class Tests extends OHCoreTestCase {
 		// then:
 		Opd result = opdIoOperationRepository.findOne(id);
 		assertThat(result.getPatient().getCode()).isEqualTo(mergedPatient.getCode());
+	}
+
+	@Test
+	public void testMgrGetOpd() throws Exception {
+		int code = _setupTestOpd(false);
+		Opd foundOpd = opdIoOperationRepository.findOne(code);
+		ArrayList<Opd> opds = opdBrowserManager.getOpd(
+				foundOpd.getDisease().getType().getCode(),
+				foundOpd.getDisease().getCode(),
+				foundOpd.getVisitDate(),
+				foundOpd.getVisitDate(),
+				foundOpd.getAge() - 1,
+				foundOpd.getAge() + 1,
+				foundOpd.getSex(),
+				foundOpd.getNewPatient());
+		assertThat(opds.get(opds.size() - 1).getCode()).isEqualTo(foundOpd.getCode());
+	}
+
+	@Test
+	public void testMgrGetOpdListPatientId() throws Exception {
+		int code = _setupTestOpd(false);
+		Opd foundOpd = opdIoOperationRepository.findOne(code);
+		ArrayList<Opd> opds = opdBrowserManager.getOpdList(foundOpd.getPatient().getCode());
+		assertThat(opds.get(opds.size() - 1).getCode()).isEqualTo(foundOpd.getCode());
+	}
+
+	@Test
+	public void testMgrGetOpdListPatientIdZero() throws Exception {
+		Patient patient = testPatient.setup(false);
+		DiseaseType diseaseType = testDiseaseType.setup(false);
+
+		Disease disease = testDisease.setup(diseaseType, false);
+		disease.setCode("angal.opd.alldisease");
+		disease.getType().setCode("angal.opd.alltype");
+
+		Opd opd = testOpd.setup(patient, disease, true);
+		GregorianCalendar now = new GregorianCalendar();
+		opd.setVisitDate(now);
+
+		patientIoOperationRepository.saveAndFlush(patient);
+		diseaseTypeIoOperationRepository.saveAndFlush(diseaseType);
+		diseaseIoOperationRepository.saveAndFlush(disease);
+		opdIoOperationRepository.saveAndFlush(opd);
+
+		ArrayList<Opd> opds = opdBrowserManager.getOpdList(0);
+		assertThat(opds.get(opds.size() - 1).getCode()).isEqualTo(opd.getCode());
+	}
+
+	@Test
+	public void testMgrGetOpdToday() throws Exception {
+		Patient patient = testPatient.setup(false);
+		DiseaseType diseaseType = testDiseaseType.setup(false);
+
+		Disease disease = testDisease.setup(diseaseType, false);
+		disease.setCode("angal.opd.alldisease");
+		disease.getType().setCode("angal.opd.alltype");
+
+		Opd opd = testOpd.setup(patient, disease, true);
+		GregorianCalendar now = new GregorianCalendar();
+		opd.setVisitDate(now);
+
+		patientIoOperationRepository.saveAndFlush(patient);
+		diseaseTypeIoOperationRepository.saveAndFlush(diseaseType);
+		diseaseIoOperationRepository.saveAndFlush(disease);
+		opdIoOperationRepository.saveAndFlush(opd);
+
+		ArrayList<Opd> opds = opdBrowserManager.getOpd(false);
+		assertThat(opds.get(opds.size() - 1).getCode()).isEqualTo(opd.getCode());
+	}
+
+	@Test
+	public void testMgrGetOpdLastWeek() throws Exception {
+		Patient patient = testPatient.setup(false);
+		DiseaseType diseaseType = testDiseaseType.setup(false);
+
+		Disease disease = testDisease.setup(diseaseType, false);
+		disease.setCode("angal.opd.alldisease");
+		disease.getType().setCode("angal.opd.alltype");
+
+		Opd opd = testOpd.setup(patient, disease, true);
+		GregorianCalendar date = new GregorianCalendar();
+		date.add(Calendar.DAY_OF_MONTH, -3);
+		opd.setVisitDate(date);
+
+		patientIoOperationRepository.saveAndFlush(patient);
+		diseaseTypeIoOperationRepository.saveAndFlush(diseaseType);
+		diseaseIoOperationRepository.saveAndFlush(disease);
+		opdIoOperationRepository.saveAndFlush(opd);
+
+		ArrayList<Opd> opds = opdBrowserManager.getOpd(true);
+		assertThat(opds.get(opds.size() - 1).getCode()).isEqualTo(opd.getCode());
+	}
+
+	@Test
+	public void testMgrNewOpd() throws Exception {
+		Patient patient = testPatient.setup(false);
+		DiseaseType diseaseType = testDiseaseType.setup(false);
+		Disease disease = testDisease.setup(diseaseType, false);
+		patientIoOperationRepository.saveAndFlush(patient);
+		diseaseTypeIoOperationRepository.saveAndFlush(diseaseType);
+		diseaseIoOperationRepository.saveAndFlush(disease);
+		Opd opd = testOpd.setup(patient, disease, false);
+		// Need this to pass validation checks in manager
+		Disease disease2 = new Disease("998", "TestDescription 2", diseaseType);
+		diseaseIoOperationRepository.saveAndFlush(disease2);
+		Disease disease3 = new Disease("997", "TestDescription 3", diseaseType);
+		diseaseIoOperationRepository.saveAndFlush(disease3);
+		opd.setDisease2(disease2);
+		opd.setDisease3(disease3);
+		opd.setDate(new Date());
+		assertThat(opdBrowserManager.newOpd(opd)).isTrue();
+		_checkOpdIntoDb(opd.getCode());
+	}
+
+	@Test
+	public void testMgrUpdateOpd() throws Exception {
+		Patient patient = testPatient.setup(false);
+		DiseaseType diseaseType = testDiseaseType.setup(false);
+		Disease disease = testDisease.setup(diseaseType, false);
+		patientIoOperationRepository.saveAndFlush(patient);
+		diseaseTypeIoOperationRepository.saveAndFlush(diseaseType);
+		diseaseIoOperationRepository.saveAndFlush(disease);
+		Opd opd = testOpd.setup(patient, disease, false);
+		// Need this to pass validation checks in manager
+		Disease disease2 = new Disease("998", "TestDescription 2", diseaseType);
+		diseaseIoOperationRepository.saveAndFlush(disease2);
+		Disease disease3 = new Disease("997", "TestDescription 3", diseaseType);
+		diseaseIoOperationRepository.saveAndFlush(disease3);
+		opd.setDisease2(disease2);
+		opd.setDisease3(disease3);
+		opd.setDate(new Date());
+		assertThat(opdBrowserManager.newOpd(opd)).isTrue();
+		opd.setNote("Update");
+		assertThat(opdBrowserManager.updateOpd(opd)).isNotNull();
+		Opd updateOpd = opdIoOperationRepository.findOne(opd.getCode());
+		assertThat(updateOpd.getNote()).isEqualTo("Update");
+	}
+
+	@Test
+	public void testMgrDeleteOpd() throws Exception {
+		int code = _setupTestOpd(false);
+		Opd foundOpd = opdIoOperationRepository.findOne(code);
+		boolean result = opdBrowserManager.deleteOpd(foundOpd);
+		assertThat(result).isTrue();
+		result = opdIoOperation.isCodePresent(code);
+		assertThat(result).isFalse();
+	}
+
+	@Test
+	public void testMgrGetProgYearZero() throws Exception {
+		int code = _setupTestOpd(false);
+		int progYear = opdBrowserManager.getProgYear(0);
+		Opd foundOpd = opdIoOperationRepository.findOne(code);
+		assertThat(progYear).isEqualTo(foundOpd.getProgYear());
+	}
+
+	@Test
+	public void testMgrGetProgYear() throws Exception {
+		int code = _setupTestOpd(false);
+		Opd opd = opdIoOperationRepository.findOne(code);
+		int progYear = opdBrowserManager.getProgYear(opd.getVisitDate().get(Calendar.YEAR));
+		assertThat(progYear).isEqualTo(opd.getProgYear());
+	}
+
+	@Test
+	public void testMgrIsExistsOpdNumShouldReturnTrueWhenOpdWithGivenOPDProgressiveYearAndVisitYearExists() throws Exception {
+		int code = _setupTestOpd(false);
+		Opd opd = opdIoOperationRepository.findOne(code);
+		assertThat(opdBrowserManager.isExistOpdNum(opd.getProgYear(), opd.getVisitDate().get(Calendar.YEAR))).isTrue();
+	}
+
+	@Test
+	public void testMgrIsExistsOpdNumShouldReturnTrueWhenOpdNumExistsAndVisitYearIsNotProvided() throws Exception {
+		int code = _setupTestOpd(false);
+		Opd opd = opdIoOperationRepository.findOne(code);
+		assertThat(opdBrowserManager.isExistOpdNum(opd.getProgYear(), 0)).isTrue();
+	}
+
+	@Test
+	public void testMgrIsExistsOpdNumShouldReturnFalseWhenOpdNumExistsAndVisitYearIsIncorrect() throws Exception {
+		int code = _setupTestOpd(false);
+		Opd opd = opdIoOperationRepository.findOne(code);
+		assertThat(opdBrowserManager.isExistOpdNum(opd.getProgYear(), 1488)).isFalse();
+	}
+
+	@Test
+	public void testMgrGetLastOpd() throws Exception {
+		int code = _setupTestOpd(false);
+		Opd foundOpd = opdIoOperationRepository.findOne(code);
+		Opd lastOpd = opdBrowserManager.getLastOpd(foundOpd.getPatient().getCode());
+		assertThat(lastOpd.getCode()).isEqualTo(foundOpd.getCode());
+	}
+
+	@Test
+	public void testMgrValidationVisitDateNull() throws Exception {
+		assertThatThrownBy(() ->
+		{
+			Patient patient = testPatient.setup(false);
+			DiseaseType diseaseType = testDiseaseType.setup(false);
+			Disease disease = testDisease.setup(diseaseType, false);
+			Opd opd = testOpd.setup(patient, disease, false);
+			// Need this to pass validation checks in manager
+			opd.setDisease2(null);
+			opd.setDisease3(null);
+
+			// also let validation set userID
+			opd.setUserID(null);
+
+			opd.setVisitDate(null);
+			opdBrowserManager.newOpd(opd);
+		})
+				.isInstanceOf(OHDataValidationException.class)
+				.has(
+						new Condition<Throwable>(
+								(e -> ((OHServiceException) e).getMessages().size() == 1), "Expecting single validation error")
+				);
+	}
+
+	@Test
+	public void testMgrValidationOPDEXTENDEDPatientNull() throws Exception {
+		if (!GeneralData.OPDEXTENDED) {
+			return;
+		}
+		assertThatThrownBy(() ->
+		{
+			Patient patient = testPatient.setup(false);
+			DiseaseType diseaseType = testDiseaseType.setup(false);
+			Disease disease = testDisease.setup(diseaseType, false);
+			Opd opd = testOpd.setup(patient, disease, false);
+			// Need this to pass validation checks in manager
+			opd.setDisease2(null);
+			opd.setDisease3(null);
+
+			opd.setPatient(null);
+			opdBrowserManager.newOpd(opd);
+		})
+				.isInstanceOf(OHDataValidationException.class)
+				.has(
+						new Condition<Throwable>(
+								(e -> ((OHServiceException) e).getMessages().size() == 1), "Expecting single validation error")
+				);
+	}
+
+	@Test
+	public void testMgrValidationAgeIsLessThanZero() throws Exception {
+		assertThatThrownBy(() ->
+		{
+			Patient patient = testPatient.setup(false);
+			DiseaseType diseaseType = testDiseaseType.setup(false);
+			Disease disease = testDisease.setup(diseaseType, false);
+			Opd opd = testOpd.setup(patient, disease, false);
+			// Need this to pass validation checks in manager
+			opd.setDisease2(null);
+			opd.setDisease3(null);
+
+			opd.setAge(-99);
+			opdBrowserManager.updateOpd(opd);
+		})
+				.isInstanceOf(OHDataValidationException.class)
+				.has(
+						new Condition<Throwable>(
+								(e -> ((OHServiceException) e).getMessages().size() == 1), "Expecting single validation error")
+				);
+	}
+
+	@Test
+	public void testMgrValidationSexIsEmpty() throws Exception {
+		assertThatThrownBy(() ->
+		{
+			Patient patient = testPatient.setup(false);
+			DiseaseType diseaseType = testDiseaseType.setup(false);
+			Disease disease = testDisease.setup(diseaseType, false);
+			Opd opd = testOpd.setup(patient, disease, false);
+			// Need this to pass validation checks in manager
+			opd.setDisease2(null);
+			opd.setDisease3(null);
+
+			patient.setSex(' ');
+			opd.setSex(' ');
+			opdBrowserManager.newOpd(opd);
+		})
+				.isInstanceOf(OHDataValidationException.class)
+				.has(
+						new Condition<Throwable>(
+								(e -> ((OHServiceException) e).getMessages().size() == 1), "Expecting single validation error")
+				);
+	}
+
+	@Test
+	public void testMgrValidationDiseaseIsEmpty() throws Exception {
+		assertThatThrownBy(() ->
+		{
+			Patient patient = testPatient.setup(false);
+			DiseaseType diseaseType = testDiseaseType.setup(false);
+			Disease disease = testDisease.setup(diseaseType, false);
+			Opd opd = testOpd.setup(patient, disease, false);
+			// Need this to pass validation checks in manager
+			opd.setDisease2(null);
+			opd.setDisease3(null);
+
+			opd.setDisease(null);
+			opdBrowserManager.newOpd(opd);
+		})
+				.isInstanceOf(OHDataValidationException.class)
+				.has(
+						new Condition<Throwable>(
+								(e -> ((OHServiceException) e).getMessages().size() == 1), "Expecting single validation error")
+				);
+	}
+
+	@Test
+	public void testMgrValidationDiseaseIsEqualToDisease2() throws Exception {
+		assertThatThrownBy(() ->
+		{
+			Patient patient = testPatient.setup(false);
+			DiseaseType diseaseType = testDiseaseType.setup(false);
+			Disease disease = testDisease.setup(diseaseType, false);
+			Opd opd = testOpd.setup(patient, disease, false);
+
+			Disease disease2 = new Disease("997", "TestDescription 2", diseaseType);
+			opd.setDisease2(disease2);
+			opdBrowserManager.newOpd(opd);
+		})
+				.isInstanceOf(OHDataValidationException.class)
+				.has(
+						new Condition<Throwable>(
+								(e -> ((OHServiceException) e).getMessages().size() == 1), "Expecting single validation error")
+				);
+	}
+
+	@Test
+	public void testMgrValidationDiseaseIsEqualToDisease3() throws Exception {
+		assertThatThrownBy(() ->
+		{
+			Patient patient = testPatient.setup(false);
+			DiseaseType diseaseType = testDiseaseType.setup(false);
+			Disease disease = testDisease.setup(diseaseType, false);
+			Opd opd = testOpd.setup(patient, disease, false);
+
+			Disease disease3 = new Disease("998", "TestDescription 3", diseaseType);
+			opd.setDisease3(disease3);
+			opdBrowserManager.newOpd(opd);
+		})
+				.isInstanceOf(OHDataValidationException.class)
+				.has(
+						new Condition<Throwable>(
+								(e -> ((OHServiceException) e).getMessages().size() == 1), "Expecting single validation error")
+				);
+	}
+
+	@Test
+	public void testMgrValidationDisease2IsEqualToDisease3() throws Exception {
+		assertThatThrownBy(() ->
+		{
+			Patient patient = testPatient.setup(false);
+			DiseaseType diseaseType = testDiseaseType.setup(false);
+			Disease disease = testDisease.setup(diseaseType, false);
+			Opd opd = testOpd.setup(patient, disease, false);
+
+			Disease disease2 = new Disease("998", "TestDescription 2", diseaseType);
+			opd.setDisease2(disease2);
+			opd.setDisease3(disease2);
+			opdBrowserManager.newOpd(opd);
+		})
+				.isInstanceOf(OHDataValidationException.class)
+				.has(
+						new Condition<Throwable>(
+								(e -> ((OHServiceException) e).getMessages().size() == 1), "Expecting single validation error")
+				);
+	}
+
+	@Test
+	public void testOpdGetSet() throws Exception {
+		Patient patient = testPatient.setup(false);
+		DiseaseType diseaseType = testDiseaseType.setup(false);
+		Disease disease = testDisease.setup(diseaseType, false);
+		Opd opd = testOpd.setup(patient, disease, false);
+
+		Disease disease2 = new Disease("997", "TestDescription 2", diseaseType);
+		opd.setDisease2(disease2);
+
+		Disease disease3 = new Disease("998", "TestDescription 3", diseaseType);
+		opd.setDisease3(disease3);
+
+		opd.getPatient().setFirstName("John");
+		opd.getPatient().setSecondName("Smith");
+		assertThat(opd.getFullName()).isEqualTo("John Smith");
+
+		assertThat(opd.getfirstName()).isEqualTo("John");
+		assertThat(opd.getsecondName()).isEqualTo("Smith");
+
+		opd.getPatient().setFirstName(null);
+		opd.getPatient().setSecondName(null);
+
+		assertThat(opd.getFullName()).isEqualTo("null null");
+		assertThat(opd.getfirstName()).isNull();
+		assertThat(opd.getsecondName()).isNull();
+
+		opd.getPatient().setNextKin("nextOfKin");
+		opd.getPatient().setCity("city");
+		opd.getPatient().setAddress("address");
+
+		assertThat(opd.getnextKin()).isEqualTo("nextOfKin");
+		assertThat(opd.getcity()).isEqualTo("city");
+		assertThat(opd.getaddress()).isEqualTo("address");
+
+		opd.getPatient().setNextKin(null);
+		opd.getPatient().setCity(null);
+		opd.getPatient().setAddress(null);
+
+		assertThat(opd.getnextKin()).isNull();
+		assertThat(opd.getcity()).isNull();
+		assertThat(opd.getaddress()).isNull();
+
+		opd.setPatient(null);
+
+		assertThat(opd.getFullName()).isEmpty();
+		assertThat(opd.getfirstName()).isEmpty();
+		assertThat(opd.getsecondName()).isEmpty();
+		assertThat(opd.getnextKin()).isEmpty();
+		assertThat(opd.getcity()).isEmpty();
+		assertThat(opd.getaddress()).isEmpty();
+
+		opd.setCode(32000);
+		assertThat(opd.getCode()).isEqualTo(32000);
+
+		assertThat(opd.getDisease2()).isEqualTo(disease2);
+		assertThat(opd.getDisease3()).isEqualTo(disease3);
+
+		opd.setLock(-1);
+		assertThat(opd.getLock()).isEqualTo(-1);
+
+		opd.setNextVisitDate(new GregorianCalendar(9999, 0, 1));
+		assertThat(opd.getNextVisitDate()).isEqualTo(new GregorianCalendar(9999, 0, 1));
+	}
+
+	@Test
+	public void testOpdHashCode() throws Exception {
+		Patient patient = testPatient.setup(false);
+		DiseaseType diseaseType = testDiseaseType.setup(false);
+		Disease disease = testDisease.setup(diseaseType, false);
+		Opd opd = testOpd.setup(patient, disease, false);
+		// compute
+		int hashCode = opd.hashCode();
+		assertThat(hashCode).isEqualTo(23 * 133 + opd.getCode());
+		// used computed value
+		assertThat(opd.hashCode()).isEqualTo(hashCode);
+	}
+
+	@Test
+	public void testOpdEquals() throws Exception {
+		Patient patient = testPatient.setup(false);
+		DiseaseType diseaseType = testDiseaseType.setup(false);
+		Disease disease = testDisease.setup(diseaseType, false);
+		Opd opd = testOpd.setup(patient, disease, false);
+
+		assertThat(opd.equals(opd)).isTrue();
+		assertThat(opd).isNotEqualTo(null);
+		assertThat(opd).isNotEqualTo("someString");
 	}
 
 	private Patient _setupTestPatient(boolean usingSet) throws Exception {

--- a/src/test/java/org/isf/opd/test/Tests.java
+++ b/src/test/java/org/isf/opd/test/Tests.java
@@ -109,18 +109,18 @@ public class Tests extends OHCoreTestCase {
 		cleanH2InMemoryDb();
 	}
 
-	@Test
-	public void testOpdGets() throws Exception {
-		int code = _setupTestOpd(false);
-		_checkOpdIntoDb(code);
-	}
-
 	@Parameterized.Parameters(name = "Test with OPDEXTENDED={0}")
 	public static Collection<Object[]> opdExtended() {
 		return Arrays.asList(new Object[][] {
 				{ false },
 				{ true }
 		});
+	}
+	
+	@Test
+	public void testOpdGets() throws Exception {
+		int code = _setupTestOpd(false);
+		_checkOpdIntoDb(code);
 	}
 
 	@Test

--- a/src/test/java/org/isf/opd/test/Tests.java
+++ b/src/test/java/org/isf/opd/test/Tests.java
@@ -185,15 +185,31 @@ public class Tests extends OHCoreTestCase {
 		disease.getType().setCode("angal.opd.alltype");
 
 		Opd opd = testOpd.setup(patient, disease, true);
-		GregorianCalendar now = new GregorianCalendar();
-		opd.setVisitDate(now);
+		// set date to be today
+		opd.setVisitDate(new GregorianCalendar());
 
 		patientIoOperationRepository.saveAndFlush(patient);
 		diseaseTypeIoOperationRepository.saveAndFlush(diseaseType);
 		diseaseIoOperationRepository.saveAndFlush(disease);
 		opdIoOperationRepository.saveAndFlush(opd);
+		Patient patient2 = testPatient.setup(false);
+		DiseaseType diseaseType2 = testDiseaseType.setup(false);
+
+		Disease disease2 = testDisease.setup(diseaseType2, false);
+
+		Opd opd2 = testOpd.setup(patient2, disease2, true);
+		GregorianCalendar now = new GregorianCalendar();
+		// set date to be 14 days ago (not within the TODAY test)
+		now.add(Calendar.DAY_OF_MONTH, -14);
+		opd2.setVisitDate(now);
+
+		patientIoOperationRepository.saveAndFlush(patient2);
+		diseaseTypeIoOperationRepository.saveAndFlush(diseaseType2);
+		diseaseIoOperationRepository.saveAndFlush(disease2);
+		opdIoOperationRepository.saveAndFlush(opd2);
 
 		ArrayList<Opd> opds = opdIoOperation.getOpdList(false);
+		assertThat(opds).hasSize(1);
 		assertThat(opds.get(opds.size() - 1).getCode()).isEqualTo(opd.getCode());
 	}
 
@@ -208,6 +224,7 @@ public class Tests extends OHCoreTestCase {
 
 		Opd opd = testOpd.setup(patient, disease, true);
 		GregorianCalendar date = new GregorianCalendar();
+		// set date to be 3 days ago (within last week)
 		date.add(Calendar.DAY_OF_MONTH, -3);
 		opd.setVisitDate(date);
 
@@ -216,7 +233,24 @@ public class Tests extends OHCoreTestCase {
 		diseaseIoOperationRepository.saveAndFlush(disease);
 		opdIoOperationRepository.saveAndFlush(opd);
 
+		Patient patient2 = testPatient.setup(false);
+		DiseaseType diseaseType2 = testDiseaseType.setup(false);
+
+		Disease disease2 = testDisease.setup(diseaseType2, false);
+
+		Opd opd2 = testOpd.setup(patient2, disease2, true);
+		GregorianCalendar date2 = new GregorianCalendar();
+		// set date to be 13 days aga (not within last week)
+		date2.add(Calendar.DAY_OF_MONTH, -13);
+		opd2.setVisitDate(date2);
+
+		patientIoOperationRepository.saveAndFlush(patient2);
+		diseaseTypeIoOperationRepository.saveAndFlush(diseaseType2);
+		diseaseIoOperationRepository.saveAndFlush(disease2);
+		opdIoOperationRepository.saveAndFlush(opd2);
+
 		ArrayList<Opd> opds = opdIoOperation.getOpdList(true);
+		assertThat(opds).hasSize(1);
 		assertThat(opds.get(opds.size() - 1).getCode()).isEqualTo(opd.getCode());
 	}
 
@@ -390,15 +424,32 @@ public class Tests extends OHCoreTestCase {
 		disease.getType().setCode("angal.opd.alltype");
 
 		Opd opd = testOpd.setup(patient, disease, true);
-		GregorianCalendar now = new GregorianCalendar();
-		opd.setVisitDate(now);
+		// set date to be today
+		opd.setVisitDate(new GregorianCalendar());
 
 		patientIoOperationRepository.saveAndFlush(patient);
 		diseaseTypeIoOperationRepository.saveAndFlush(diseaseType);
 		diseaseIoOperationRepository.saveAndFlush(disease);
 		opdIoOperationRepository.saveAndFlush(opd);
 
+		Patient patient2 = testPatient.setup(false);
+		DiseaseType diseaseType2 = testDiseaseType.setup(false);
+
+		Disease disease2 = testDisease.setup(diseaseType2, false);
+
+		Opd opd2 = testOpd.setup(patient2, disease2, true);
+		GregorianCalendar now = new GregorianCalendar();
+		// set date to be 14 days ago (not within the TODAY test)
+		now.add(Calendar.DAY_OF_MONTH, -14);
+		opd2.setVisitDate(now);
+
+		patientIoOperationRepository.saveAndFlush(patient2);
+		diseaseTypeIoOperationRepository.saveAndFlush(diseaseType2);
+		diseaseIoOperationRepository.saveAndFlush(disease2);
+		opdIoOperationRepository.saveAndFlush(opd2);
+
 		ArrayList<Opd> opds = opdBrowserManager.getOpd(false);
+		assertThat(opds).hasSize(1);
 		assertThat(opds.get(opds.size() - 1).getCode()).isEqualTo(opd.getCode());
 	}
 
@@ -413,6 +464,7 @@ public class Tests extends OHCoreTestCase {
 
 		Opd opd = testOpd.setup(patient, disease, true);
 		GregorianCalendar date = new GregorianCalendar();
+		// set date to be 3 days ago (within last week)
 		date.add(Calendar.DAY_OF_MONTH, -3);
 		opd.setVisitDate(date);
 
@@ -421,7 +473,24 @@ public class Tests extends OHCoreTestCase {
 		diseaseIoOperationRepository.saveAndFlush(disease);
 		opdIoOperationRepository.saveAndFlush(opd);
 
+		Patient patient2 = testPatient.setup(false);
+		DiseaseType diseaseType2 = testDiseaseType.setup(false);
+
+		Disease disease2 = testDisease.setup(diseaseType2, false);
+
+		Opd opd2 = testOpd.setup(patient2, disease2, true);
+		GregorianCalendar date2 = new GregorianCalendar();
+		// set date to be 13 days ago (not within last week)
+		date2.add(Calendar.DAY_OF_MONTH, -13);
+		opd2.setVisitDate(date2);
+
+		patientIoOperationRepository.saveAndFlush(patient2);
+		diseaseTypeIoOperationRepository.saveAndFlush(diseaseType2);
+		diseaseIoOperationRepository.saveAndFlush(disease2);
+		opdIoOperationRepository.saveAndFlush(opd2);
+
 		ArrayList<Opd> opds = opdBrowserManager.getOpd(true);
+		assertThat(opds).hasSize(1);
 		assertThat(opds.get(opds.size() - 1).getCode()).isEqualTo(opd.getCode());
 	}
 

--- a/src/test/java/org/isf/opd/test/Tests.java
+++ b/src/test/java/org/isf/opd/test/Tests.java
@@ -24,7 +24,9 @@ package org.isf.opd.test;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Calendar;
+import java.util.Collection;
 import java.util.Date;
 import java.util.GregorianCalendar;
 
@@ -35,6 +37,7 @@ import org.isf.disease.test.TestDisease;
 import org.isf.distype.model.DiseaseType;
 import org.isf.distype.service.DiseaseTypeIoOperationRepository;
 import org.isf.distype.test.TestDiseaseType;
+import org.isf.generaldata.GeneralData;
 import org.isf.opd.model.Opd;
 import org.isf.opd.service.OpdIoOperationRepository;
 import org.isf.opd.service.OpdIoOperations;
@@ -45,11 +48,24 @@ import org.isf.patient.test.TestPatient;
 import org.isf.utils.exception.OHException;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.test.context.junit4.rules.SpringClassRule;
+import org.springframework.test.context.junit4.rules.SpringMethodRule;
 
+@RunWith(Parameterized.class)
 public class Tests extends OHCoreTestCase {
+
+	@ClassRule
+	public static final SpringClassRule springClassRule = new SpringClassRule();
+
+	@Rule
+	public final SpringMethodRule springMethodRule = new SpringMethodRule();
 
 	private static TestOpd testOpd;
 	private static TestPatient testPatient;
@@ -69,6 +85,10 @@ public class Tests extends OHCoreTestCase {
 	@Autowired
 	ApplicationEventPublisher applicationEventPublisher;
 
+	public Tests(boolean opdExtended) {
+		GeneralData.OPDEXTENDED = opdExtended;
+	}
+
 	@BeforeClass
 	public static void setUpClass() {
 		testOpd = new TestOpd();
@@ -86,6 +106,14 @@ public class Tests extends OHCoreTestCase {
 	public void testOpdGets() throws Exception {
 		int code = _setupTestOpd(false);
 		_checkOpdIntoDb(code);
+	}
+
+	@Parameterized.Parameters(name = "Test with OPDEXTENDED={0}")
+	public static Collection<Object[]> opdExtended() {
+		return Arrays.asList(new Object[][] {
+				{ false },
+				{ true }
+		});
 	}
 
 	@Test


### PR DESCRIPTION
Use parameterized testing method for OPDEXTENDED with `true` and `false` values.

Coverage before:
![image](https://user-images.githubusercontent.com/1105445/107576688-7c1af880-6bbf-11eb-8a99-00f2a293239c.png)

Coverage after:
![image](https://user-images.githubusercontent.com/1105445/107576732-863cf700-6bbf-11eb-8590-5630ed25cbec.png)
