### PR TITLE
OP-450 fix getDaysBetweenDate() and parseDate()

### DIFF
--- a/src/main/java/org/isf/utils/time/TimeTools.java
+++ b/src/main/java/org/isf/utils/time/TimeTools.java
@@ -30,7 +30,6 @@ import java.util.Calendar;
 import java.util.Date;
 import java.util.GregorianCalendar;
 
-import org.isf.generaldata.GeneralData;
 import org.isf.generaldata.MessageBundle;
 import org.isf.utils.db.DbQueryLogger;
 import org.isf.utils.exception.OHException;
@@ -39,29 +38,20 @@ import org.joda.time.Period;
 import org.joda.time.PeriodType;
 
 /**
- * Some useful functions for time calculation.
+ * Some useful functions for time calculations.
  *
  * @author Mwithi
  */
 public class TimeTools {
 
-	public static final String YYYY_MM_DD = "yyyy-MM-dd";
+	public static final String YYYY_MM_DD_HH_MM_SS = "yyyy-MM-dd HH:mm:ss";
 
-	public static void main(String[] args) {
-		GeneralData.getGeneralData();
-		MessageBundle.initialize();
-		GregorianCalendar dateFrom = new GregorianCalendar(2014, 10, 1);
-		GregorianCalendar dateTo = new GregorianCalendar();
-		System.out.println("Formatted Age: " + getFormattedAge(dateFrom.getTime()));
-		System.out.println("Days between: " + getDaysBetweenDates(dateFrom, dateTo, true));
-		System.out.println("Weeks between: " + getWeeksBetweenDates(dateFrom, dateTo, true));
-		System.out.println("Months between: " + getMonthsBetweenDates(dateFrom, dateTo, true));
+	private TimeTools() {
 	}
-	
-	
-	
+
 	/**
 	 * Returns <code>true</code> if the DATE part is the same (no matter the time)
+	 *
 	 * @param aDate
 	 * @param today
 	 * @return
@@ -73,70 +63,73 @@ public class TimeTools {
 		date2.setTime(today);
 		return isSameDay(date1, date2);
 	}
+
 	public static boolean isSameDay(GregorianCalendar aDate, GregorianCalendar today) {
 		return (aDate.get(Calendar.YEAR) == today.get(Calendar.YEAR)) &&
-			   (aDate.get(Calendar.MONTH) == today.get(Calendar.MONTH)) &&
-			   (aDate.get(Calendar.DAY_OF_MONTH) == today.get(Calendar.DAY_OF_MONTH));
+				(aDate.get(Calendar.MONTH) == today.get(Calendar.MONTH)) &&
+				(aDate.get(Calendar.DAY_OF_MONTH) == today.get(Calendar.DAY_OF_MONTH));
 	}
 
 	/**
 	 * Returns the difference in days between two dates
+	 *
 	 * @param from
 	 * @param to
 	 * @param ignoreTime - if <code>True</code> only dates will be compared
 	 * @return the number of days, negative if from is after to
 	 */
 	public static int getDaysBetweenDates(GregorianCalendar from, GregorianCalendar to, boolean ignoreTime) {
-		
+
 		if (ignoreTime) {
-			from.set(GregorianCalendar.HOUR_OF_DAY, 0);
-			from.set(GregorianCalendar.MINUTE, 0);
-			from.set(GregorianCalendar.SECOND, 0);
-			to.set(GregorianCalendar.HOUR_OF_DAY, 0);
-			to.set(GregorianCalendar.MINUTE, 0);
-			to.set(GregorianCalendar.SECOND, 0);
+			from.set(Calendar.HOUR_OF_DAY, 0);
+			from.set(Calendar.MINUTE, 0);
+			from.set(Calendar.SECOND, 0);
+			to.set(Calendar.HOUR_OF_DAY, 0);
+			to.set(Calendar.MINUTE, 0);
+			to.set(Calendar.SECOND, 0);
 		}
-		
+
 		DateTime dateFrom = new DateTime(from);
 		DateTime dateTo = new DateTime(to);
 		Period period = new Period(dateFrom, dateTo, PeriodType.days());
 		return period.getDays();
 	}
-	
+
 	/**
 	 * Returns the difference in days between two dates
+	 *
 	 * @param from
 	 * @param to
 	 * @param ignoreTime - if <code>True</code> only dates will be compared
 	 * @return the number of days, negative if from is after to
 	 */
 	public static int getDaysBetweenDates(Date from, Date to, boolean ignoreTime) {
-		
 		if (ignoreTime) {
-			GregorianCalendar dateFrom = new GregorianCalendar(); 
+			GregorianCalendar dateFrom = new GregorianCalendar();
 			GregorianCalendar dateTo = new GregorianCalendar();
 			dateFrom.setTime(from);
-			dateFrom.set(GregorianCalendar.HOUR_OF_DAY, 0);
-			dateFrom.set(GregorianCalendar.MINUTE, 0);
-			dateFrom.set(GregorianCalendar.SECOND, 0);
-			
+			dateFrom.set(Calendar.HOUR_OF_DAY, 0);
+			dateFrom.set(Calendar.MINUTE, 0);
+			dateFrom.set(Calendar.SECOND, 0);
+
 			dateTo.setTime(to);
-			dateTo.set(GregorianCalendar.HOUR_OF_DAY, 0);
-			dateTo.set(GregorianCalendar.MINUTE, 0);
-			dateTo.set(GregorianCalendar.SECOND, 0);
-			
+			dateTo.set(Calendar.HOUR_OF_DAY, 0);
+			dateTo.set(Calendar.MINUTE, 0);
+			dateTo.set(Calendar.SECOND, 0);
+
 			from = dateFrom.getTime();
-			to = dateFrom.getTime();
+			to = dateTo.getTime();
 		}
-		
+
 		DateTime dateFrom = new DateTime(from);
 		DateTime dateTo = new DateTime(to);
 		Period period = new Period(dateFrom, dateTo, PeriodType.days());
 		return period.getDays();
 	}
-	
+
 	/**
 	 * Returns the difference in weeks between two dates
+	 *
 	 * @param from
 	 * @param to
 	 * @param ignoreTime - if <code>True</code> only dates will be compared
@@ -145,50 +138,51 @@ public class TimeTools {
 	public static int getWeeksBetweenDates(GregorianCalendar from, GregorianCalendar to, boolean ignoreTime) {
 
 		if (ignoreTime) {
-			from.set(GregorianCalendar.HOUR_OF_DAY, 0);
-			from.set(GregorianCalendar.MINUTE, 0);
-			from.set(GregorianCalendar.SECOND, 0);
-			to.set(GregorianCalendar.HOUR_OF_DAY, 0);
-			to.set(GregorianCalendar.MINUTE, 0);
-			to.set(GregorianCalendar.SECOND, 0);
+			from.set(Calendar.HOUR_OF_DAY, 0);
+			from.set(Calendar.MINUTE, 0);
+			from.set(Calendar.SECOND, 0);
+			to.set(Calendar.HOUR_OF_DAY, 0);
+			to.set(Calendar.MINUTE, 0);
+			to.set(Calendar.SECOND, 0);
 		}
-		
+
 		DateTime dateFrom = new DateTime(from);
 		DateTime dateTo = new DateTime(to);
 		Period period = new Period(dateFrom, dateTo, PeriodType.weeks());
 		return period.getWeeks();
 	}
-	
+
 	/**
 	 * Returns the difference in months between two dates
+	 *
 	 * @param from
 	 * @param to
 	 * @param ignoreTime - if <code>True</code> only dates will be compared
 	 * @return the number of days, negative if from is after to
 	 */
 	public static int getMonthsBetweenDates(GregorianCalendar from, GregorianCalendar to, boolean ignoreTime) {
-		
+
 		if (ignoreTime) {
-			from.set(GregorianCalendar.HOUR_OF_DAY, 0);
-			from.set(GregorianCalendar.MINUTE, 0);
-			from.set(GregorianCalendar.SECOND, 0);
-			to.set(GregorianCalendar.HOUR_OF_DAY, 0);
-			to.set(GregorianCalendar.MINUTE, 0);
-			to.set(GregorianCalendar.SECOND, 0);
+			from.set(Calendar.HOUR_OF_DAY, 0);
+			from.set(Calendar.MINUTE, 0);
+			from.set(Calendar.SECOND, 0);
+			to.set(Calendar.HOUR_OF_DAY, 0);
+			to.set(Calendar.MINUTE, 0);
+			to.set(Calendar.SECOND, 0);
 		}
-		
+
 		DateTime dateFrom = new DateTime(from);
 		DateTime dateTo = new DateTime(to);
 		Period period = new Period(dateFrom, dateTo, PeriodType.months());
 		return period.getMonths();
 	}
-	
+
 	/**
 	 * Return the age in the format {years}y {months}m {days}d or with other locale pattern
-	 * 
-	 * @author Mwithi 
+	 *
 	 * @param birthDate - the birthdate
 	 * @return string with the formatted age
+	 * @author Mwithi
 	 */
 	public static String getFormattedAge(Date birthDate) {
 		GregorianCalendar birthday = new GregorianCalendar();
@@ -203,27 +197,33 @@ public class TimeTools {
 		}
 		return age;
 	}
-	
+
 	/**
 	 * Return a string representation of the dateTime with the given pattern
+	 *
 	 * @param dateTime - a GregorianCalendar object
 	 * @param pattern - the pattern. If <code>null</code> "yyyy-MM-dd HH:mm:ss" will be used
 	 * @return the String representation of the GregorianCalendar
 	 */
 	public static String formatDateTime(GregorianCalendar dateTime, String pattern) {
-		if (pattern == null) pattern = "yyyy-MM-dd HH:mm:ss";
+		if (pattern == null) {
+			pattern = YYYY_MM_DD_HH_MM_SS;
+		}
 		SimpleDateFormat format = new SimpleDateFormat(pattern);  //$NON-NLS-1$
 		return format.format(dateTime.getTime());
 	}
-	
+
 	/**
 	 * Return a string representation of the dateTime with the given pattern
+	 *
 	 * @param date - a Date object
 	 * @param pattern - the pattern. If <code>null</code> "yyyy-MM-dd HH:mm:ss" will be used
 	 * @return the String representation of the GregorianCalendar
 	 */
 	public static String formatDateTime(Date date, String pattern) {
-		if (pattern == null) pattern = "yyyy-MM-dd HH:mm:ss";
+		if (pattern == null) {
+			pattern = YYYY_MM_DD_HH_MM_SS;
+		}
 		GregorianCalendar dateTime = new GregorianCalendar();
 		dateTime.setTime(date);
 		SimpleDateFormat format = new SimpleDateFormat(pattern);  //$NON-NLS-1$
@@ -232,15 +232,17 @@ public class TimeTools {
 
 	/**
 	 * Return a string representation of the dateTime in the form "yyyy-MM-dd HH:mm:ss"
+	 *
 	 * @param time - a GregorianCalendar object
 	 * @return the String representation of the GregorianCalendar
 	 */
 	public static String formatDateTimeReport(GregorianCalendar time) {
 		return formatDateTime(time, null);
 	}
-	
+
 	/**
 	 * Return a string representation of the dateTime in the form "yyyy-MM-dd HH:mm:ss"
+	 *
 	 * @param date - a Date object
 	 * @return the String represetation of the Date
 	 */
@@ -249,51 +251,56 @@ public class TimeTools {
 		time.setTime(date);
 		return formatDateTime(time, null);
 	}
-	
+
 	/**
 	 * Return the first instance of the current date
+	 *
 	 * @return
 	 */
 	public static GregorianCalendar getDateToday0() {
 		GregorianCalendar date = new GregorianCalendar();
-		date.set(GregorianCalendar.HOUR_OF_DAY, 0);
-		date.set(GregorianCalendar.MINUTE, 0);
-		date.set(GregorianCalendar.SECOND, 0);
+		date.set(Calendar.HOUR_OF_DAY, 0);
+		date.set(Calendar.MINUTE, 0);
+		date.set(Calendar.SECOND, 0);
 		return date;
 	}
-	
+
 	/**
 	 * Return the last instance of the current date
+	 *
 	 * @return
 	 */
 	public static GregorianCalendar getDateToday24() {
 		GregorianCalendar date = new GregorianCalendar();
-		date.set(GregorianCalendar.HOUR_OF_DAY, 23);
-		date.set(GregorianCalendar.MINUTE, 59);
-		date.set(GregorianCalendar.SECOND, 59);
+		date.set(Calendar.HOUR_OF_DAY, 23);
+		date.set(Calendar.MINUTE, 59);
+		date.set(Calendar.SECOND, 59);
 		return date;
 	}
-	
+
 	/**
 	 * Return a {@link GregorianCalendar} representation of the string using the given pattern
+	 *
 	 * @param string - a String object to be passed
 	 * @param pattern - the pattern. If <code>null</code> "yyyy-MM-dd HH:mm:ss" will be used
 	 * @param noTime - if <code>True</code> the time will be 00:00:00, actual time otherwise.
 	 * @return the String representation of the GregorianCalendar
-	 * @throws ParseException 
+	 * @throws ParseException
 	 */
 	public static GregorianCalendar parseDate(String string, String pattern, boolean noTime) throws ParseException {
-		if (pattern == null) pattern = "yyyy-MM-dd HH:mm:ss";
+		if (pattern == null) {
+			pattern = YYYY_MM_DD_HH_MM_SS;
+		}
 		SimpleDateFormat format = new SimpleDateFormat(pattern);  //$NON-NLS-1$
 		Date date = format.parse(string);
 		GregorianCalendar calendar = new GregorianCalendar();
 		if (noTime) {
 			calendar.setTime(date);
+			calendar.set(calendar.get(Calendar.YEAR), calendar.get(Calendar.MONTH), calendar.get(Calendar.DAY_OF_MONTH), 0, 0, 0);
+			calendar.set(Calendar.MILLISECOND, 0);
 		} else {
 			calendar.setTimeInMillis(date.getTime());
 		}
-		//System.out.println(formatDateTime(calendar, null));
-
 		return calendar;
 	}
 
@@ -304,12 +311,12 @@ public class TimeTools {
 	public static GregorianCalendar getBeginningOfNextDay(GregorianCalendar date) {
 		return new DateTime(date).plusDays(1).withTimeAtStartOfDay().toGregorianCalendar();
 	}
-	
-//////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
+	//////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 	/**
 	 * Returns the difference in days between two dates
+	 *
 	 * @param from
 	 * @param to
 	 * @return the number of days
@@ -324,6 +331,7 @@ public class TimeTools {
 
 	/**
 	 * Returns the difference in days between two dates
+	 *
 	 * @param from
 	 * @param to
 	 * @return the number of days
@@ -337,6 +345,7 @@ public class TimeTools {
 
 	/**
 	 * Returns the difference in weeks between two dates
+	 *
 	 * @param from
 	 * @param to
 	 * @return the number of weeks
@@ -350,6 +359,7 @@ public class TimeTools {
 
 	/**
 	 * Returns the difference in months between two dates
+	 *
 	 * @param from
 	 * @param to
 	 * @return the number of months
@@ -361,21 +371,21 @@ public class TimeTools {
 		return period.getMonths();
 	}
 
-	public static GregorianCalendar getDate(String strDate, String format) throws ParseException{
+	public static GregorianCalendar getDate(String strDate, String format) throws ParseException {
 		try {
 			SimpleDateFormat sdf = new SimpleDateFormat(format);
-			Date date=sdf.parse(strDate);
-			if(date!=null){
-				GregorianCalendar calDate=new GregorianCalendar();
+			Date date = sdf.parse(strDate);
+			if (date != null) {
+				GregorianCalendar calDate = new GregorianCalendar();
 				calDate.setTime(date);
 				return calDate;
 			}
 		} catch (ParseException e) {
-			if(!format.equals("dd/MM/yyyy")){
+			if (!format.equals("dd/MM/yyyy")) {
 				SimpleDateFormat sdf = new SimpleDateFormat("dd/MM/yyyy");
-				Date date=sdf.parse(strDate);
-				if(date!=null){
-					GregorianCalendar calDate=new GregorianCalendar();
+				Date date = sdf.parse(strDate);
+				if (date != null) {
+					GregorianCalendar calDate = new GregorianCalendar();
 					calDate.setTime(date);
 					return calDate;
 				}
@@ -383,14 +393,15 @@ public class TimeTools {
 		}
 		return null;
 	}
+
 	/**
 	 * Return the actual date and time of the server
 	 *
-	 * @author hadesthanos
 	 * @return DateTime
+	 * @author hadesthanos
 	 */
-	public static GregorianCalendar getServerDateTime()  {
-		GregorianCalendar serverDate=new GregorianCalendar();
+	public static GregorianCalendar getServerDateTime() {
+		GregorianCalendar serverDate = new GregorianCalendar();
 		String query = " SELECT NOW( ) as time ";
 
 		DbQueryLogger dbQuery = new DbQueryLogger();
@@ -398,50 +409,47 @@ public class TimeTools {
 			ResultSet resultSet = dbQuery.getData(query, true);
 			while (resultSet.next()) {
 				String date = resultSet.getString("time");
-				SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
-				java.util.Date utilDate = new java.util.Date();
-				utilDate = sdf.parse(date);
+				SimpleDateFormat sdf = new SimpleDateFormat(YYYY_MM_DD_HH_MM_SS);
+				java.util.Date utilDate = sdf.parse(date);
 				serverDate.setTime(utilDate);
 			}
-		} catch (SQLException e) {
-			e.printStackTrace();
-		} catch (OHException e) {
-			e.printStackTrace();
-		} catch (ParseException e) {
+		} catch (SQLException | OHException | ParseException e) {
 			e.printStackTrace();
 		}
 		return serverDate;
 	}
-	
+
 	/**
 	 * Convert GregorianCalendar -> String using format "dd/MM/yy"
+	 *
 	 * @param time - a Calendar datetime
-	 * @return a String representing the Calendar in the format "dd/MM/yy" 
+	 * @return a String representing the Calendar in the format "dd/MM/yy"
 	 * @deprecated use formatDateTime(GregorianCalendar dateTime, String pattern) instead
 	 */
 	@Deprecated
-    public static String getConvertedString(GregorianCalendar time) {
-		if (time == null)
+	public static String getConvertedString(GregorianCalendar time) {
+		if (time == null) {
 			return MessageBundle.getMessage("angal.malnutrition.nodate");
-		String string = String
-				.valueOf(time.get(GregorianCalendar.DAY_OF_MONTH));
-		string += "/" + String.valueOf(time.get(GregorianCalendar.MONTH) + 1);
-		String year = String.valueOf(time.get(GregorianCalendar.YEAR));
-		year = year.substring(2, year.length());
-		string += "/" + year;
+		}
+		String string = String.valueOf(time.get(Calendar.DAY_OF_MONTH));
+		string += '/' + String.valueOf(time.get(Calendar.MONTH) + 1);
+		String year = String.valueOf(time.get(Calendar.YEAR));
+		year = year.substring(2);
+		string += '/' + year;
 		return string;
 	}
 
-    /**
-     * Convert String -> Date using pattern "ddMMyy" and the server time
-     * ( SELECT NOW() as time )
-     * @param string - a date in the form ddMMyy
-     * @return a Calendar datetime
-     * @throws ParseException
-     * @deprecated use getDate(String strDate, String format) instead 
-     */
+	/**
+	 * Convert String -> Date using pattern "ddMMyy" and the server time
+	 * ( SELECT NOW() as time )
+	 *
+	 * @param string - a date in the form ddMMyy
+	 * @return a Calendar datetime
+	 * @throws ParseException
+	 * @deprecated use getDate(String strDate, String format) instead
+	 */
 	@Deprecated
-    public static GregorianCalendar convertToDate(String string) throws ParseException {
+	public static GregorianCalendar convertToDate(String string) throws ParseException {
 		GregorianCalendar date = TimeTools.getServerDateTime();
 		SimpleDateFormat sdf = new SimpleDateFormat("ddMMyy");
 		date.setTime(sdf.parse(string));

--- a/src/test/java/org/isf/utils/time/TestTimeTools.java
+++ b/src/test/java/org/isf/utils/time/TestTimeTools.java
@@ -26,13 +26,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.util.Date;
 import java.util.GregorianCalendar;
 
-import org.isf.generaldata.MessageBundle;
-import org.junit.Ignore;
 import org.junit.Test;
 
 public class TestTimeTools {
 
-	@Ignore
 	@Test
 	public void testGetDaysBetweenDatesDate() {
 		Date dateFrom = new Date(114, 10, 3, 0, 0, 0);
@@ -68,7 +65,7 @@ public class TestTimeTools {
 	}
 
 	@Test
-	public void testIsSameDayDate() throws Exception {
+	public void testIsSameDayDate() {
 		Date day1 = new Date(114, 10, 3, 0, 0, 0);
 		Date day2 = new Date(114, 10, 3, 10, 10, 0);
 		assertThat(TimeTools.isSameDay(day1, day2)).isTrue();
@@ -78,7 +75,7 @@ public class TestTimeTools {
 	}
 
 	@Test
-	public void testIsSameDayGregorian() throws Exception {
+	public void testIsSameDayGregorian() {
 		GregorianCalendar day1 = new GregorianCalendar(2014, 10, 3, 0, 0, 0);
 		GregorianCalendar day2 = new GregorianCalendar(2014, 10, 3, 10, 10, 0);
 		assertThat(TimeTools.isSameDay(day1, day2)).isTrue();
@@ -88,31 +85,31 @@ public class TestTimeTools {
 	}
 
 	@Test
-	public void testFormatDateTimeGregorian() throws Exception {
+	public void testFormatDateTimeGregorian() {
 		GregorianCalendar dateTime = new GregorianCalendar(2021, 10, 3, 23, 59, 59);
 		assertThat(TimeTools.formatDateTime(dateTime, null)).isEqualTo("2021-11-03 23:59:59");
 	}
 
 	@Test
-	public void testFormatDateTimeDate() throws Exception {
+	public void testFormatDateTimeDate() {
 		Date dateTime = new Date(121, 10, 3, 23, 59, 59);
 		assertThat(TimeTools.formatDateTime(dateTime, null)).isEqualTo("2021-11-03 23:59:59");
 	}
 
 	@Test
-	public void testFormatDateTimeReportGregorian() throws Exception {
+	public void testFormatDateTimeReportGregorian() {
 		GregorianCalendar dateTime = new GregorianCalendar(2021, 10, 3, 23, 59, 59);
 		assertThat(TimeTools.formatDateTimeReport(dateTime)).isEqualTo("2021-11-03 23:59:59");
 	}
 
 	@Test
-	public void testFormatDateTimeReportDate() throws Exception {
+	public void testFormatDateTimeReportDate() {
 		Date dateTime = new Date(121, 10, 3, 23, 59, 59);
 		assertThat(TimeTools.formatDateTimeReport(dateTime)).isEqualTo("2021-11-03 23:59:59");
 	}
 
 	@Test
-	public void testFormatAge() throws Exception {
+	public void testFormatAge() {
 		assertThat(TimeTools.getFormattedAge(null)).isEmpty();
 		Date dateTime = new Date(121, 10, 3, 23, 59, 59);
 		// If message bundles were accessbile the age would look something like the pattern below
@@ -120,7 +117,6 @@ public class TestTimeTools {
 		assertThat(TimeTools.getFormattedAge(dateTime)).isEqualTo("angal.common.agepattern");
 	}
 
-	@Ignore
 	@Test
 	public void testParseDate() throws Exception {
 		assertThat(TimeTools.parseDate("2021-11-03 23:59:59", "yyyy-MM-dd HH:mm:ss", false))


### PR DESCRIPTION
See OP-450.

In addition did a few other small cleanups:

- Format the file
- Use character type for single length string
- Remove unused import
- Remove unused main routine now covered by tests
- Add private constructor given all methods are static
- Use base **Calendar** class instead of **GregorianCalendar** class
- Extract common date pattern to class constant
- Given the TimeTools file is fixed via OP-450, remove the `@Ignore` directives in the test file