### PR TITLE
Chore: use parameterized logging message instead of concatenation

### DIFF
--- a/src/main/java/org/isf/sms/service/SmsSenderGSM.java
+++ b/src/main/java/org/isf/sms/service/SmsSenderGSM.java
@@ -117,7 +117,7 @@ public class SmsSenderGSM implements SmsSenderInterface, SerialPortEventListener
 					serialPort.addEventListener(this);
 					serialPort.notifyOnDataAvailable(true);
 				} catch (TooManyListenersException e) {
-					logger.debug("Too many listeners. (" + e.toString() + ")");
+					logger.debug("Too many listeners. ({})", e.toString());
 				}
 
 			} catch (PortInUseException e) {


### PR DESCRIPTION
Use more efficient parameterized logging message instead of concatenation; this was just introduced with a recent push.