### PR TITLE
OP-251 Close connection after opening it. Fixes Connection leak.

### DIFF
--- a/src/main/java/org/isf/stat/manager/JasperReportsManager.java
+++ b/src/main/java/org/isf/stat/manager/JasperReportsManager.java
@@ -780,6 +780,7 @@ public class JasperReportsManager {
         final Map localParameters = parameters;
         Connection connection = dataSource.getConnection();
         JasperPrint jasperPrint = JasperFillManager.fillReport(jasperReport, localParameters, connection);
+        connection.close();
         return new JasperReportResultDto(jasperPrint, jasperFilename, filename);
     }
 


### PR DESCRIPTION
I did some debugging, and it looks like the thread is in waiting state because of

at com.mchange.v2.resourcepool.BasicResourcePool.awaitAvailable(BasicResourcePool.java:1414)

After some googling, it looks like this comment from SO describes why it happens: https://stackoverflow.com/a/14108717

So, most probably, the Connection object leak.

I added a close connection operation in generateJasperReport, 

After running the application with this change I cannot reproduce the bug, but I'm not 100% sure as it reproduced previously from time to time.