### PR TITLE
Chore remove deprecated method: getExamrows

### DIFF
--- a/src/main/java/org/isf/exa/service/ExamRowIoOperations.java
+++ b/src/main/java/org/isf/exa/service/ExamRowIoOperations.java
@@ -92,18 +92,6 @@ public class ExamRowIoOperations {
 	 * Returns the list of {@link ExamRow}s
 	 * @return the list of {@link ExamRow}s
 	 * @throws OHServiceException
-	 * @deprecated use <code>getExamRows()</code>
-	 */
-	@Deprecated
-	public ArrayList<ExamRow> getExamrows() throws OHServiceException 
-	{
-		return getExamRows();
-	}
-
-	/**
-	 * Returns the list of {@link ExamRow}s
-	 * @return the list of {@link ExamRow}s
-	 * @throws OHServiceException
 	 */
 	public ArrayList<ExamRow> getExamRows() throws OHServiceException
 	{

--- a/src/test/java/org/isf/exa/test/Tests.java
+++ b/src/test/java/org/isf/exa/test/Tests.java
@@ -138,7 +138,7 @@ public class Tests extends OHCoreTestCase {
 		ArrayList<ExamRow> examRows = examRowIoOperation.getExamRows();
 		assertThat(examRows.get(examRows.size() - 1).getDescription()).isEqualTo(foundExamRow.getDescription());
 		// deprecated method
-		examRows = examRowIoOperation.getExamrows();
+		examRows = examRowIoOperation.getExamRows();
 		assertThat(examRows.get(examRows.size() - 1).getDescription()).isEqualTo(foundExamRow.getDescription());
 	}
 


### PR DESCRIPTION
Remove deprecated `getExamrows` method.    The method is not used in GUI and the API project uses the non-deprecated version: `getExamRows`.

Changed the test code to use `getExamRows`.