### PR TITLE
Chore instanceOf returns false for null

### DIFF
--- a/src/main/java/org/isf/medicalstock/manager/MovStockInsertingManager.java
+++ b/src/main/java/org/isf/medicalstock/manager/MovStockInsertingManager.java
@@ -92,14 +92,14 @@ public class MovStockInsertingManager {
 			// Check supplier
 			if (movement.getType().getType().contains("+")) {
 				Object supplier = movement.getSupplier();
-				if (supplier == null || supplier instanceof String) {
+				if (supplier instanceof String) {
 					errors.add(new OHExceptionMessage("emptyOrNullSupplierError",
 							MessageBundle.getMessage("angal.medicalstock.multiplecharging.pleaseselectasupplier"), //$NON-NLS-1$
 							OHSeverityLevel.ERROR));
 				}
 			} else {
 				Object ward = movement.getWard();
-				if (ward == null || ward instanceof String) {
+				if (ward instanceof String) {
 					errors.add(new OHExceptionMessage("emptyOrNullWardError",
 							MessageBundle.getMessage("angal.medicalstock.multipledischarging.pleaseselectaward"), //$NON-NLS-1$
 							OHSeverityLevel.ERROR));


### PR DESCRIPTION
No need to test for `null` because `instanceOf` always returns `false` for a `null` value.

Found with SpotBugs.