### PR TITLE
OP-439 Increase coverage and format Model file

### DIFF
--- a/src/main/java/org/isf/patvac/manager/PatVacManager.java
+++ b/src/main/java/org/isf/patvac/manager/PatVacManager.java
@@ -28,8 +28,8 @@ import java.util.List;
 import org.isf.generaldata.MessageBundle;
 import org.isf.patvac.model.PatientVaccine;
 import org.isf.patvac.service.PatVacIoOperations;
-import org.isf.utils.exception.OHServiceException;
 import org.isf.utils.exception.OHDataValidationException;
+import org.isf.utils.exception.OHServiceException;
 import org.isf.utils.exception.model.OHExceptionMessage;
 import org.isf.utils.exception.model.OHSeverityLevel;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -50,22 +50,22 @@ public class PatVacManager {
 
 	@Autowired
 	private PatVacIoOperations ioOperations;
-	
+
 	/**
 	 * Returns all {@link PatientVaccine}s of today or one week ago
-	 * 
+	 *
 	 * @param minusOneWeek - if <code>true</code> return the last week
 	 * @return the list of {@link PatientVaccine}s
-	 * @throws OHServiceException 
-	 */  
+	 * @throws OHServiceException
+	 */
 	public ArrayList<PatientVaccine> getPatientVaccine(boolean minusOneWeek) throws OHServiceException {
-        return  ioOperations.getPatientVaccine(minusOneWeek);
+		return ioOperations.getPatientVaccine(minusOneWeek);
 	}
-	
+
 	/**
 	 * Returns all {@link PatientVaccine}s within <code>dateFrom</code> and
 	 * <code>dateTo</code>
-	 * 
+	 *
 	 * @param vaccineTypeCode
 	 * @param vaccineCode
 	 * @param dateFrom
@@ -74,92 +74,93 @@ public class PatVacManager {
 	 * @param ageFrom
 	 * @param ageTo
 	 * @return the list of {@link PatientVaccine}s
-	 * @throws OHServiceException 
+	 * @throws OHServiceException
 	 */
-	public ArrayList<PatientVaccine> getPatientVaccine(String vaccineTypeCode,String vaccineCode, 
-													   GregorianCalendar dateFrom, GregorianCalendar dateTo, 
-													   char sex, int ageFrom, int ageTo) throws OHServiceException {
-        return ioOperations.getPatientVaccine(vaccineTypeCode, vaccineCode, dateFrom, dateTo, sex, ageFrom, ageTo);
+	public ArrayList<PatientVaccine> getPatientVaccine(String vaccineTypeCode, String vaccineCode,
+			GregorianCalendar dateFrom, GregorianCalendar dateTo,
+			char sex, int ageFrom, int ageTo) throws OHServiceException {
+		return ioOperations.getPatientVaccine(vaccineTypeCode, vaccineCode, dateFrom, dateTo, sex, ageFrom, ageTo);
 	}
 
 	/**
 	 * Inserts a {@link PatientVaccine} in the DB
-	 * 
+	 *
 	 * @param patVac - the {@link PatientVaccine} to insert
-	 * @return <code>true</code> if the item has been inserted, <code>false</code> otherwise 
-	 * @throws OHServiceException 
+	 * @return <code>true</code> if the item has been inserted, <code>false</code> otherwise
+	 * @throws OHServiceException
 	 */
 	public boolean newPatientVaccine(PatientVaccine patVac) throws OHServiceException {
-        validatePatientVaccine(patVac);
-        return ioOperations.newPatientVaccine(patVac);
+		validatePatientVaccine(patVac);
+		return ioOperations.newPatientVaccine(patVac);
 	}
 
 	/**
 	 * Updates a {@link PatientVaccine}
-	 * 
+	 *
 	 * @param patVac - the {@link PatientVaccine} to update
-	 * @return <code>true</code> if the item has been updated, <code>false</code> otherwise 
-	 * @throws OHServiceException 
+	 * @return <code>true</code> if the item has been updated, <code>false</code> otherwise
+	 * @throws OHServiceException
 	 */
 	public boolean updatePatientVaccine(PatientVaccine patVac) throws OHServiceException {
-        validatePatientVaccine(patVac);
-        return ioOperations.updatePatientVaccine(patVac);
+		validatePatientVaccine(patVac);
+		return ioOperations.updatePatientVaccine(patVac);
 	}
 
 	/**
 	 * Deletes a {@link PatientVaccine}
-	 * 
+	 *
 	 * @param patVac - the {@link PatientVaccine} to delete
-	 * @return <code>true</code> if the item has been deleted, <code>false</code> otherwise 
-	 * @throws OHServiceException 
+	 * @return <code>true</code> if the item has been deleted, <code>false</code> otherwise
+	 * @throws OHServiceException
 	 */
 	public boolean deletePatientVaccine(PatientVaccine patVac) throws OHServiceException {
-        return ioOperations.deletePatientVaccine(patVac);
+		return ioOperations.deletePatientVaccine(patVac);
 	}
-	
+
 	/**
 	 * Returns the max progressive number within specified year or within current year if <code>0</code>.
-	 * 
+	 *
 	 * @param year
 	 * @return <code>int</code> - the progressive number in the year
-	 * @throws OHServiceException 
+	 * @throws OHServiceException
 	 */
 	public int getProgYear(int year) throws OHServiceException {
-        return ioOperations.getProgYear(year);
+		return ioOperations.getProgYear(year);
 	}
 
 	/**
 	 * Verify if the object is valid for CRUD and return a list of errors, if any
+	 *
 	 * @param patientVaccine
-	 * @throws OHDataValidationException 
+	 * @throws OHDataValidationException
 	 */
-    protected void validatePatientVaccine(PatientVaccine patientVaccine) throws OHDataValidationException{
-        List<OHExceptionMessage> errors = new ArrayList<OHExceptionMessage>();
+	protected void validatePatientVaccine(PatientVaccine patientVaccine) throws OHDataValidationException {
+		List<OHExceptionMessage> errors = new ArrayList<>();
 
-        if(patientVaccine.getVaccineDate() == null){
-            errors.add(new OHExceptionMessage(MessageBundle.getMessage("angal.hospital"),
-                    MessageBundle.getMessage("angal.patvac.pleaseinsertvaccinedate"),
-                    OHSeverityLevel.ERROR));
-        }
-        if(patientVaccine.getProgr() < 0){
-            errors.add(new OHExceptionMessage(MessageBundle.getMessage("angal.hospital"),
-                    MessageBundle.getMessage("angal.patvac.pleaseinsertavalidprogressive"),
-                    OHSeverityLevel.ERROR));
-        }
-        if(patientVaccine.getVaccine() == null){
-            errors.add(new OHExceptionMessage(MessageBundle.getMessage("angal.hospital"),
-                    MessageBundle.getMessage("angal.patvac.pleaseselectavaccine"),
-                    OHSeverityLevel.ERROR));
-        }
-        if(patientVaccine.getPatient() == null
-                || StringUtils.isEmpty(patientVaccine.getPatName())
-                || StringUtils.isEmpty(String.valueOf(patientVaccine.getPatSex()))){
-            errors.add(new OHExceptionMessage(MessageBundle.getMessage("angal.hospital"),
-                    MessageBundle.getMessage("angal.patvac.pleaseselectapatient"),
-                    OHSeverityLevel.ERROR));
-        }
-        if(!errors.isEmpty()){
-	        throw new OHDataValidationException(errors);
-	    }
-    }
+		if (patientVaccine.getVaccineDate() == null) {
+			errors.add(new OHExceptionMessage(MessageBundle.getMessage("angal.hospital"),
+					MessageBundle.getMessage("angal.patvac.pleaseinsertvaccinedate"),
+					OHSeverityLevel.ERROR));
+		}
+		if (patientVaccine.getProgr() < 0) {
+			errors.add(new OHExceptionMessage(MessageBundle.getMessage("angal.hospital"),
+					MessageBundle.getMessage("angal.patvac.pleaseinsertavalidprogressive"),
+					OHSeverityLevel.ERROR));
+		}
+		if (patientVaccine.getVaccine() == null) {
+			errors.add(new OHExceptionMessage(MessageBundle.getMessage("angal.hospital"),
+					MessageBundle.getMessage("angal.patvac.pleaseselectavaccine"),
+					OHSeverityLevel.ERROR));
+		}
+		if (patientVaccine.getPatient() == null
+				|| StringUtils.isEmpty(patientVaccine.getPatName())
+				|| StringUtils.isEmpty(String.valueOf(patientVaccine.getPatSex()))) {
+			errors.add(new OHExceptionMessage(MessageBundle.getMessage("angal.hospital"),
+					MessageBundle.getMessage("angal.patvac.pleaseselectapatient"),
+					OHSeverityLevel.ERROR));
+		}
+		if (!errors.isEmpty()) {
+			throw new OHDataValidationException(errors);
+		}
+	}
 }

--- a/src/main/java/org/isf/patvac/model/PatientVaccine.java
+++ b/src/main/java/org/isf/patvac/model/PatientVaccine.java
@@ -22,9 +22,9 @@
 package org.isf.patvac.model;
 
 import java.util.GregorianCalendar;
+
 import javax.persistence.AttributeOverride;
 import javax.persistence.AttributeOverrides;
-
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.EntityListeners;
@@ -37,8 +37,8 @@ import javax.persistence.Table;
 import javax.persistence.Transient;
 import javax.validation.constraints.NotNull;
 
-import org.isf.utils.db.Auditable;
 import org.isf.patient.model.Patient;
+import org.isf.utils.db.Auditable;
 import org.isf.vaccine.model.Vaccine;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
@@ -195,7 +195,6 @@ public class PatientVaccine extends Auditable<String>
 		this.patient.setSex(patSex);
 	}
 
