### PR TITLE
Chore: update license plugin version to match gui and api projects

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<spring.framework.version>4.3.28.RELEASE</spring.framework.version>
-		<license.maven.plugin.version>4.0.rc2</license.maven.plugin.version>
+		<license.maven.plugin.version>4.0</license.maven.plugin.version>
 	</properties>
 
 	<build>


### PR DESCRIPTION
Same version change as dependabot PRs in [GUI](https://github.com/informatici/openhospital-gui/pull/454) and [API](https://github.com/informatici/openhospital-api/pull/114) projects.