### PR TITLE
Chore: use primitive type instead of class object

### DIFF
--- a/src/main/java/org/isf/therapy/manager/TherapyManager.java
+++ b/src/main/java/org/isf/therapy/manager/TherapyManager.java
@@ -262,8 +262,8 @@ public class TherapyManager {
 
 		ArrayList<Medical> medArray = medManager.getMedicals();
 
-		Double neededQty = 0.;
-		Double actualQty = 0.;
+		double neededQty = 0.;
+		double actualQty = 0.;
 
 		for (Therapy th : therapies) {
 


### PR DESCRIPTION
This is a performance improvement.

Found with IntelliJ Analyze plugin.