### PR TITLE
Chore: add log4.properties file to test/resources

### DIFF
--- a/src/test/resources/log4j.properties
+++ b/src/test/resources/log4j.properties
@@ -1,0 +1,27 @@
+# logging di default su file, livello FINEST (debug++)
+log4j.rootLogger=INFO, StdOut
+log4j.rootCategory=FINEST, null
+
+# Null appender (off)
+log4j.appender.null=org.apache.log4j.varia.NullAppender
+
+# StdOut Appender (with classes) (not used)
+log4j.appender.StdOut = org.apache.log4j.ConsoleAppender
+log4j.appender.StdOut.layout=org.apache.log4j.PatternLayout
+log4j.appender.StdOut.layout.ConversionPattern=[%d{dd/MMM/yyyy HH:mm:ss}] [%X{OHUserGroup}:%X{OHUser}] %-p - %m%n
+
+# Assigning appenders to packages
+log4j.category.org.isf=INFO,StdOut
+log4j.additivity.org.isf = false
+
+# Assigning appenders to Hibernate packages, set
+# - hibernate.SQL to DEBUG for SQL queries to be logged
+# - hibernate.type to TRACE for queries parameters to be logged with "binding parameter [?]"
+log4j.logger.org.hibernate=INFO,StdOut
+#log4j.logger.org.hibernate.SQL=DEBUG,StdOut
+#log4j.logger.org.hibernate.type=INFO,StdOut
+#log4j.logger.org.springframework.beans=INFO,StdOut
+#log4j.additivity.org.springframework.beans = true
+#logging.level.ROOT=INFO
+#logging.level.org.springframework.orm.jpa=DEBUG
+#logging.level.org.springframework.transaction=DEBUG


### PR DESCRIPTION
Add `log4.properties` to `test/resources` so the testing code doesn't complain about misconfigured log4j statements