### PR TITLE
OP-456 Cannot fill database with demo data when using oh-core_database docker image

### DIFF
--- a/Dockerfile-ohdb
+++ b/Dockerfile-ohdb
@@ -24,4 +24,4 @@ COPY mysql/db/step_6* /docker-entrypoint-initdb.d/
 COPY mysql/db/data_en/* data_en/
 #COPY mysql/db/data_es/* data_es/
 #COPY mysql/db/data_it/* data_it/
-#COPY mysql/cnf/my.cnf /etc/mysql/conf.d
+COPY mysql/db/conf/my.cnf /etc/mysql/conf.d

--- a/mysql/db/conf/my.cnf
+++ b/mysql/db/conf/my.cnf
@@ -1,0 +1,2 @@
+[mysqld]
+lower_case_table_names = 1


### PR DESCRIPTION
Adds file _my.cnf_ with mysql configuration to set **lower_case_table_names** to make database case-insensitive in docker environment.