### PR TITLE
Chore: use more natural assertj syntax

### DIFF
--- a/src/test/java/org/isf/dicom/test/Tests.java
+++ b/src/test/java/org/isf/dicom/test/Tests.java
@@ -283,8 +283,9 @@ public class Tests extends OHCoreTestCase {
 		FileDicom fileDicom = testFileDicom.setup(dicomType, true);
 
 		assertThat(fileDicom.equals(fileDicom)).isTrue();
-		assertThat(fileDicom).isNotEqualTo(null);
-		assertThat(fileDicom).isNotEqualTo("someString");
+		assertThat(fileDicom)
+				.isNotEqualTo(null)
+				.isNotEqualTo("someString");
 
 		FileDicom fileDicom2 = testFileDicom.setup(dicomType, true);
 		fileDicom2.setIdFile(99L);

--- a/src/test/java/org/isf/dicom/test/Tests.java
+++ b/src/test/java/org/isf/dicom/test/Tests.java
@@ -284,7 +284,7 @@ public class Tests extends OHCoreTestCase {
 
 		assertThat(fileDicom.equals(fileDicom)).isTrue();
 		assertThat(fileDicom)
-				.isNotEqualTo(null)
+				.isNotNull()
 				.isNotEqualTo("someString");
 
 		FileDicom fileDicom2 = testFileDicom.setup(dicomType, true);

--- a/src/test/java/org/isf/disease/test/Tests.java
+++ b/src/test/java/org/isf/disease/test/Tests.java
@@ -92,7 +92,7 @@ public class Tests extends OHCoreTestCase {
 	@Test
 	public void testIoGetDiseases() throws Exception {
 		String code = _setupTestDisease(false);
-		Disease foundDisease = diseaseIoOperation.getDiseaseByCode(Integer.valueOf(code));
+		Disease foundDisease = diseaseIoOperation.getDiseaseByCode(Integer.parseInt(code));
 
 		ArrayList<Disease> diseases = diseaseIoOperation.getDiseases(foundDisease.getType().getCode(), false, false, false);
 		assertThat(diseases).contains(foundDisease);
@@ -104,7 +104,7 @@ public class Tests extends OHCoreTestCase {
 		diseases = diseaseIoOperation.getDiseases(foundDisease.getType().getCode(), true, false, false);
 		assertThat(diseases).contains(foundDisease);
 
-		foundDisease = diseaseIoOperation.getDiseaseByCode(Integer.valueOf(code));
+		foundDisease = diseaseIoOperation.getDiseaseByCode(Integer.parseInt(code));
 		diseases = diseaseIoOperation.getDiseases(foundDisease.getType().getCode(), true, true, false);
 		assertThat(diseases).doesNotContain(foundDisease);
 		foundDisease.setOpdInclude(true);
@@ -113,7 +113,7 @@ public class Tests extends OHCoreTestCase {
 		diseases = diseaseIoOperation.getDiseases(foundDisease.getType().getCode(), true, true, false);
 		assertThat(diseases).contains(foundDisease);
 
-		foundDisease = diseaseIoOperation.getDiseaseByCode(Integer.valueOf(code));
+		foundDisease = diseaseIoOperation.getDiseaseByCode(Integer.parseInt(code));
 		diseases = diseaseIoOperation.getDiseases(foundDisease.getType().getCode(), true, true, true);
 		assertThat(diseases).doesNotContain(foundDisease);
 		foundDisease.setOpdInclude(true);
@@ -145,10 +145,10 @@ public class Tests extends OHCoreTestCase {
 	@Test
 	public void testIoUpdateDisease() throws Exception {
 		String code = _setupTestDisease(false);
-		Disease foundDisease = diseaseIoOperation.getDiseaseByCode(Integer.valueOf(code));
+		Disease foundDisease = diseaseIoOperation.getDiseaseByCode(Integer.parseInt(code));
 		foundDisease.setDescription("Update");
 		Disease result = diseaseIoOperation.updateDisease(foundDisease);
-		Disease updateDisease = diseaseIoOperation.getDiseaseByCode(Integer.valueOf(code));
+		Disease updateDisease = diseaseIoOperation.getDiseaseByCode(Integer.parseInt(code));
 
 		assertThat(result.getDescription()).isEqualTo("Update");
 		assertThat(updateDisease.getDescription()).isEqualTo("Update");
@@ -157,7 +157,7 @@ public class Tests extends OHCoreTestCase {
 	@Test
 	public void testIoHasDiseaseModified() throws Exception {
 		String code = _setupTestDisease(false);
-		Disease foundDisease = diseaseIoOperation.getDiseaseByCode(Integer.valueOf(code));
+		Disease foundDisease = diseaseIoOperation.getDiseaseByCode(Integer.parseInt(code));
 		boolean result = diseaseIoOperation.deleteDisease(foundDisease);
 		assertThat(result).isTrue();
 		assertThat(foundDisease.getIpdInInclude()).isFalse();
@@ -167,7 +167,7 @@ public class Tests extends OHCoreTestCase {
 	@Test
 	public void testIoDeleteDisease() throws Exception {
 		String code = _setupTestDisease(false);
-		Disease foundDisease = diseaseIoOperation.getDiseaseByCode(Integer.valueOf(code));
+		Disease foundDisease = diseaseIoOperation.getDiseaseByCode(Integer.parseInt(code));
 		boolean result = diseaseIoOperation.deleteDisease(foundDisease);
 		assertThat(result).isTrue();
 		assertThat(foundDisease.getIpdInInclude()).isFalse();
@@ -185,7 +185,7 @@ public class Tests extends OHCoreTestCase {
 	@Test
 	public void testIoIsDescriptionPresent() throws Exception {
 		String code = _setupTestDisease(false);
-		Disease foundDisease = diseaseIoOperation.getDiseaseByCode(Integer.valueOf(code));
+		Disease foundDisease = diseaseIoOperation.getDiseaseByCode(Integer.parseInt(code));
 		boolean result = diseaseIoOperation.isDescriptionPresent(foundDisease.getDescription(), foundDisease.getType().getCode());
 		assertThat(result).isTrue();
 	}
@@ -193,14 +193,14 @@ public class Tests extends OHCoreTestCase {
 	@Test
 	public void testMgrGetDiseaseByCode() throws Exception {
 		String code = _setupTestDisease(false);
-		Disease foundDisease = diseaseBrowserManager.getDiseaseByCode(Integer.valueOf(code));
+		Disease foundDisease = diseaseBrowserManager.getDiseaseByCode(Integer.parseInt(code));
 		testDisease.check(foundDisease);
 	}
 
 	@Test
 	public void testMgrGetDiseases() throws Exception {
 		String code = _setupTestDisease(false);
-		Disease foundDisease = diseaseBrowserManager.getDiseaseByCode(Integer.valueOf(code));
+		Disease foundDisease = diseaseBrowserManager.getDiseaseByCode(Integer.parseInt(code));
 
 		ArrayList<Disease> diseases = diseaseBrowserManager.getDisease(foundDisease.getType().getCode());
 		assertThat(diseases).contains(foundDisease);
@@ -212,7 +212,7 @@ public class Tests extends OHCoreTestCase {
 		diseases = diseaseBrowserManager.getDiseaseOpd(foundDisease.getType().getCode());
 		assertThat(diseases).contains(foundDisease);
 
-		foundDisease = diseaseBrowserManager.getDiseaseByCode(Integer.valueOf(code));
+		foundDisease = diseaseBrowserManager.getDiseaseByCode(Integer.parseInt(code));
 		diseases = diseaseBrowserManager.getDiseaseIpdIn();
 		assertThat(diseases).doesNotContain(foundDisease);
 		foundDisease.setOpdInclude(true);
@@ -221,7 +221,7 @@ public class Tests extends OHCoreTestCase {
 		diseases = diseaseBrowserManager.getDiseaseOpd();
 		assertThat(diseases).contains(foundDisease);
 
-		foundDisease = diseaseBrowserManager.getDiseaseByCode(Integer.valueOf(code));
+		foundDisease = diseaseBrowserManager.getDiseaseByCode(Integer.parseInt(code));
 		diseases = diseaseBrowserManager.getDiseaseIpdOut(foundDisease.getType().getCode());
 		assertThat(diseases).doesNotContain(foundDisease);
 		foundDisease.setOpdInclude(true);
@@ -259,18 +259,18 @@ public class Tests extends OHCoreTestCase {
 	@Test
 	public void testMgrUpdateDisease() throws Exception {
 		String code = _setupTestDisease(false);
-		Disease foundDisease = diseaseBrowserManager.getDiseaseByCode(Integer.valueOf(code));
+		Disease foundDisease = diseaseBrowserManager.getDiseaseByCode(Integer.parseInt(code));
 		foundDisease.setDescription("Update");
 		Disease result = diseaseBrowserManager.updateDisease(foundDisease);
 		assertThat(result.getDescription()).isEqualTo("Update");
-		Disease updateDisease = diseaseBrowserManager.getDiseaseByCode(Integer.valueOf(code));
+		Disease updateDisease = diseaseBrowserManager.getDiseaseByCode(Integer.parseInt(code));
 		assertThat(updateDisease.getDescription()).isEqualTo("Update");
 	}
 
 	@Test
 	public void testMgrHasDiseaseModified() throws Exception {
 		String code = _setupTestDisease(false);
-		Disease foundDisease = diseaseBrowserManager.getDiseaseByCode(Integer.valueOf(code));
+		Disease foundDisease = diseaseBrowserManager.getDiseaseByCode(Integer.parseInt(code));
 		boolean result = diseaseBrowserManager.deleteDisease(foundDisease);
 		assertThat(result).isTrue();
 		assertThat(foundDisease.getIpdInInclude()).isFalse();
@@ -280,7 +280,7 @@ public class Tests extends OHCoreTestCase {
 	@Test
 	public void testMgrDeleteDisease() throws Exception {
 		String code = _setupTestDisease(false);
-		Disease foundDisease = diseaseBrowserManager.getDiseaseByCode(Integer.valueOf(code));
+		Disease foundDisease = diseaseBrowserManager.getDiseaseByCode(Integer.parseInt(code));
 		boolean result = diseaseBrowserManager.deleteDisease(foundDisease);
 		assertThat(result).isTrue();
 		assertThat(foundDisease.getIpdInInclude()).isFalse();
@@ -298,7 +298,7 @@ public class Tests extends OHCoreTestCase {
 	@Test
 	public void testMgrIsDescriptionPresent() throws Exception {
 		String code = _setupTestDisease(false);
-		Disease foundDisease = diseaseBrowserManager.getDiseaseByCode(Integer.valueOf(code));
+		Disease foundDisease = diseaseBrowserManager.getDiseaseByCode(Integer.parseInt(code));
 		boolean result = diseaseBrowserManager.descriptionControl(foundDisease.getDescription(), foundDisease.getType().getCode());
 		assertThat(result).isTrue();
 	}
@@ -306,7 +306,7 @@ public class Tests extends OHCoreTestCase {
 	@Test
 	public void testDiseaseEqualHashToString() throws Exception {
 		String code = _setupTestDisease(false);
-		Disease disease = diseaseBrowserManager.getDiseaseByCode(Integer.valueOf(code));
+		Disease disease = diseaseBrowserManager.getDiseaseByCode(Integer.parseInt(code));
 		DiseaseType diseaseType2 = testDiseaseType.setup(false);
 		Disease disease2 = new Disease("998", "someDescription", diseaseType2);
 		assertThat(disease.equals(disease)).isTrue();
@@ -325,7 +325,7 @@ public class Tests extends OHCoreTestCase {
 	@Test
 	public void testDiseaseGetterSetter() throws Exception {
 		String code = _setupTestDisease(false);
-		Disease disease = diseaseBrowserManager.getDiseaseByCode(Integer.valueOf(code));
+		Disease disease = diseaseBrowserManager.getDiseaseByCode(Integer.parseInt(code));
 		disease.setLock(-99);
 		assertThat(disease.getLock()).isEqualTo(-99);
 	}
@@ -372,7 +372,7 @@ public class Tests extends OHCoreTestCase {
 	@Test
 	public void testMgrValidationInsert() throws Exception {
 		String code = _setupTestDisease(false);
-		Disease disease = diseaseBrowserManager.getDiseaseByCode(Integer.valueOf(code));
+		Disease disease = diseaseBrowserManager.getDiseaseByCode(Integer.parseInt(code));
 		// code already exists and same description used
 		DiseaseType diseaseType = new DiseaseType("ZZ", "TestDescription");
 		Disease disease2 = testDisease.setup(diseaseType, false);

--- a/src/test/java/org/isf/medicals/test/Tests.java
+++ b/src/test/java/org/isf/medicals/test/Tests.java
@@ -561,14 +561,14 @@ public class Tests extends OHCoreTestCase {
 		Medical medical3 = new Medical(3, medicalType3, "TP3", "TestDescription2", 1, 2, 3, 4, 5);
 
 		assertThat(medical.equals(medical)).isTrue();
-		assertThat(medical.equals(new Integer(1))).isFalse();
-
-		assertThat(medical.equals(medical2)).isFalse();
+		assertThat(medical)
+				.isNotEqualTo("someString")
+				.isNotEqualTo(medical2);
 
 		medical2.setProd_code(null);
 		medical3.setProd_code(null);
-		assertThat(medical2.equals(medical3)).isFalse();
-		assertThat(medical3.equals(medical2)).isFalse();
+		assertThat(medical2).isNotEqualTo(medical3);
+		assertThat(medical3).isNotEqualTo(medical2);
 	}
 
 	@Test

--- a/src/test/java/org/isf/medicalstock/test/Tests.java
+++ b/src/test/java/org/isf/medicalstock/test/Tests.java
@@ -1033,8 +1033,9 @@ public class Tests extends OHCoreTestCase {
 		String code = _setupTestLot(true);
 		Lot lot = lotIoOperationRepository.findOne(code);
 		assertThat(lot.equals(lot)).isTrue();
-		assertThat(lot).isNotEqualTo(null);
-		assertThat(lot).isNotEqualTo("someString");
+		assertThat(lot)
+				.isNotEqualTo(null)
+				.isNotEqualTo("someString");
 
 		Lot lot2 = new Lot(null);
 		assertThat(lot).isNotEqualTo(lot2);
@@ -1091,8 +1092,9 @@ public class Tests extends OHCoreTestCase {
 		int code = _setupTestMovement(false);
 		Movement movement = movementIoOperationRepository.findOne(code);
 		assertThat(movement.equals(movement)).isTrue();
-		assertThat(movement).isNotEqualTo(null);
-		assertThat(movement).isNotEqualTo("someString");
+		assertThat(movement)
+				.isNotEqualTo(null)
+				.isNotEqualTo("someString");
 
 		Movement movement2 = new Movement();
 		movement2.setCode(-99);

--- a/src/test/java/org/isf/medicalstock/test/Tests.java
+++ b/src/test/java/org/isf/medicalstock/test/Tests.java
@@ -1034,7 +1034,7 @@ public class Tests extends OHCoreTestCase {
 		Lot lot = lotIoOperationRepository.findOne(code);
 		assertThat(lot.equals(lot)).isTrue();
 		assertThat(lot)
-				.isNotEqualTo(null)
+				.isNotNull()
 				.isNotEqualTo("someString");
 
 		Lot lot2 = new Lot(null);
@@ -1093,7 +1093,7 @@ public class Tests extends OHCoreTestCase {
 		Movement movement = movementIoOperationRepository.findOne(code);
 		assertThat(movement.equals(movement)).isTrue();
 		assertThat(movement)
-				.isNotEqualTo(null)
+				.isNotNull()
 				.isNotEqualTo("someString");
 
 		Movement movement2 = new Movement();

--- a/src/test/java/org/isf/medicalstockward/test/Tests.java
+++ b/src/test/java/org/isf/medicalstockward/test/Tests.java
@@ -1093,7 +1093,7 @@ public class Tests extends OHCoreTestCase {
 		assertThat(medicalWardId1.equals(medicalWardId1)).isTrue();
 		assertThat(medicalWardId1)
 				.isNotEqualTo("someString")
-				.isNotEqualTo(null);
+				.isNotNull();
 
 		// medical doesn't match
 		assertThat(medicalWardId1).isNotEqualTo(medicalWardId2);
@@ -1308,7 +1308,8 @@ public class Tests extends OHCoreTestCase {
 		MedicalWard medicalWard2 = new MedicalWard(medical2, 10.0D, lot2);
 
 		assertThat(medicalWard1.equals(medicalWard1)).isTrue();
-		assertThat(medicalWard1).isNotEqualTo(null)
+		assertThat(medicalWard1)
+				.isNotNull()
 				.isNotEqualTo("some String")
 				.isNotEqualTo(medicalWard2);
 

--- a/src/test/java/org/isf/medicalstockward/test/Tests.java
+++ b/src/test/java/org/isf/medicalstockward/test/Tests.java
@@ -1091,23 +1091,24 @@ public class Tests extends OHCoreTestCase {
 		MedicalWardId medicalWardId2 = medicalWard2.getId();
 
 		assertThat(medicalWardId1.equals(medicalWardId1)).isTrue();
-		assertThat(medicalWardId1.equals(new Integer(1))).isFalse();
-		assertThat(medicalWardId1.equals(null)).isFalse();
+		assertThat(medicalWardId1)
+				.isNotEqualTo("someString")
+				.isNotEqualTo(null);
 
 		// medical doesn't match
-		assertThat(medicalWardId1.equals(medicalWardId2)).isFalse();
+		assertThat(medicalWardId1).isNotEqualTo(medicalWardId2);
 
 		// ward doesn't match
 		medicalWardId2.setMedical(medicalWardId1.getMedical());
-		assertThat(medicalWardId1.equals(medicalWardId2)).isFalse();
+		assertThat(medicalWardId1).isNotEqualTo(medicalWardId2);
 
 		// lot doesn't match
 		medicalWardId2.setWard(medicalWardId1.getWard());
-		assertThat(medicalWardId1.equals(medicalWardId2)).isFalse();
+		assertThat(medicalWardId1).isNotEqualTo(medicalWardId2);
 
 		// everything matches
 		medicalWardId2.setLot(medicalWardId1.getLot());
-		assertThat(medicalWardId1.equals(medicalWardId2)).isTrue();
+		assertThat(medicalWardId1).isEqualTo(medicalWardId2);
 	}
 
 	@Test
@@ -1195,12 +1196,13 @@ public class Tests extends OHCoreTestCase {
 		movementWard2.setCode(-1);
 
 		assertThat(movementWard1.equals(movementWard1)).isTrue();
-		assertThat(movementWard1.equals(new Integer(1))).isFalse();
-		assertThat(movementWard1.equals(movementWard2)).isFalse();
+		assertThat(movementWard1)
+				.isNotEqualTo("someString")
+				.isNotEqualTo(movementWard2);
 
 		// set the codes equal
 		movementWard2.setCode(movementWard1.getCode());
-		assertThat(movementWard1.equals(movementWard2)).isTrue();
+		assertThat(movementWard1).isEqualTo(movementWard2);
 	}
 
 	@Test
@@ -1280,7 +1282,7 @@ public class Tests extends OHCoreTestCase {
 		Ward ward2 = testWard.setup(true);
 		MedicalWard medicalWard2 = new MedicalWard(medical2, 10.0D, lot2);
 
-		assertThat(medicalWard1.compareTo(new Integer(1))).isZero();
+		assertThat(medicalWard1.compareTo(1)).isZero();
 		assertThat(medicalWard1.compareTo(medicalWard2)).isZero();
 
 		medicalWard2.getMedical().setDescription("some new description");
@@ -1306,12 +1308,12 @@ public class Tests extends OHCoreTestCase {
 		MedicalWard medicalWard2 = new MedicalWard(medical2, 10.0D, lot2);
 
 		assertThat(medicalWard1.equals(medicalWard1)).isTrue();
-		assertThat(medicalWard1.equals(null)).isFalse();
-		assertThat(medicalWard1.equals("some String")).isFalse();
-		assertThat(medicalWard1.equals(medicalWard2)).isFalse();
+		assertThat(medicalWard1).isNotEqualTo(null)
+				.isNotEqualTo("some String")
+				.isNotEqualTo(medicalWard2);
 
 		medicalWard2.setMedical(medicalWard1.getMedical());
-		assertThat(medicalWard1.equals(medicalWard2)).isTrue();
+		assertThat(medicalWard1).isEqualTo(medicalWard2);
 	}
 
 	@Test

--- a/src/test/java/org/isf/medstockmovtype/test/Tests.java
+++ b/src/test/java/org/isf/medstockmovtype/test/Tests.java
@@ -220,7 +220,7 @@ public class Tests extends OHCoreTestCase {
 	@Test
 	public void testMovementTypeToString() throws Exception {
 		MovementType movementType = new MovementType("ZZABCD", "TestDescription", "+");
-		assertThat(movementType.toString()).isEqualTo("TestDescription");
+		assertThat(movementType).hasToString("TestDescription");
 	}
 
 	@Test
@@ -231,10 +231,11 @@ public class Tests extends OHCoreTestCase {
 		MovementType movementType4 = new MovementType("ZZABCD", "TestDescription", "++");
 
 		assertThat(movementType1.equals(movementType1)).isTrue();
-		assertThat(movementType1.equals(new Integer(-1))).isFalse();
-		assertThat(movementType1.equals(movementType2)).isFalse();
-		assertThat(movementType1.equals(movementType3)).isTrue();
-		assertThat(movementType1.equals(movementType4)).isTrue();
+		assertThat(movementType1)
+				.isNotEqualTo("someString")
+				.isNotEqualTo(movementType2)
+				.isEqualTo(movementType3)
+				.isEqualTo(movementType4);
 	}
 
 	@Test

--- a/src/test/java/org/isf/medtype/test/Tests.java
+++ b/src/test/java/org/isf/medtype/test/Tests.java
@@ -202,7 +202,7 @@ public class Tests extends OHCoreTestCase {
 	public void testMedicalTypeToString() throws Exception {
 		String code = _setupTestMedicalType(false);
 		MedicalType foundMedicalType = medicalTypeIoOperationRepository.findOne(code);
-		assertThat(foundMedicalType.toString()).isEqualTo(foundMedicalType.getDescription());
+		assertThat(foundMedicalType).hasToString(foundMedicalType.getDescription());
 	}
 
 	@Test
@@ -212,9 +212,10 @@ public class Tests extends OHCoreTestCase {
 		MedicalType medicalType3 = new MedicalType("Z", "otherDescription");
 
 		assertThat(medicalType1.equals(medicalType1)).isTrue();
-		assertThat(medicalType1.equals(new Integer(1))).isFalse();
-		assertThat(medicalType1.equals(medicalType2)).isFalse();
-		assertThat(medicalType1.equals(medicalType3)).isFalse();
+		assertThat(medicalType1)
+				.isNotEqualTo("someString")
+				.isNotEqualTo(medicalType2)
+				.isNotEqualTo(medicalType3);
 	}
 
 	@Test

--- a/src/test/java/org/isf/menu/test/Tests.java
+++ b/src/test/java/org/isf/menu/test/Tests.java
@@ -535,7 +535,7 @@ public class Tests extends OHCoreTestCase {
 		User user = testUser.setup(userGroup, true);
 
 		assertThat(user)
-				.isNotEqualTo(null)
+				.isNotNull()
 				.isNotEqualTo("someString");
 
 		User user1 = testUser.setup(userGroup, false);
@@ -572,7 +572,7 @@ public class Tests extends OHCoreTestCase {
 		UserGroup userGroup = testUserGroup.setup(true);
 
 		assertThat(userGroup)
-				.isNotEqualTo(null)
+				.isNotNull()
 				.isNotEqualTo("someString");
 
 		UserGroup userGroup1 = testUserGroup.setup(false);
@@ -603,7 +603,7 @@ public class Tests extends OHCoreTestCase {
 		UserMenuItem userMenuItem = testUserMenu.setup(true);
 
 		assertThat(userMenuItem)
-				.isNotEqualTo(null)
+				.isNotNull()
 				.isNotEqualTo("someString");
 
 		UserMenuItem userMenuItem1 = testUserMenu.setup(false);

--- a/src/test/java/org/isf/menu/test/Tests.java
+++ b/src/test/java/org/isf/menu/test/Tests.java
@@ -526,7 +526,7 @@ public class Tests extends OHCoreTestCase {
 	public void testUserToString() throws Exception {
 		UserGroup userGroup = testUserGroup.setup(true);
 		User user = testUser.setup(userGroup, true);
-		assertThat(user.toString()).isEqualTo(user.getUserName());
+		assertThat(user).hasToString(user.getUserName());
 	}
 
 	@Test
@@ -534,19 +534,20 @@ public class Tests extends OHCoreTestCase {
 		UserGroup userGroup = testUserGroup.setup(true);
 		User user = testUser.setup(userGroup, true);
 
-		assertThat(user.equals(null)).isFalse();
-		assertThat(user.equals("someString")).isFalse();
+		assertThat(user)
+				.isNotEqualTo(null)
+				.isNotEqualTo("someString");
 
 		User user1 = testUser.setup(userGroup, false);
 		user1.setUserName("someOtherName");
-		assertThat(user.equals(user1)).isFalse();
+		assertThat(user).isNotEqualTo(user1);
 
 		user1.setUserName(user.getUserName());
 		user1.setDesc("someOtherDescription");
-		assertThat(user.equals(user1)).isFalse();
+		assertThat(user).isNotEqualTo(user1);
 
 		user1.setDesc(user.getDesc().toLowerCase());
-		assertThat(user.equals(user1)).isTrue();
+		assertThat(user).isEqualTo(user1);
 	}
 
 	@Test
@@ -570,21 +571,22 @@ public class Tests extends OHCoreTestCase {
 	public void testUserGroupEquals() throws Exception {
 		UserGroup userGroup = testUserGroup.setup(true);
 
-		assertThat(userGroup.equals(null)).isFalse();
-		assertThat(userGroup.equals("someString")).isFalse();
+		assertThat(userGroup)
+				.isNotEqualTo(null)
+				.isNotEqualTo("someString");
 
 		UserGroup userGroup1 = testUserGroup.setup(false);
 
 		userGroup.setCode("code1");
 		userGroup1.setCode("code2");
-		assertThat(userGroup.equals(userGroup1)).isFalse();
+		assertThat(userGroup).isNotEqualTo(userGroup1);
 
 		userGroup1.setCode(userGroup.getCode());
 		userGroup1.setDesc("someOtherDescription");
-		assertThat(userGroup.equals(userGroup1)).isFalse();
+		assertThat(userGroup).isNotEqualTo(userGroup1);
 
 		userGroup1.setDesc(userGroup.getDesc().toLowerCase());
-		assertThat(userGroup.equals(userGroup1)).isTrue();
+		assertThat(userGroup).isEqualTo(userGroup1);
 	}
 
 	@Test
@@ -600,58 +602,59 @@ public class Tests extends OHCoreTestCase {
 	public void testUserMenuItemEquals() throws Exception {
 		UserMenuItem userMenuItem = testUserMenu.setup(true);
 
-		assertThat(userMenuItem.equals(null)).isFalse();
-		assertThat(userMenuItem.equals("someString")).isFalse();
+		assertThat(userMenuItem)
+				.isNotEqualTo(null)
+				.isNotEqualTo("someString");
 
 		UserMenuItem userMenuItem1 = testUserMenu.setup(false);
 		userMenuItem.setCode("code1");
 		userMenuItem1.setCode("code2");
-		assertThat(userMenuItem.equals(userMenuItem1)).isFalse();
+		assertThat(userMenuItem).isNotEqualTo(userMenuItem1);
 
 		userMenuItem1.setCode(userMenuItem.getCode());
 		userMenuItem1.setButtonLabel("someOtherButtonLabel");
-		assertThat(userMenuItem.equals(userMenuItem1)).isFalse();
+		assertThat(userMenuItem).isNotEqualTo(userMenuItem1);
 
 		userMenuItem1.setButtonLabel(userMenuItem.getButtonLabel());
 		userMenuItem1.setAltLabel("someOtherLabel");
-		assertThat(userMenuItem.equals(userMenuItem1)).isFalse();
+		assertThat(userMenuItem).isNotEqualTo(userMenuItem1);
 
 		userMenuItem1.setAltLabel(userMenuItem.getAltLabel());
 		userMenuItem1.setTooltip("someOtherToolTip");
-		assertThat(userMenuItem.equals(userMenuItem1)).isFalse();
+		assertThat(userMenuItem).isNotEqualTo(userMenuItem1);
 
 		userMenuItem1.setTooltip(userMenuItem.getTooltip());
 		userMenuItem1.setShortcut('?');
-		assertThat(userMenuItem.equals(userMenuItem1)).isFalse();
+		assertThat(userMenuItem).isNotEqualTo(userMenuItem1);
 
 		userMenuItem1.setShortcut(userMenuItem.getShortcut());
 		userMenuItem1.setMySubmenu("someOtherSubMenu");
-		assertThat(userMenuItem.equals(userMenuItem1)).isFalse();
+		assertThat(userMenuItem).isNotEqualTo(userMenuItem1);
 
 		userMenuItem1.setMySubmenu(userMenuItem.getMySubmenu());
 		userMenuItem1.setMyClass("someOtherClass");
-		assertThat(userMenuItem.equals(userMenuItem1)).isFalse();
+		assertThat(userMenuItem).isNotEqualTo(userMenuItem1);
 
 		userMenuItem1.setMyClass(userMenuItem.getMyClass());
 		userMenuItem1.setASubMenu(!userMenuItem.isASubMenu());
-		assertThat(userMenuItem.equals(userMenuItem1)).isFalse();
+		assertThat(userMenuItem).isNotEqualTo(userMenuItem1);
 
 		userMenuItem1.setASubMenu(userMenuItem.isASubMenu());
 		userMenuItem1.setPosition(-1);
-		assertThat(userMenuItem.equals(userMenuItem1)).isFalse();
+		assertThat(userMenuItem).isNotEqualTo(userMenuItem1);
 
 		userMenuItem1.setPosition(userMenuItem.getPosition());
 		userMenuItem1.setActive(!userMenuItem.isActive());
-		assertThat(userMenuItem.equals(userMenuItem1)).isFalse();
+		assertThat(userMenuItem).isNotEqualTo(userMenuItem1);
 
 		userMenuItem1.setActive(userMenuItem.isActive());
-		assertThat(userMenuItem.equals(userMenuItem1)).isTrue();
+		assertThat(userMenuItem).isEqualTo(userMenuItem1);
 	}
 
 	@Test
 	public void testUserMenuItemToString() throws Exception {
 		UserMenuItem userMenuItem = testUserMenu.setup(true);
-		assertThat(userMenuItem.toString()).isEqualTo(userMenuItem.getButtonLabel());
+		assertThat(userMenuItem).hasToString(userMenuItem.getButtonLabel());
 	}
 
 	@Test

--- a/src/test/java/org/isf/opd/test/Tests.java
+++ b/src/test/java/org/isf/opd/test/Tests.java
@@ -859,7 +859,7 @@ public class Tests extends OHCoreTestCase {
 
 		assertThat(opd.equals(opd)).isTrue();
 		assertThat(opd)
-				.isNotEqualTo(null)
+				.isNotNull()
 				.isNotEqualTo("someString");
 	}
 

--- a/src/test/java/org/isf/opd/test/Tests.java
+++ b/src/test/java/org/isf/opd/test/Tests.java
@@ -858,8 +858,9 @@ public class Tests extends OHCoreTestCase {
 		Opd opd = testOpd.setup(patient, disease, false);
 
 		assertThat(opd.equals(opd)).isTrue();
-		assertThat(opd).isNotEqualTo(null);
-		assertThat(opd).isNotEqualTo("someString");
+		assertThat(opd)
+				.isNotEqualTo(null)
+				.isNotEqualTo("someString");
 	}
 
 	private Patient _setupTestPatient(boolean usingSet) throws Exception {

--- a/src/test/java/org/isf/operation/test/Tests.java
+++ b/src/test/java/org/isf/operation/test/Tests.java
@@ -850,8 +850,9 @@ public class Tests extends OHCoreTestCase {
 		Operation operation = testOperation.setup(operationType, true);
 
 		assertThat(operation).isEqualTo(operation);
-		assertThat(operation).isNotEqualTo(null);
-		assertThat(operation).isNotEqualTo("a string");
+		assertThat(operation)
+				.isNotNull()
+				.isNotEqualTo("a string");
 
 		OperationType operationType1 = testOperationType.setup(false);
 		Operation operation1 = testOperation.setup(operationType, true);
@@ -938,8 +939,9 @@ public class Tests extends OHCoreTestCase {
 		OperationRow operationRow = testOperationRow.setup(operation, false);
 
 		assertThat(operationRow.equals(operationRow)).isTrue();
-		assertThat(operationRow).isNotEqualTo(null);
-		assertThat(operationRow).isNotEqualTo("some string");
+		assertThat(operationRow)
+				.isNotNull()
+				.isNotEqualTo("some string");
 	}
 
 	@Test

--- a/src/test/java/org/isf/opetype/test/Tests.java
+++ b/src/test/java/org/isf/opetype/test/Tests.java
@@ -226,7 +226,7 @@ public class Tests extends OHCoreTestCase {
 
 		assertThat(operationType.equals(operationType)).isTrue();
 		assertThat(operationType)
-				.isNotEqualTo(null)
+				.isNotNull()
 				.isNotEqualTo("someString");
 
 		OperationType operationType1 = new OperationType("Z", "description");

--- a/src/test/java/org/isf/opetype/test/Tests.java
+++ b/src/test/java/org/isf/opetype/test/Tests.java
@@ -225,8 +225,9 @@ public class Tests extends OHCoreTestCase {
 		OperationType operationType = new OperationType("Z", "description");
 
 		assertThat(operationType.equals(operationType)).isTrue();
-		assertThat(operationType).isNotEqualTo(null);
-		assertThat(operationType).isNotEqualTo("someString");
+		assertThat(operationType)
+				.isNotEqualTo(null)
+				.isNotEqualTo("someString");
 
 		OperationType operationType1 = new OperationType("Z", "description");
 		assertThat(operationType).isEqualTo(operationType1);

--- a/src/test/java/org/isf/patient/test/Tests.java
+++ b/src/test/java/org/isf/patient/test/Tests.java
@@ -681,7 +681,7 @@ public class Tests extends OHCoreTestCase {
 		Patient patient = testPatient.setup(false);
 		assertThat(patient.equals(patient)).isTrue();
 		assertThat(patient)
-				.isNotEqualTo(null)
+				.isNotNull()
 				.isNotEqualTo("someString");
 		Patient patient2 = testPatient.setup(true);
 		patient.setCode(1);

--- a/src/test/java/org/isf/patient/test/Tests.java
+++ b/src/test/java/org/isf/patient/test/Tests.java
@@ -680,8 +680,9 @@ public class Tests extends OHCoreTestCase {
 	public void testPatientEquals() throws Exception {
 		Patient patient = testPatient.setup(false);
 		assertThat(patient.equals(patient)).isTrue();
-		assertThat(patient.equals(null)).isFalse();
-		assertThat(patient).isNotEqualTo("someString");
+		assertThat(patient)
+				.isNotEqualTo(null)
+				.isNotEqualTo("someString");
 		Patient patient2 = testPatient.setup(true);
 		patient.setCode(1);
 		patient.setCode(2);

--- a/src/test/java/org/isf/patvac/test/Tests.java
+++ b/src/test/java/org/isf/patvac/test/Tests.java
@@ -517,8 +517,9 @@ public class Tests extends OHCoreTestCase {
 				"patName", 21, 'F');
 
 		assertThat(patientVaccine1.equals(patientVaccine1)).isTrue();
-		assertThat(patientVaccine1.equals(null)).isFalse();
-		assertThat(patientVaccine1).isNotEqualTo("someString");
+		assertThat(patientVaccine1)
+				.isNotEqualTo(null)
+				.isNotEqualTo("someString");
 
 		patientVaccine2.setCode(-99);
 		assertThat(patientVaccine1).isNotEqualTo(patientVaccine2);

--- a/src/test/java/org/isf/patvac/test/Tests.java
+++ b/src/test/java/org/isf/patvac/test/Tests.java
@@ -518,7 +518,7 @@ public class Tests extends OHCoreTestCase {
 
 		assertThat(patientVaccine1.equals(patientVaccine1)).isTrue();
 		assertThat(patientVaccine1)
-				.isNotEqualTo(null)
+				.isNotNull()
 				.isNotEqualTo("someString");
 
 		patientVaccine2.setCode(-99);

--- a/src/test/java/org/isf/pregtreattype/test/Tests.java
+++ b/src/test/java/org/isf/pregtreattype/test/Tests.java
@@ -228,9 +228,10 @@ public class Tests extends OHCoreTestCase {
 		pregnantTreatmentType.setCode("ZZ");
 		pregnantTreatmentType.setDescription("someDescription");
 
-		assertThat(pregnantTreatmentType).isEqualTo(pregnantTreatmentType);
-		assertThat(pregnantTreatmentType).isNotEqualTo(null);
-		assertThat(pregnantTreatmentType).isNotEqualTo("someString");
+		assertThat(pregnantTreatmentType)
+				.isEqualTo(pregnantTreatmentType)
+				.isNotEqualTo(null)
+				.isNotEqualTo("someString");
 
 		PregnantTreatmentType pregnantTreatmentType2 = new PregnantTreatmentType();
 		pregnantTreatmentType.setCode("XX");

--- a/src/test/java/org/isf/pregtreattype/test/Tests.java
+++ b/src/test/java/org/isf/pregtreattype/test/Tests.java
@@ -230,7 +230,7 @@ public class Tests extends OHCoreTestCase {
 
 		assertThat(pregnantTreatmentType)
 				.isEqualTo(pregnantTreatmentType)
-				.isNotEqualTo(null)
+				.isNotNull()
 				.isNotEqualTo("someString");
 
 		PregnantTreatmentType pregnantTreatmentType2 = new PregnantTreatmentType();

--- a/src/test/java/org/isf/priceslist/test/Tests.java
+++ b/src/test/java/org/isf/priceslist/test/Tests.java
@@ -392,7 +392,7 @@ public class Tests extends OHCoreTestCase {
 
 		assertThat(price.equals(price)).isTrue();
 		assertThat(price)
-				.isNotEqualTo(null)
+				.isNotNull()
 				.isNotEqualTo("someString");
 
 		PriceList priceList2 = testPriceList.setup(true);
@@ -445,7 +445,7 @@ public class Tests extends OHCoreTestCase {
 
 		assertThat(priceList.equals(priceList)).isTrue();
 		assertThat(priceList)
-				.isNotEqualTo(null)
+				.isNotNull()
 				.isNotEqualTo("someString");
 
 		PriceList priceList2 = testPriceList.setup(true);

--- a/src/test/java/org/isf/priceslist/test/Tests.java
+++ b/src/test/java/org/isf/priceslist/test/Tests.java
@@ -391,12 +391,13 @@ public class Tests extends OHCoreTestCase {
 		Price price = new Price(priceList, "TG", "TestItem", "TestDescription", 10.10);
 
 		assertThat(price.equals(price)).isTrue();
-		assertThat(price).isNotEqualTo(null);
-		assertThat(price).isNotEqualTo("someString");
+		assertThat(price)
+				.isNotEqualTo(null)
+				.isNotEqualTo("someString");
 
 		PriceList priceList2 = testPriceList.setup(true);
 		Price price2 = new Price(priceList2, "TG", "TestItem", "TestDescriptionOther", 10.10);
-		assertThat(price.equals(price2)).isTrue();
+		assertThat(price).isEqualTo(price2);
 
 		price2.setDesc("TestDescription");
 		price.setId(-1);
@@ -443,8 +444,9 @@ public class Tests extends OHCoreTestCase {
 		PriceList priceList = testPriceList.setup(true);
 
 		assertThat(priceList.equals(priceList)).isTrue();
-		assertThat(priceList).isNotEqualTo(null);
-		assertThat(priceList).isNotEqualTo("someString");
+		assertThat(priceList)
+				.isNotEqualTo(null)
+				.isNotEqualTo("someString");
 
 		PriceList priceList2 = testPriceList.setup(true);
 		priceList.setId(-1);

--- a/src/test/java/org/isf/pricesothers/test/Tests.java
+++ b/src/test/java/org/isf/pricesothers/test/Tests.java
@@ -216,8 +216,9 @@ public class Tests extends OHCoreTestCase {
 		PricesOthers pricesOthers = new PricesOthers(-1, "TestCode", "TestDescription", true, false, false, true);
 
 		assertThat(pricesOthers.equals(pricesOthers)).isTrue();
-		assertThat(pricesOthers).isNotEqualTo(null);
-		assertThat(pricesOthers).isNotEqualTo("someString");
+		assertThat(pricesOthers)
+				.isNotEqualTo(null)
+				.isNotEqualTo("someString");
 
 		PricesOthers pricesOthers2 = testPricesOthers.setup(true);
 		pricesOthers2.setId(-99);

--- a/src/test/java/org/isf/pricesothers/test/Tests.java
+++ b/src/test/java/org/isf/pricesothers/test/Tests.java
@@ -217,7 +217,7 @@ public class Tests extends OHCoreTestCase {
 
 		assertThat(pricesOthers.equals(pricesOthers)).isTrue();
 		assertThat(pricesOthers)
-				.isNotEqualTo(null)
+				.isNotNull()
 				.isNotEqualTo("someString");
 
 		PricesOthers pricesOthers2 = testPricesOthers.setup(true);

--- a/src/test/java/org/isf/supplier/test/Tests.java
+++ b/src/test/java/org/isf/supplier/test/Tests.java
@@ -161,8 +161,9 @@ public class Tests extends OHCoreTestCase {
 		Supplier supplier = new Supplier(1, "TestName", "TestAddress", "TestTax", "TestPhone", "TestFax", "TestEmail", "TestNode");
 
 		assertThat(supplier.equals(supplier)).isTrue();
-		assertThat(supplier).isNotEqualTo(null);
-		assertThat(supplier).isNotEqualTo("someString");
+		assertThat(supplier)
+				.isNotEqualTo(null)
+				.isNotEqualTo("someString");
 
 		Supplier supplier2 = new Supplier(2, "TestName", "TestAddress", "TestTax", "TestPhone", "TestFax", "TestEmail", "TestNode");
 		assertThat(supplier).isNotEqualTo(supplier2);

--- a/src/test/java/org/isf/supplier/test/Tests.java
+++ b/src/test/java/org/isf/supplier/test/Tests.java
@@ -162,7 +162,7 @@ public class Tests extends OHCoreTestCase {
 
 		assertThat(supplier.equals(supplier)).isTrue();
 		assertThat(supplier)
-				.isNotEqualTo(null)
+				.isNotNull()
 				.isNotEqualTo("someString");
 
 		Supplier supplier2 = new Supplier(2, "TestName", "TestAddress", "TestTax", "TestPhone", "TestFax", "TestEmail", "TestNode");

--- a/src/test/java/org/isf/therapy/test/Tests.java
+++ b/src/test/java/org/isf/therapy/test/Tests.java
@@ -358,8 +358,9 @@ public class Tests extends OHCoreTestCase {
 		TherapyRow therapyRow = therapyIoOperationRepository.findOne(id);
 
 		assertThat(therapyRow.equals(therapyRow)).isTrue();
-		assertThat(therapyRow).isNotEqualTo(null);
-		assertThat(therapyRow).isNotEqualTo("someString");
+		assertThat(therapyRow)
+				.isNotEqualTo(null)
+				.isNotEqualTo("someString");
 
 		MedicalType medicalType = testMedicalType.setup(false);
 		Medical medical = testMedical.setup(medicalType, false);

--- a/src/test/java/org/isf/therapy/test/Tests.java
+++ b/src/test/java/org/isf/therapy/test/Tests.java
@@ -359,7 +359,7 @@ public class Tests extends OHCoreTestCase {
 
 		assertThat(therapyRow.equals(therapyRow)).isTrue();
 		assertThat(therapyRow)
-				.isNotEqualTo(null)
+				.isNotNull()
 				.isNotEqualTo("someString");
 
 		MedicalType medicalType = testMedicalType.setup(false);

--- a/src/test/java/org/isf/vaccine/test/Tests.java
+++ b/src/test/java/org/isf/vaccine/test/Tests.java
@@ -287,7 +287,7 @@ public class Tests extends OHCoreTestCase {
 
 		assertThat(vaccine.equals(vaccine)).isTrue();
 		assertThat(vaccine)
-				.isNotEqualTo(null)
+				.isNotNull()
 				.isNotEqualTo("someStringValue");
 
 		VaccineType vaccineType2 = new VaccineType("A", "adescription");

--- a/src/test/java/org/isf/vaccine/test/Tests.java
+++ b/src/test/java/org/isf/vaccine/test/Tests.java
@@ -286,8 +286,9 @@ public class Tests extends OHCoreTestCase {
 		Vaccine vaccine = new Vaccine("aCode", "aDescription", vaccineType);
 
 		assertThat(vaccine.equals(vaccine)).isTrue();
-		assertThat(vaccine).isNotEqualTo(null);
-		assertThat(vaccine).isNotEqualTo("someStringValue");
+		assertThat(vaccine)
+				.isNotEqualTo(null)
+				.isNotEqualTo("someStringValue");
 
 		VaccineType vaccineType2 = new VaccineType("A", "adescription");
 		Vaccine vaccine2 = new Vaccine("bCode", "bDescription", vaccineType2);

--- a/src/test/java/org/isf/vactype/test/Tests.java
+++ b/src/test/java/org/isf/vactype/test/Tests.java
@@ -250,7 +250,7 @@ public class Tests extends OHCoreTestCase {
 
 		assertThat(vaccineType.equals(vaccineType)).isTrue();
 		assertThat(vaccineType)
-				.isNotEqualTo(null)
+				.isNotNull()
 				.isNotEqualTo("someStringValue");
 
 		VaccineType vaccineType2 = new VaccineType("A", "adescription");

--- a/src/test/java/org/isf/vactype/test/Tests.java
+++ b/src/test/java/org/isf/vactype/test/Tests.java
@@ -249,8 +249,9 @@ public class Tests extends OHCoreTestCase {
 		VaccineType vaccineType = testVaccineType.setup(true);
 
 		assertThat(vaccineType.equals(vaccineType)).isTrue();
-		assertThat(vaccineType).isNotEqualTo(null);
-		assertThat(vaccineType).isNotEqualTo("someStringValue");
+		assertThat(vaccineType)
+				.isNotEqualTo(null)
+				.isNotEqualTo("someStringValue");
 
 		VaccineType vaccineType2 = new VaccineType("A", "adescription");
 		assertThat(vaccineType).isNotEqualTo(vaccineType2);

--- a/src/test/java/org/isf/visits/test/Tests.java
+++ b/src/test/java/org/isf/visits/test/Tests.java
@@ -351,7 +351,7 @@ public class Tests extends OHCoreTestCase {
 
 		assertThat(visit.equals(visit)).isTrue();
 		assertThat(visit)
-				.isNotEqualTo(null)
+				.isNotNull()
 				.isNotEqualTo("someString");
 
 		Visit visit2 = new Visit(-1, null, null, null, false, null, null, null);

--- a/src/test/java/org/isf/visits/test/Tests.java
+++ b/src/test/java/org/isf/visits/test/Tests.java
@@ -350,8 +350,9 @@ public class Tests extends OHCoreTestCase {
 		Visit visit = visitManager.findVisit(id);
 
 		assertThat(visit.equals(visit)).isTrue();
-		assertThat(visit).isNotEqualTo(null);
-		assertThat(visit).isNotEqualTo("someString");
+		assertThat(visit)
+				.isNotEqualTo(null)
+				.isNotEqualTo("someString");
 
 		Visit visit2 = new Visit(-1, null, null, null, false, null, null, null);
 		assertThat(visit).isNotEqualTo(visit2);

--- a/src/test/java/org/isf/ward/test/Tests.java
+++ b/src/test/java/org/isf/ward/test/Tests.java
@@ -492,8 +492,9 @@ public class Tests extends OHCoreTestCase {
 	public void testWardEquals() throws Exception {
 		Ward ward = testWard.setup(false);
 		assertThat(ward.equals(ward)).isTrue();
-		assertThat(ward).isNotEqualTo(null);
-		assertThat(ward).isNotEqualTo("someString");
+		assertThat(ward)
+				.isNotEqualTo(null)
+				.isNotEqualTo("someString");
 
 		Ward ward2 = testWard.setup(false);
 		ward2.setCode("-1");

--- a/src/test/java/org/isf/ward/test/Tests.java
+++ b/src/test/java/org/isf/ward/test/Tests.java
@@ -493,7 +493,7 @@ public class Tests extends OHCoreTestCase {
 		Ward ward = testWard.setup(false);
 		assertThat(ward.equals(ward)).isTrue();
 		assertThat(ward)
-				.isNotEqualTo(null)
+				.isNotNull()
 				.isNotEqualTo("someString");
 
 		Ward ward2 = testWard.setup(false);


### PR DESCRIPTION
Minor changes to use consistent and more natural **assertj** syntax across the tests.   Some of this style was adopted with the later tests and this PR goes back and makes the style consistent.