### PR TITLE
Op 473 email validation regex

### DIFF
--- a/src/main/java/org/isf/utils/validator/EmailValidator.java
+++ b/src/main/java/org/isf/utils/validator/EmailValidator.java
@@ -27,11 +27,12 @@ import java.util.regex.Pattern;
 public class EmailValidator {
 
 	// Java email validation permitted by RFC 5322
-	// Current regex
-	private static final String EMAIL_REGEX = "^[A-Z0-9_!#$%&'*+/=?`{|}~^.-]+@[A-Z0-9.-]+$";
-	// Proposed regex
-	//private static final String EMAIL_REGEX = "^[A-Z0-9_!#$%&'*+/=?`{|}~^.-]+@[A-Z0-9.-]+\\.[A-Z]{2,}$";
-
+	// Found this expression and discussion near the end of https://www.regular-expressions.info/email.html
+	private static final String EMAIL_REGEX = "\\A(?=[A-Z0-9@.!#$%&'*+/=?^_‘{|}~-]{6,254}\\z)"
+			+ "(?=[A-Z0-9.!#$%&'*+/=?^_‘{|}~-]{1,64}@)"
+			+ "[A-Z0-9!#$%&'*+/=?^_‘{|}~-]+(?:\\.[A-Z0-9!#$%&'*+/=?^_‘{|}~-]+)*"
+			+ "@(?:(?=[A-Z0-9-]{1,63}\\.)[A-Z0-9](?:[A-Z0-9-]*[A-Z0-9])?\\.)+"
+			+ "(?=[A-Z0-9-]{1,63}\\z)[A-Z0-9](?:[A-Z0-9-]*[A-Z0-9])?\\z";
 	private static final Pattern EMAIL_PATTERN = Pattern.compile(EMAIL_REGEX, Pattern.CASE_INSENSITIVE);
 
 	public static boolean isValid(String email) {

--- a/src/main/java/org/isf/utils/validator/EmailValidator.java
+++ b/src/main/java/org/isf/utils/validator/EmailValidator.java
@@ -24,22 +24,25 @@ package org.isf.utils.validator;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-public class EmailValidator
-{
-	//Java email validation permitted by RFC 5322
-    private static final String EMAIL_REGEX = "^[a-zA-Z0-9_!#$%&'*+/=?`{|}~^.-]+@[a-zA-Z0-9.-]+$";
- 
-    private static final Pattern EMAIL_PATTERN = Pattern.compile(EMAIL_REGEX);
- 
-    public static boolean isValid(String email) {
- 
-    	//Empty emails are allowed in the app
-        if (email == null || email.isEmpty()) {
-            return true;
-        }
- 
-        Matcher matcher = EMAIL_PATTERN.matcher(email);
-        return matcher.matches();
-    }
+public class EmailValidator {
+
+	// Java email validation permitted by RFC 5322
+	// Current regex
+	private static final String EMAIL_REGEX = "^[A-Z0-9_!#$%&'*+/=?`{|}~^.-]+@[A-Z0-9.-]+$";
+	// Proposed regex
+	//private static final String EMAIL_REGEX = "^[A-Z0-9_!#$%&'*+/=?`{|}~^.-]+@[A-Z0-9.-]+\\.[A-Z]{2,}$";
+
+	private static final Pattern EMAIL_PATTERN = Pattern.compile(EMAIL_REGEX, Pattern.CASE_INSENSITIVE);
+
+	public static boolean isValid(String email) {
+
+		// Empty emails are allowed in the app
+		if (email == null || email.isEmpty()) {
+			return true;
+		}
+
+		Matcher matcher = EMAIL_PATTERN.matcher(email);
+		return matcher.matches();
+	}
 
 }

--- a/src/test/java/org/isf/utils/validator/TestEmailValidator.java
+++ b/src/test/java/org/isf/utils/validator/TestEmailValidator.java
@@ -1,0 +1,40 @@
+package org.isf.utils.validator;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Test;
+
+public class TestEmailValidator {
+
+	@Test
+	public void testIsEmpty() throws Exception {
+		assertThat(EmailValidator.isValid("")).isTrue();
+		assertThat(EmailValidator.isValid(null)).isTrue();
+	}
+
+	@Test
+	public void testDoesNotMatchPattern() throws Exception {
+		assertThat(EmailValidator.isValid("abc")).isFalse();
+		assertThat(EmailValidator.isValid("\"ThisIsName\"@thisCompany.com")).isFalse();
+		assertThat(EmailValidator.isValid("@yahoo.com")).isFalse();
+		assertThat(EmailValidator.isValid("point#domain.com")).isFalse();
+	}
+
+	@Test
+	public void testDoesMatchPattern() throws Exception {
+		assertThat(EmailValidator.isValid("ABCD@MYCOMPANY.COM")).isTrue();
+		assertThat(EmailValidator.isValid("abcabcd@mycompany.org")).isTrue();
+		assertThat(EmailValidator.isValid("someTpoint@domain.co.in")).isTrue();
+		assertThat(EmailValidator.isValid("1point@domain.co.in")).isTrue();
+	}
+
+	// With the current regex in the validator these email address are considered valid
+	// Using the proposed alternative regex in the validator thiese email address are not valid
+	@Test
+	public void testQuestionablePatterns() throws Exception {
+		// just numbers (like an IP address)
+		assertThat(EmailValidator.isValid("1.2@3.4")).isTrue();
+		// no domain (.com, .org, .net, etc.)
+		assertThat(EmailValidator.isValid("1point@domain")).isTrue();
+	}
+}

--- a/src/test/java/org/isf/utils/validator/TestEmailValidator.java
+++ b/src/test/java/org/isf/utils/validator/TestEmailValidator.java
@@ -49,13 +49,11 @@ public class TestEmailValidator {
 		assertThat(EmailValidator.isValid("1point@domain.co.in")).isTrue();
 	}
 
-	// With the current regex in the validator these email address are considered valid
-	// Using the proposed alternative regex in the validator thiese email address are not valid
 	@Test
 	public void testQuestionablePatterns() throws Exception {
 		// just numbers (like an IP address)
 		assertThat(EmailValidator.isValid("1.2@3.4")).isTrue();
 		// no domain (.com, .org, .net, etc.)
-		assertThat(EmailValidator.isValid("1point@domain")).isTrue();
+		assertThat(EmailValidator.isValid("1point@domain")).isFalse();
 	}
 }

--- a/src/test/java/org/isf/utils/validator/TestEmailValidator.java
+++ b/src/test/java/org/isf/utils/validator/TestEmailValidator.java
@@ -1,3 +1,24 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2021 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.utils.validator;
 
 import static org.assertj.core.api.Assertions.assertThat;


### PR DESCRIPTION
See OP-473

The current validation routine simplifies the regex by making the matcher case-insensitive but changes nothing else (than formatting).  Given this setup all the new accompanying tests pass as the system currently exists.

Given the note in OP-473, there is a suggested alternative regex that make the tests in `testQuestionablePatterns` fail (as I think they should).
