### PR TITLE
Chore: use more natural assertj syntax (part 2)

### DIFF
--- a/src/test/java/org/isf/accounting/test/Tests.java
+++ b/src/test/java/org/isf/accounting/test/Tests.java
@@ -187,10 +187,11 @@ public class Tests extends OHCoreTestCase {
 		Bill foundBill2 = accountingBillIoOperationRepository.findOne(id2);
 
 		assertThat(bill.equals(bill)).isTrue();
-		assertThat(bill.equals(new GregorianCalendar())).isFalse();
-		assertThat(bill.equals(foundBill)).isTrue();
+		assertThat(bill)
+				.isNotEqualTo(new GregorianCalendar())
+				.isEqualTo(foundBill);
 		foundBill2.setId(-1);
-		assertThat(bill.equals(foundBill2)).isFalse();
+		assertThat(bill).isNotEqualTo(foundBill2);
 		assertThat(bill.compareTo(foundBill2)).isEqualTo(id + 1);   // id - (-1)
 		foundBill.setId(id);
 
@@ -416,12 +417,13 @@ public class Tests extends OHCoreTestCase {
 
 		BillPayments billPayment = payments.get(0);
 		assertThat(foundBillPayment.equals(foundBillPayment)).isTrue();
-		assertThat(foundBillPayment.equals(new GregorianCalendar())).isFalse();
-		assertThat(foundBillPayment.equals(billPayment)).isTrue();
+		assertThat(foundBillPayment)
+				.isNotEqualTo(new GregorianCalendar())
+				.isEqualTo(billPayment);
 		int id2 = _setupTestBillPayments(false);
 		BillPayments foundBillPayment2 = accountingBillPaymentIoOperationRepository.findOne(id2);
 		foundBillPayment2.setId(-1);
-		assertThat(foundBillPayment.equals(foundBillPayment2)).isFalse();
+		assertThat(foundBillPayment).isNotEqualTo(foundBillPayment2);
 		foundBillPayment.setId(id);
 
 		assertThat(billPayment.compareTo(new GregorianCalendar())).isEqualTo(0);
@@ -447,12 +449,13 @@ public class Tests extends OHCoreTestCase {
 
 		BillItems billItem = billItems.get(0);
 		assertThat(foundBillItem.equals(foundBillItem)).isTrue();
-		assertThat(foundBillItem.equals(new GregorianCalendar())).isFalse();
-		assertThat(foundBillItem.equals(billItem)).isTrue();
+		assertThat(foundBillItem)
+				.isNotEqualTo(new GregorianCalendar())
+				.isEqualTo(billItem);
 		int id2 = _setupTestBillItems(false);
 		BillItems foundBillItem2 = accountingBillItemsIoOperationRepository.findOne(id2);
 		foundBillItem2.setId(-1);
-		assertThat(foundBillItem.equals(foundBillItem2)).isFalse();
+		assertThat(foundBillItem).isNotEqualTo(foundBillItem2);
 		foundBillItem.setId(id);
 
 		String itemId = billItem.getItemId();

--- a/src/test/java/org/isf/admission/test/Tests.java
+++ b/src/test/java/org/isf/admission/test/Tests.java
@@ -1080,9 +1080,9 @@ public class Tests extends OHCoreTestCase {
 		Admission admission2 = buildNewAdmission();
 		admission2.setId(id);   // no really legal but needed for these tests
 		assertThat(admission.equals(admission)).isTrue();
-		assertThat(admission.equals(admission2)).isTrue();
-		assertThat(admission.equals("xyzzy")).isFalse();
-		assertThat(admission.equals(admission2)).isTrue();
+		assertThat(admission)
+				.isEqualTo(admission2)
+				.isNotEqualTo("xyzzy");
 
 		assertThat(admission.compareTo(admission2)).isZero();
 		admission2.setId(9999);

--- a/src/test/java/org/isf/admtype/test/Tests.java
+++ b/src/test/java/org/isf/admtype/test/Tests.java
@@ -141,14 +141,15 @@ public class Tests extends OHCoreTestCase {
 		AdmissionType admissionType = admissionTypeIoOperationRepository.findOne(code);
 		AdmissionType admissionType2 = new AdmissionType("someCode", "someDescription");
 		assertThat(admissionType.equals(admissionType)).isTrue();
-		assertThat(admissionType.equals(admissionType2)).isFalse();
-		assertThat(admissionType.equals("xyzzy")).isFalse();
+		assertThat(admissionType)
+				.isNotEqualTo(admissionType2)
+				.isNotEqualTo("xyzzy");
 		admissionType2.setCode(code);
-		assertThat(admissionType.equals(admissionType2)).isTrue();
+		assertThat(admissionType).isEqualTo(admissionType2);
 
 		assertThat(admissionType.hashCode()).isPositive();
 
-		assertThat(admissionType2.toString()).isEqualTo("someDescription");
+		assertThat(admissionType2).hasToString("someDescription");
 	}
 
 	@Test

--- a/src/test/java/org/isf/agetype/test/Tests.java
+++ b/src/test/java/org/isf/agetype/test/Tests.java
@@ -159,14 +159,15 @@ public class Tests extends OHCoreTestCase {
 		ageType2.setFrom(ageType.getFrom());
 		ageType2.setTo(ageType.getTo());
 		assertThat(ageType.equals(ageType)).isTrue();
-		assertThat(ageType.equals(ageType2)).isTrue();
-		assertThat(ageType.equals("xyzzy")).isFalse();
+		assertThat(ageType)
+				.isEqualTo(ageType2)
+				.isNotEqualTo("xyzzy");
 		ageType2.setCode("xxxx");
-		assertThat(ageType.equals(ageType2)).isFalse();
+		assertThat(ageType).isNotEqualTo(ageType2);
 
 		assertThat(ageType.hashCode()).isPositive();
 
-		assertThat(ageType2.toString()).isEqualTo(ageType.getDescription());
+		assertThat(ageType2).hasToString(ageType.getDescription());
 	}
 
 	@Test

--- a/src/test/java/org/isf/disctype/test/Tests.java
+++ b/src/test/java/org/isf/disctype/test/Tests.java
@@ -220,14 +220,15 @@ public class Tests extends OHCoreTestCase {
 		DischargeType dischargeType = dischargeTypeIoOperationRepository.findOne(code);
 		DischargeType dischargeType2 = new DischargeType("someCode", "someDescription");
 		assertThat(dischargeType.equals(dischargeType)).isTrue();
-		assertThat(dischargeType.equals(dischargeType2)).isFalse();
-		assertThat(dischargeType.equals("xyzzy")).isFalse();
+		assertThat(dischargeType)
+				.isNotEqualTo(dischargeType2)
+				.isNotEqualTo("xyzzy");
 		dischargeType2.setCode(code);
-		assertThat(dischargeType.equals(dischargeType2)).isTrue();
+		assertThat(dischargeType).isEqualTo(dischargeType2);
 
 		assertThat(dischargeType.hashCode()).isPositive();
 
-		assertThat(dischargeType2.toString()).isEqualTo("someDescription");
+		assertThat(dischargeType2).hasToString("someDescription");
 	}
 
 	private String _setupTestDischargeType(boolean usingSet) throws OHException {

--- a/src/test/java/org/isf/disease/test/Tests.java
+++ b/src/test/java/org/isf/disease/test/Tests.java
@@ -310,16 +310,17 @@ public class Tests extends OHCoreTestCase {
 		DiseaseType diseaseType2 = testDiseaseType.setup(false);
 		Disease disease2 = new Disease("998", "someDescription", diseaseType2);
 		assertThat(disease.equals(disease)).isTrue();
-		assertThat(disease.equals(disease2)).isFalse();
-		assertThat(disease.equals("xyzzy")).isFalse();
+		assertThat(disease)
+				.isNotEqualTo(disease2)
+				.isNotEqualTo("xyzzy");
 		disease2.setCode(disease.getCode());
 		disease2.setType(disease.getType());
 		disease2.setDescription(disease.getDescription());
-		assertThat(disease.equals(disease2)).isTrue();
+		assertThat(disease).isEqualTo(disease2);
 
 		assertThat(disease.hashCode()).isPositive();
 
-		assertThat(disease2.toString()).isEqualTo(disease.getDescription());
+		assertThat(disease2).hasToString(disease.getDescription());
 	}
 
 	@Test

--- a/src/test/java/org/isf/distype/test/Tests.java
+++ b/src/test/java/org/isf/distype/test/Tests.java
@@ -220,15 +220,16 @@ public class Tests extends OHCoreTestCase {
 		DiseaseType diseaseType = diseaseTypeIoOperationRepository.getOne(code);
 		DiseaseType diseaseType2 = new DiseaseType("code", "description");
 		assertThat(diseaseType.equals(diseaseType)).isTrue();
-		assertThat(diseaseType.equals(diseaseType2)).isFalse();
-		assertThat(diseaseType.equals("xyzzy")).isFalse();
+		assertThat(diseaseType)
+				.isNotEqualTo(diseaseType2)
+				.isNotEqualTo("xyzzy");
 		diseaseType2.setCode(diseaseType.getCode());
 		diseaseType2.setDescription(diseaseType.getDescription());
-		assertThat(diseaseType.equals(diseaseType2)).isTrue();
+		assertThat(diseaseType).isEqualTo(diseaseType2);
 
 		assertThat(diseaseType.hashCode()).isPositive();
 
-		assertThat(diseaseType.toString()).isEqualTo(diseaseType.getDescription());
+		assertThat(diseaseType).hasToString(diseaseType.getDescription());
 	}
 
 	private String _setupTestDiseaseType(boolean usingSet) throws OHException {

--- a/src/test/java/org/isf/dlvrrestype/test/Tests.java
+++ b/src/test/java/org/isf/dlvrrestype/test/Tests.java
@@ -206,7 +206,7 @@ public class Tests extends OHCoreTestCase {
 		assertThat(deliveryResultType.hashCode()).isPositive();
 
 		DeliveryResultType deliveryResultType2 = new DeliveryResultType("someCode", "someDescription");
-		assertThat(deliveryResultType2.toString()).isEqualTo("someDescription");
+		assertThat(deliveryResultType2).hasToString("someDescription");
 	}
 
 	private String _setupTestDeliveryResultType(boolean usingSet) throws OHException {

--- a/src/test/java/org/isf/dlvrtype/test/Tests.java
+++ b/src/test/java/org/isf/dlvrtype/test/Tests.java
@@ -207,15 +207,16 @@ public class Tests extends OHCoreTestCase {
 		DeliveryType deliveryType = deliveryTypeIoOperationRepository.findOne(code);
 		DeliveryType deliveryType2 = new DeliveryType("someCode", "someDescription");
 		assertThat(deliveryType.equals(deliveryType)).isTrue();
-		assertThat(deliveryType.equals(deliveryType2)).isFalse();
-		assertThat(deliveryType.equals("xyzzy")).isFalse();
+		assertThat(deliveryType)
+				.isNotEqualTo(deliveryType2)
+				.isNotEqualTo("xyzzy");
 		deliveryType2.setCode(code);
 		deliveryType2.setDescription(deliveryType.getDescription());
-		assertThat(deliveryType.equals(deliveryType2)).isTrue();
+		assertThat(deliveryType).isEqualTo(deliveryType2);
 
 		assertThat(deliveryType.hashCode()).isPositive();
 
-		assertThat(deliveryType2.toString()).isEqualTo(deliveryType.getDescription());
+		assertThat(deliveryType2).hasToString(deliveryType.getDescription());
 	}
 
 	private String _setupTestDeliveryType(boolean usingSet) throws OHException {

--- a/src/test/java/org/isf/exa/test/Tests.java
+++ b/src/test/java/org/isf/exa/test/Tests.java
@@ -492,16 +492,17 @@ public class Tests extends OHCoreTestCase {
 		ExamType examType = testExamType.setup(false);
 		Exam exam2 = new Exam("XXX", "TestDescription", examType, 1, "TestDefaultResult");
 		assertThat(exam.equals(exam)).isTrue();
-		assertThat(exam.equals(exam2)).isFalse();
-		assertThat(exam.equals("xyzzy")).isFalse();
+		assertThat(exam)
+				.isNotEqualTo(exam2)
+				.isNotEqualTo("xyzzy");
 		exam2.setCode(exam.getCode());
 		exam2.setDescription(exam.getDescription());
 		exam2.setExamtype(exam.getExamtype());
-		assertThat(exam.equals(exam2)).isTrue();
+		assertThat(exam).isEqualTo(exam2);
 
 		assertThat(exam.hashCode()).isPositive();
 
-		assertThat(exam2.toString()).isEqualTo(exam.getDescription());
+		assertThat(exam2).hasToString(exam.getDescription());
 	}
 
 	@Test
@@ -512,16 +513,17 @@ public class Tests extends OHCoreTestCase {
 		Exam exam2 = new Exam("XXX", "TestDescription", examType, 1, "TestDefaultResult");
 		ExamRow examRow2 = new ExamRow(exam2, "NewDescription");
 		assertThat(examRow.equals(examRow)).isTrue();
-		assertThat(examRow.equals(examRow2)).isFalse();
-		assertThat(examRow.equals("xyzzy")).isFalse();
+		assertThat(examRow)
+				.isNotEqualTo(examRow2)
+				.isNotEqualTo("xyzzy");
 		examRow2.setCode(examRow.getCode());
 		examRow2.setExamCode(examRow.getExamCode());
 		examRow2.setDescription(examRow.getDescription());
-		assertThat(examRow.equals(examRow2)).isTrue();
+		assertThat(examRow).isEqualTo(examRow2);
 
 		assertThat(examRow.hashCode()).isPositive();
 
-		assertThat(examRow.toString()).isEqualTo(examRow.getDescription());
+		assertThat(examRow).hasToString(examRow.getDescription());
 	}
 
 	@Test

--- a/src/test/java/org/isf/examination/test/Tests.java
+++ b/src/test/java/org/isf/examination/test/Tests.java
@@ -341,10 +341,11 @@ public class Tests extends OHCoreTestCase {
 		PatientExamination patientExamination2 = testPatientExamination.setup(patient, false);
 		patientExamination2.setPex_ID(-1);
 		assertThat(patientExamination.equals(patientExamination)).isTrue();
-		assertThat(patientExamination.equals(patientExamination2)).isFalse();
-		assertThat(patientExamination.equals("xyzzy")).isFalse();
+		assertThat(patientExamination)
+				.isNotEqualTo(patientExamination2)
+				.isNotEqualTo("xyzzy");
 		patientExamination2.setPex_ID(patientExamination.getPex_ID());
-		assertThat(patientExamination.equals(patientExamination2)).isTrue();
+		assertThat(patientExamination).isEqualTo(patientExamination2);
 		assertThat(patientExamination.compareTo(patientExamination2)).isZero();
 
 		assertThat(patientExamination.hashCode()).isPositive();

--- a/src/test/java/org/isf/exatype/test/Tests.java
+++ b/src/test/java/org/isf/exatype/test/Tests.java
@@ -213,7 +213,7 @@ public class Tests extends OHCoreTestCase {
 
 		assertThat(foundExamType.hashCode()).isPositive();
 
-		assertThat(foundExamType.toString()).isEqualTo(foundExamType.getDescription());
+		assertThat(foundExamType).hasToString(foundExamType.getDescription());
 	}
 
 	private String _setupTestExamType(boolean usingSet) throws OHException {

--- a/src/test/java/org/isf/hospital/test/Tests.java
+++ b/src/test/java/org/isf/hospital/test/Tests.java
@@ -153,7 +153,7 @@ public class Tests extends OHCoreTestCase {
 
 		assertThat(hospital.hashCode()).isPositive();
 
-		assertThat(hospital.toString()).isEqualTo(hospital.getDescription());
+		assertThat(hospital).hasToString(hospital.getDescription());
 	}
 
 	private String _setupTestHospital(boolean usingSet) throws OHException {

--- a/src/test/java/org/isf/lab/test/Tests.java
+++ b/src/test/java/org/isf/lab/test/Tests.java
@@ -894,7 +894,6 @@ public class Tests extends OHCoreTestCase {
 			// laboratory 1, Procedure One
 			ArrayList<String> labRow = new ArrayList<>();
 			Laboratory laboratory = testLaboratory.setup(exam, patient, false);
-			;
 
 			laboratory.setInOutPatient("");
 
@@ -1301,10 +1300,11 @@ public class Tests extends OHCoreTestCase {
 		Laboratory laboratory = labIoOperationRepository.findOne(code);
 		Laboratory laboratory2 = new Laboratory(code + 1, null, new GregorianCalendar(), "result", "note", null, "name");
 		assertThat(laboratory.equals(laboratory)).isTrue();
-		assertThat(laboratory.equals(laboratory2)).isFalse();
-		assertThat(laboratory.equals("xyzzy")).isFalse();
+		assertThat(laboratory)
+				.isNotEqualTo(laboratory2)
+				.isNotEqualTo("xyzzy");
 		laboratory2.setCode(code);
-		assertThat(laboratory.equals(laboratory2)).isTrue();
+		assertThat(laboratory).isEqualTo(laboratory2);
 
 		assertThat(laboratory.hashCode()).isPositive();
 
@@ -1333,16 +1333,17 @@ public class Tests extends OHCoreTestCase {
 		LaboratoryRow laboratoryRow = labRowIoOperationRepository.findOne(code);
 		LaboratoryRow laboratoryRow2 = new LaboratoryRow(code + 1, null, "description");
 		assertThat(laboratoryRow.equals(laboratoryRow)).isTrue();
-		assertThat(laboratoryRow.equals(laboratoryRow2)).isFalse();
-		assertThat(laboratoryRow.equals("xyzzy")).isFalse();
+		assertThat(laboratoryRow)
+				.isNotEqualTo(laboratoryRow2)
+				.isNotEqualTo("xyzzy");
 		laboratoryRow2.setCode(code);
-		assertThat(laboratoryRow.equals(laboratoryRow2)).isTrue();
+		assertThat(laboratoryRow).isEqualTo(laboratoryRow2);
 
 		laboratoryRow.setCode(null);
 		laboratoryRow2.setCode(null);
-		assertThat(laboratoryRow.equals(laboratoryRow2)).isFalse();
+		assertThat(laboratoryRow).isNotEqualTo(laboratoryRow2);
 		laboratoryRow.setDescription("description");
-		assertThat(laboratoryRow.equals(laboratoryRow)).isTrue();
+		assertThat(laboratoryRow).isEqualTo(laboratoryRow);
 
 		assertThat(laboratoryRow.hashCode()).isPositive();
 	}

--- a/src/test/java/org/isf/malnutrition/test/Tests.java
+++ b/src/test/java/org/isf/malnutrition/test/Tests.java
@@ -667,14 +667,15 @@ public class Tests extends OHCoreTestCase {
 		assertThat(malnutrition1.equals(malnutrition1)).isTrue();
 
 		// does not match because wrong class
-		assertThat(malnutrition1.equals(null)).isFalse();
-		assertThat(malnutrition1.equals(new Integer(1))).isFalse();
+		assertThat(malnutrition1)
+				.isNotNull()
+				.isNotEqualTo("xyzzy");
 
 		Malnutrition malnutrition2 = new Malnutrition(0, new GregorianCalendar(11, 1, 1),
 				new GregorianCalendar(11, 10, 11), admission, patient, 1185.47f, 170.70f);
 
 		// does not match because dates do not match
-		assertThat(malnutrition1.equals(malnutrition2)).isFalse();
+		assertThat(malnutrition1).isNotEqualTo(malnutrition2);
 
 		Malnutrition malnutrition3 = new Malnutrition(0, new GregorianCalendar(111, 1, 1),
 				new GregorianCalendar(111, 10, 11), admission, patient, 4185.47f, 470.70f);
@@ -686,13 +687,13 @@ public class Tests extends OHCoreTestCase {
 		malnutrition3.setDateSupp(null);
 
 		// dates are null but the height and weight do not match
-		assertThat(malnutrition2.equals(malnutrition3)).isFalse();
+		assertThat(malnutrition2).isNotEqualTo(malnutrition3);
 
 		Malnutrition malnutrition4 = new Malnutrition(0, new GregorianCalendar(1, 1, 1),
 				new GregorianCalendar(1, 10, 11), admission, patient, 185.47f, 70.70f);
 
 		// matches because all the same values
-		assertThat(malnutrition4.equals(malnutrition1)).isTrue();
+		assertThat(malnutrition4).isEqualTo(malnutrition1);
 	}
 
 	@Test

--- a/src/test/java/org/isf/menu/test/Tests.java
+++ b/src/test/java/org/isf/menu/test/Tests.java
@@ -499,27 +499,28 @@ public class Tests extends OHCoreTestCase {
 		GroupMenu groupMenu = testGroupMenu.setup(true);
 		groupMenu.setCode(1);
 
-		assertThat(groupMenu.equals(null)).isFalse();
-		assertThat(groupMenu.equals("aString")).isFalse();
+		assertThat(groupMenu)
+				.isNotNull()
+				.isNotEqualTo("aString");
 
 		GroupMenu groupMenu1 = testGroupMenu.setup(false);
 		groupMenu1.setCode(-1);
-		assertThat(groupMenu.equals(groupMenu1)).isFalse();
+		assertThat(groupMenu).isNotEqualTo(groupMenu1);
 
 		groupMenu1.setCode(groupMenu.getCode());
 		groupMenu1.setUserGroup("someOtherGroup");
-		assertThat(groupMenu.equals(groupMenu1)).isFalse();
+		assertThat(groupMenu).isNotEqualTo(groupMenu1);
 
 		groupMenu1.setUserGroup(groupMenu.getUserGroup());
 		groupMenu1.setMenuItem("someOtherMenuItem");
-		assertThat(groupMenu.equals(groupMenu1)).isFalse();
+		assertThat(groupMenu).isNotEqualTo(groupMenu1);
 
 		groupMenu1.setMenuItem(groupMenu.getMenuItem());
 		groupMenu1.setActive(-1);
-		assertThat(groupMenu.equals(groupMenu1)).isFalse();
+		assertThat(groupMenu).isNotEqualTo(groupMenu1);
 
 		groupMenu1.setActive(groupMenu.getActive());
-		assertThat(groupMenu.equals(groupMenu1)).isTrue();
+		assertThat(groupMenu).isEqualTo(groupMenu1);
 	}
 
 	@Test
@@ -564,7 +565,7 @@ public class Tests extends OHCoreTestCase {
 	public void testUserGroupToString() throws Exception {
 		UserGroup userGroup = testUserGroup.setup(true);
 		userGroup.setCode("someCode");
-		assertThat(userGroup.toString()).isEqualTo("someCode");
+		assertThat(userGroup).hasToString("someCode");
 	}
 
 	@Test


### PR DESCRIPTION
This is the second (and final) part (previous PR #363) of minor changes to use consistent and more natural assertj syntax across the tests. Some of this style was adopted with the later tests and this PR goes back and makes the style consistent.