-
 	@Override
 	public int hashCode() {
 		final int prime = 31;
@@ -204,8 +203,7 @@ public class PatientVaccine extends Auditable<String>
 		hascode = prime * hascode + ((patient == null) ? 0 : patient.hashCode());
 		hascode = prime * hascode + progr;
 		hascode = prime * hascode + ((vaccine == null) ? 0 : vaccine.hashCode());
-		hascode = prime * hascode
-				+ ((vaccineDate == null) ? 0 : vaccineDate.hashCode());
+		hascode = prime * hascode + ((vaccineDate == null) ? 0 : vaccineDate.hashCode());
 		return hascode;
 	}
 
@@ -224,24 +222,19 @@ public class PatientVaccine extends Auditable<String>
 		if (code != other.code) {
 			return false;
 		}
-		if (patient == null && other.patient != null) {
-				return false;
+		if ((patient != null && !patient.equals(other.patient))
+				|| (other.patient != null && !other.patient.equals(patient))) {
+			return false;
 		}
 		if (progr != other.progr) {
 			return false;
 		}
-		if (vaccine == null) {
-			if (other.vaccine != null) {
-				return false;
-			}
-		} else if (!vaccine.equals(other.vaccine)) {
+		if ((vaccine != null && !vaccine.equals(other.vaccine))
+				|| (other.vaccine != null && !other.vaccine.equals(vaccine))) {
 			return false;
 		}
-		if (vaccineDate == null) {
-			if (other.vaccineDate != null) {
-				return false;
-			}
-		} else if (!vaccineDate.equals(other.vaccineDate)) {
+		if ((vaccineDate != null && !vaccineDate.equals(other.vaccineDate))
+				|| (other.vaccineDate != null && !other.vaccineDate.equals(vaccineDate))) {
 			return false;
 		}
 		return true;

--- a/src/test/java/org/isf/patvac/test/Tests.java
+++ b/src/test/java/org/isf/patvac/test/Tests.java
@@ -193,7 +193,7 @@ public class Tests extends OHCoreTestCase {
 	public void testIoGetProgYear() throws Exception {
 		int prog_year = 0;
 		int found_prog_year = 0;
-		_setupTestPatientVaccine(false);
+		_setupTestPatientVaccine(true);
 		List<PatientVaccine> patientVaccineList = patvacIoOperation.getPatientVaccine(null, null, null, null, 'A', 0, 0);
 		for (PatientVaccine patVac : patientVaccineList) {
 			if (patVac.getProgr() > found_prog_year)
@@ -224,38 +224,82 @@ public class Tests extends OHCoreTestCase {
 	@Test
 	public void testMgrGetPatientVaccineToday() throws Exception {
 		VaccineType vaccineType = testVaccineType.setup(false);
+		vaccineType.setCode("A");
 		Vaccine vaccine = testVaccine.setup(vaccineType, false);
+		vaccine.setCode("ABC");
 		Patient patient = testPatient.setup(false);
+		patient.setCode(1);
 		PatientVaccine patientVaccine = testPatientVaccine.setup(patient, vaccine, true);
 
-		patientVaccine.setVaccineDate(new GregorianCalendar());
+		// Today
+		GregorianCalendar now = new GregorianCalendar();
+		patientVaccine.setVaccineDate(now);
 
 		vaccineTypeIoOperationRepository.saveAndFlush(vaccineType);
 		vaccineIoOperationRepository.saveAndFlush(vaccine);
 		patientIoOperationRepository.saveAndFlush(patient);
 		patVacIoOperationRepository.saveAndFlush(patientVaccine);
 
+		VaccineType vaccineType2 = testVaccineType.setup(false);
+		vaccineType2.setCode("Z");
+		Vaccine vaccine2 = testVaccine.setup(vaccineType, false);
+		vaccine2.setCode("CBA");
+		Patient patient2 = testPatient.setup(false);
+		patient2.setCode(2);
+		PatientVaccine patientVaccine2 = testPatientVaccine.setup(patient2, vaccine2, true);
+
+		// 8 days ago
+		now.add(Calendar.DATE, -8);
+		patientVaccine2.setVaccineDate(now);
+
+		vaccineTypeIoOperationRepository.saveAndFlush(vaccineType2);
+		vaccineIoOperationRepository.saveAndFlush(vaccine2);
+		patientIoOperationRepository.saveAndFlush(patient2);
+		patVacIoOperationRepository.saveAndFlush(patientVaccine2);
+
 		ArrayList<PatientVaccine> patientVaccines = patVacManager.getPatientVaccine(false);
+		assertThat(patientVaccines).hasSize(1);
 		assertThat(patientVaccines.get(patientVaccines.size() - 1).getPatName()).isEqualTo(patientVaccine.getPatName());
 	}
 
 	@Test
 	public void testMgrGetPatientVaccineLastWeek() throws Exception {
 		VaccineType vaccineType = testVaccineType.setup(false);
+		vaccineType.setCode("A");
 		Vaccine vaccine = testVaccine.setup(vaccineType, false);
+		vaccine.setCode("ABC");
 		Patient patient = testPatient.setup(false);
+		patient.setCode(1);
 		PatientVaccine patientVaccine = testPatientVaccine.setup(patient, vaccine, true);
 
-		GregorianCalendar date = new GregorianCalendar();
-		date.add(Calendar.DAY_OF_MONTH, -3);
-		patientVaccine.setVaccineDate(date);
+		GregorianCalendar now = new GregorianCalendar();
+		now.add(Calendar.DAY_OF_MONTH, -3);
+		patientVaccine.setVaccineDate(now);
 
 		vaccineTypeIoOperationRepository.saveAndFlush(vaccineType);
 		vaccineIoOperationRepository.saveAndFlush(vaccine);
 		patientIoOperationRepository.saveAndFlush(patient);
 		patVacIoOperationRepository.saveAndFlush(patientVaccine);
 
+		VaccineType vaccineType2 = testVaccineType.setup(false);
+		vaccineType2.setCode("Z");
+		Vaccine vaccine2 = testVaccine.setup(vaccineType, false);
+		vaccine2.setCode("CBA");
+		Patient patient2 = testPatient.setup(false);
+		patient2.setCode(2);
+		PatientVaccine patientVaccine2 = testPatientVaccine.setup(patient2, vaccine2, true);
+
+		// 8 days ago
+		now.add(Calendar.DATE, -8);
+		patientVaccine2.setVaccineDate(now);
+
+		vaccineTypeIoOperationRepository.saveAndFlush(vaccineType2);
+		vaccineIoOperationRepository.saveAndFlush(vaccine2);
+		patientIoOperationRepository.saveAndFlush(patient2);
+		patVacIoOperationRepository.saveAndFlush(patientVaccine2);
+
 		ArrayList<PatientVaccine> patientVaccines = patVacManager.getPatientVaccine(true);
+		assertThat(patientVaccines).hasSize(1);
 		assertThat(patientVaccines.get(patientVaccines.size() - 1).getPatName()).isEqualTo(patientVaccine.getPatName());
 	}
 

--- a/src/test/java/org/isf/patvac/test/Tests.java
+++ b/src/test/java/org/isf/patvac/test/Tests.java
@@ -22,20 +22,24 @@
 package org.isf.patvac.test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.GregorianCalendar;
 import java.util.List;
 
+import org.assertj.core.api.Condition;
 import org.isf.OHCoreTestCase;
 import org.isf.patient.model.Patient;
 import org.isf.patient.model.PatientMergedEvent;
 import org.isf.patient.service.PatientIoOperationRepository;
 import org.isf.patient.test.TestPatient;
+import org.isf.patvac.manager.PatVacManager;
 import org.isf.patvac.model.PatientVaccine;
 import org.isf.patvac.service.PatVacIoOperationRepository;
 import org.isf.patvac.service.PatVacIoOperations;
+import org.isf.utils.exception.OHServiceException;
 import org.isf.vaccine.model.Vaccine;
 import org.isf.vaccine.service.VaccineIoOperationRepository;
 import org.isf.vaccine.test.TestVaccine;
@@ -60,6 +64,8 @@ public class Tests extends OHCoreTestCase {
 	PatVacIoOperations patvacIoOperation;
 	@Autowired
 	PatientIoOperationRepository patientIoOperationRepository;
+	@Autowired
+	PatVacManager patVacManager;
 	@Autowired
 	VaccineIoOperationRepository vaccineIoOperationRepository;
 	@Autowired
@@ -215,6 +221,305 @@ public class Tests extends OHCoreTestCase {
 		assertThat(result.getPatient().getCode()).isEqualTo(mergedPatient.getCode());
 	}
 
+	@Test
+	public void testMgrGetPatientVaccineToday() throws Exception {
+		VaccineType vaccineType = testVaccineType.setup(false);
+		Vaccine vaccine = testVaccine.setup(vaccineType, false);
+		Patient patient = testPatient.setup(false);
+		PatientVaccine patientVaccine = testPatientVaccine.setup(patient, vaccine, true);
+
+		patientVaccine.setVaccineDate(new GregorianCalendar());
+
+		vaccineTypeIoOperationRepository.saveAndFlush(vaccineType);
+		vaccineIoOperationRepository.saveAndFlush(vaccine);
+		patientIoOperationRepository.saveAndFlush(patient);
+		patVacIoOperationRepository.saveAndFlush(patientVaccine);
+
+		ArrayList<PatientVaccine> patientVaccines = patVacManager.getPatientVaccine(false);
+		assertThat(patientVaccines.get(patientVaccines.size() - 1).getPatName()).isEqualTo(patientVaccine.getPatName());
+	}
+
+	@Test
+	public void testMgrGetPatientVaccineLastWeek() throws Exception {
+		VaccineType vaccineType = testVaccineType.setup(false);
+		Vaccine vaccine = testVaccine.setup(vaccineType, false);
+		Patient patient = testPatient.setup(false);
+		PatientVaccine patientVaccine = testPatientVaccine.setup(patient, vaccine, true);
+
+		GregorianCalendar date = new GregorianCalendar();
+		date.add(Calendar.DAY_OF_MONTH, -3);
+		patientVaccine.setVaccineDate(date);
+
+		vaccineTypeIoOperationRepository.saveAndFlush(vaccineType);
+		vaccineIoOperationRepository.saveAndFlush(vaccine);
+		patientIoOperationRepository.saveAndFlush(patient);
+		patVacIoOperationRepository.saveAndFlush(patientVaccine);
+
+		ArrayList<PatientVaccine> patientVaccines = patVacManager.getPatientVaccine(true);
+		assertThat(patientVaccines.get(patientVaccines.size() - 1).getPatName()).isEqualTo(patientVaccine.getPatName());
+	}
+
+	@Test
+	public void testMgrGetPatientVaccine() throws Exception {
+		int code = _setupTestPatientVaccine(false);
+		PatientVaccine foundPatientVaccine = patVacIoOperationRepository.findOne(code);
+		ArrayList<PatientVaccine> patientVaccines = patVacManager.getPatientVaccine(
+				foundPatientVaccine.getVaccine().getVaccineType().getCode(),
+				foundPatientVaccine.getVaccine().getCode(),
+				foundPatientVaccine.getVaccineDate(),
+				foundPatientVaccine.getVaccineDate(),
+				foundPatientVaccine.getPatient().getSex(),
+				foundPatientVaccine.getPatient().getAge(),
+				foundPatientVaccine.getPatient().getAge());
+		assertThat(patientVaccines.get(patientVaccines.size() - 1).getPatName()).isEqualTo(foundPatientVaccine.getPatName());
+	}
+
+	@Test
+	@Transactional // requires active session because of lazy loading patient
+	public void testMgrUpdatePatientVaccine() throws Exception {
+		int code = _setupTestPatientVaccine(false);
+		PatientVaccine foundPatientVaccine = patVacIoOperationRepository.findOne(code);
+		foundPatientVaccine.setPatName("Update");
+		boolean result = patVacManager.updatePatientVaccine(foundPatientVaccine);
+		assertThat(result).isTrue();
+		PatientVaccine updatePatientVaccine = patVacIoOperationRepository.findOne(code);
+		assertThat(updatePatientVaccine.getPatName()).isEqualTo("Update");
+	}
+
+	@Test
+	public void testMgrNewPatientVaccine() throws Exception {
+		Patient patient = testPatient.setup(false);
+		VaccineType vaccineType = testVaccineType.setup(false);
+		Vaccine vaccine = testVaccine.setup(vaccineType, false);
+		patientIoOperationRepository.saveAndFlush(patient);
+		vaccineTypeIoOperationRepository.saveAndFlush(vaccineType);
+		vaccineIoOperationRepository.saveAndFlush(vaccine);
+		PatientVaccine patientVaccine = testPatientVaccine.setup(patient, vaccine, true);
+		boolean result = patVacManager.newPatientVaccine(patientVaccine);
+		assertThat(result).isTrue();
+		_checkPatientVaccineIntoDb(patientVaccine.getCode());
+	}
+
+	@Test
+	public void testMgrDeletePatientVaccine() throws Exception {
+		int code = _setupTestPatientVaccine(true);
+		PatientVaccine foundPatientVaccine = patVacIoOperationRepository.findOne(code);
+		assertThat(patVacManager.deletePatientVaccine(foundPatientVaccine)).isTrue();
+		assertThat(patvacIoOperation.isCodePresent(code)).isFalse();
+	}
+
+	@Test
+	public void testMgrGetProgYear() throws Exception {
+		int prog_year = 0;
+		int found_prog_year = 0;
+		_setupTestPatientVaccine(true);
+		List<PatientVaccine> patientVaccineList = patVacManager.getPatientVaccine(null, null, null, null, 'A', 0, 0);
+		for (PatientVaccine patVac : patientVaccineList) {
+			if (patVac.getProgr() > found_prog_year)
+				found_prog_year = patVac.getProgr();
+		}
+		prog_year = patVacManager.getProgYear(0);
+		assertThat(prog_year).isEqualTo(found_prog_year);
+
+		prog_year = patVacManager.getProgYear(1984); //TestPatientVaccine's year
+		assertThat(prog_year).isEqualTo(10);
+	}
+
+	@Test
+	public void testMgrValidationVaccineDateIsNull() {
+		assertThatThrownBy(() -> {
+			VaccineType vaccineType = testVaccineType.setup(false);
+			Vaccine vaccine = testVaccine.setup(vaccineType, false);
+			Patient patient = testPatient.setup(false);
+			PatientVaccine patientVaccine = testPatientVaccine.setup(patient, vaccine, true);
+
+			patientVaccine.setVaccineDate(null);
+
+			patVacManager.newPatientVaccine(patientVaccine);
+		})
+				.isInstanceOf(OHServiceException.class)
+				.has(
+						new Condition<Throwable>(
+								(e -> ((OHServiceException) e).getMessages().size() == 1), "Expecting single validation error")
+				);
+	}
+
+	@Test
+	public void testMgrValidationProgrLessThanZero() {
+		assertThatThrownBy(() -> {
+			VaccineType vaccineType = testVaccineType.setup(false);
+			Vaccine vaccine = testVaccine.setup(vaccineType, false);
+			Patient patient = testPatient.setup(false);
+			PatientVaccine patientVaccine = testPatientVaccine.setup(patient, vaccine, true);
+
+			patientVaccine.setProgr(-99);
+
+			patVacManager.newPatientVaccine(patientVaccine);
+		})
+				.isInstanceOf(OHServiceException.class)
+				.has(
+						new Condition<Throwable>(
+								(e -> ((OHServiceException) e).getMessages().size() == 1), "Expecting single validation error")
+				);
+	}
+
+	@Test
+	public void testMgrValidationVaccineIsNull() {
+		assertThatThrownBy(() -> {
+			VaccineType vaccineType = testVaccineType.setup(false);
+			Vaccine vaccine = testVaccine.setup(vaccineType, false);
+			Patient patient = testPatient.setup(false);
+			PatientVaccine patientVaccine = testPatientVaccine.setup(patient, vaccine, true);
+
+			patientVaccine.setVaccine(null);
+
+			patVacManager.newPatientVaccine(patientVaccine);
+		})
+				.isInstanceOf(OHServiceException.class)
+				.has(
+						new Condition<Throwable>(
+								(e -> ((OHServiceException) e).getMessages().size() == 1), "Expecting single validation error")
+				);
+	}
+
+	@Test
+	public void testMgrValidationPatientIsNull() {
+		assertThatThrownBy(() -> {
+			VaccineType vaccineType = testVaccineType.setup(false);
+			Vaccine vaccine = testVaccine.setup(vaccineType, false);
+			Patient patient = testPatient.setup(false);
+			PatientVaccine patientVaccine = testPatientVaccine.setup(patient, vaccine, true);
+
+			patientVaccine.setPatient(null);
+
+			patVacManager.newPatientVaccine(patientVaccine);
+		})
+				.isInstanceOf(OHServiceException.class)
+				.has(
+						new Condition<Throwable>(
+								(e -> ((OHServiceException) e).getMessages().size() == 1), "Expecting single validation error")
+				);
+	}
+
+	@Test
+	public void testMgrValidationPatientNameIsEmpty() {
+		assertThatThrownBy(() -> {
+			VaccineType vaccineType = testVaccineType.setup(false);
+			Vaccine vaccine = testVaccine.setup(vaccineType, false);
+			Patient patient = testPatient.setup(false);
+			PatientVaccine patientVaccine = testPatientVaccine.setup(patient, vaccine, true);
+
+			patientVaccine.getPatient().setFirstName(" ");
+
+			patVacManager.newPatientVaccine(patientVaccine);
+		})
+				.isInstanceOf(OHServiceException.class)
+				.has(
+						new Condition<Throwable>(
+								(e -> ((OHServiceException) e).getMessages().size() == 1), "Expecting single validation error")
+				);
+	}
+
+	@Test
+	public void testMgrValidationPatientSexIsEmpty() {
+		assertThatThrownBy(() -> {
+			VaccineType vaccineType = testVaccineType.setup(false);
+			Vaccine vaccine = testVaccine.setup(vaccineType, false);
+			Patient patient = testPatient.setup(false);
+			PatientVaccine patientVaccine = testPatientVaccine.setup(patient, vaccine, true);
+
+			patientVaccine.getPatient().setSex(' ');
+
+			patVacManager.newPatientVaccine(patientVaccine);
+		})
+				.isInstanceOf(OHServiceException.class)
+				.has(
+						new Condition<Throwable>(
+								(e -> ((OHServiceException) e).getMessages().size() == 1), "Expecting single validation error")
+				);
+	}
+
+	@Test
+	public void testPatientVaccineConstuctor() {
+		PatientVaccine patientVaccine = new PatientVaccine(0, 10, new GregorianCalendar(), new Patient(), new Vaccine(), 0,
+				"patName", 21, 'F');
+
+		assertThat(patientVaccine.getPatAge()).isEqualTo(21);
+		patientVaccine.setPatAge(-1);
+		assertThat(patientVaccine.getPatAge()).isEqualTo(-1);
+
+		assertThat(patientVaccine.getPatSex()).isEqualTo('F');
+		patientVaccine.setPatSex(' ');
+		assertThat(patientVaccine.getPatSex()).isEqualTo(' ');
+	}
+
+	@Test
+	public void testPatientVaccineHashCode() {
+		PatientVaccine patientVaccine = new PatientVaccine(0, 0, null, new Patient(), null, 0,
+				"patName", 21, 'F');
+		patientVaccine.setPatient(null);
+		assertThat(patientVaccine.hashCode()).isEqualTo(31 * 31 * 31 * 31 * 31);
+	}
+
+	@Test
+	public void testPatientVaccineEquals() {
+		PatientVaccine patientVaccine1 = new PatientVaccine(0, 0, null, new Patient(), null, 0,
+				"patName", 21, 'F');
+		PatientVaccine patientVaccine2 = new PatientVaccine(0, 0, null, new Patient(), null, 0,
+				"patName", 21, 'F');
+
+		assertThat(patientVaccine1.equals(patientVaccine1)).isTrue();
+		assertThat(patientVaccine1.equals(null)).isFalse();
+		assertThat(patientVaccine1).isNotEqualTo("someString");
+
+		patientVaccine2.setCode(-99);
+		assertThat(patientVaccine1).isNotEqualTo(patientVaccine2);
+
+		patientVaccine2.setCode(patientVaccine1.getCode());
+		patientVaccine2.setPatient(null);
+		assertThat(patientVaccine1).isNotEqualTo(patientVaccine2);
+
+		patientVaccine1.setPatient(null);
+		patientVaccine2.setPatient(new Patient());
+		patientVaccine2.getPatient().setCode(1);
+		assertThat(patientVaccine1).isNotEqualTo(patientVaccine2);
+
+		patientVaccine1.setPatient(new Patient());
+		patientVaccine1.getPatient().setCode(1);
+		assertThat(patientVaccine1).isEqualTo(patientVaccine2);
+
+		patientVaccine2.setProgr(-99);
+		assertThat(patientVaccine1).isNotEqualTo(patientVaccine2);
+
+		patientVaccine2.setProgr(patientVaccine1.getProgr());
+		patientVaccine2.setVaccine(new Vaccine());
+		patientVaccine2.getVaccine().setCode("Z");
+		patientVaccine2.getVaccine().setDescription("desciption");
+		patientVaccine2.getVaccine().setVaccineType(new VaccineType());
+		patientVaccine2.getVaccine().getVaccineType().setCode("A");
+		patientVaccine2.getVaccine().getVaccineType().setDescription("description");
+		assertThat(patientVaccine1).isNotEqualTo(patientVaccine2);
+
+		patientVaccine1.setVaccine(new Vaccine());
+		patientVaccine1.getVaccine().setCode("Z");
+		patientVaccine1.getVaccine().setDescription("desciption");
+		patientVaccine1.getVaccine().setVaccineType(new VaccineType());
+		patientVaccine1.getVaccine().getVaccineType().setCode("A");
+		patientVaccine1.getVaccine().getVaccineType().setDescription("description");
+		assertThat(patientVaccine1).isEqualTo(patientVaccine2);
+
+		patientVaccine1.setVaccineDate(new GregorianCalendar());
+		patientVaccine2.setVaccineDate(null);
+		assertThat(patientVaccine1).isNotEqualTo(patientVaccine2);
+
+		patientVaccine2.setVaccineDate(patientVaccine1.getVaccineDate());
+		patientVaccine1.setVaccineDate(null);
+		assertThat(patientVaccine1).isNotEqualTo(patientVaccine2);
+
+		patientVaccine2.setVaccineDate(null);
+		assertThat(patientVaccine1).isEqualTo(patientVaccine2);
+	}
+
 	private Patient _setupTestPatient(boolean usingSet) throws Exception {
 		Patient patient = testPatient.setup(usingSet);
 		patientIoOperationRepository.saveAndFlush(patient);
@@ -233,7 +538,7 @@ public class Tests extends OHCoreTestCase {
 		return patientVaccine.getCode();
 	}
 
-	private void _checkPatientVaccineIntoDb(int code) throws Exception {
+	private void _checkPatientVaccineIntoDb(int code) {
 		PatientVaccine foundPatientVaccine = patVacIoOperationRepository.findOne(code);
 		testPatientVaccine.check(foundPatientVaccine);
 	}

--- a/src/test/java/org/isf/patvac/test/Tests.java
+++ b/src/test/java/org/isf/patvac/test/Tests.java
@@ -228,7 +228,6 @@ public class Tests extends OHCoreTestCase {
 		Vaccine vaccine = testVaccine.setup(vaccineType, false);
 		vaccine.setCode("ABC");
 		Patient patient = testPatient.setup(false);
-		patient.setCode(1);
 		PatientVaccine patientVaccine = testPatientVaccine.setup(patient, vaccine, true);
 
 		// Today
@@ -241,11 +240,10 @@ public class Tests extends OHCoreTestCase {
 		patVacIoOperationRepository.saveAndFlush(patientVaccine);
 
 		VaccineType vaccineType2 = testVaccineType.setup(false);
-		vaccineType2.setCode("Z");
-		Vaccine vaccine2 = testVaccine.setup(vaccineType, false);
+		vaccineType2.setCode("X");
+		Vaccine vaccine2 = testVaccine.setup(vaccineType2, false);
 		vaccine2.setCode("CBA");
 		Patient patient2 = testPatient.setup(false);
-		patient2.setCode(2);
 		PatientVaccine patientVaccine2 = testPatientVaccine.setup(patient2, vaccine2, true);
 
 		// 8 days ago
@@ -266,10 +264,13 @@ public class Tests extends OHCoreTestCase {
 	public void testMgrGetPatientVaccineLastWeek() throws Exception {
 		VaccineType vaccineType = testVaccineType.setup(false);
 		vaccineType.setCode("A");
+		vaccineType.setDescription("Type Description1");
 		Vaccine vaccine = testVaccine.setup(vaccineType, false);
 		vaccine.setCode("ABC");
+		vaccine.setDescription("Description1");
 		Patient patient = testPatient.setup(false);
-		patient.setCode(1);
+		patient.setFirstName("firstName1");
+		patient.setSecondName("secondName1");
 		PatientVaccine patientVaccine = testPatientVaccine.setup(patient, vaccine, true);
 
 		GregorianCalendar now = new GregorianCalendar();
@@ -283,10 +284,13 @@ public class Tests extends OHCoreTestCase {
 
 		VaccineType vaccineType2 = testVaccineType.setup(false);
 		vaccineType2.setCode("Z");
-		Vaccine vaccine2 = testVaccine.setup(vaccineType, false);
+		vaccineType2.setDescription("Type Description2");
+		Vaccine vaccine2 = testVaccine.setup(vaccineType2, false);
 		vaccine2.setCode("CBA");
+		vaccine2.setDescription("Description2");
 		Patient patient2 = testPatient.setup(false);
-		patient2.setCode(2);
+		patient2.setFirstName("firstName2");
+		patient2.setSecondName("secondName2");
 		PatientVaccine patientVaccine2 = testPatientVaccine.setup(patient2, vaccine2, true);
 
 		// 8 days ago


### PR DESCRIPTION
Coverage before:
![image](https://user-images.githubusercontent.com/1105445/107881622-22fadf80-6eb3-11eb-82ab-6e239ed81a42.png)

Coverage after:
![image](https://user-images.githubusercontent.com/1105445/107881630-29895700-6eb3-11eb-9906-572c2125615e.png)

Also improvements to `equals()` routine to handle more `null` cases.