### PR TITLE
OP-488 Implement patient search in oh-core

### DIFF
--- a/src/main/java/org/isf/patient/manager/PatientBrowserManager.java
+++ b/src/main/java/org/isf/patient/manager/PatientBrowserManager.java
@@ -21,6 +21,12 @@
  */
 package org.isf.patient.manager;
 
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
 import org.isf.accounting.manager.BillBrowserManager;
 import org.isf.accounting.model.Bill;
 import org.isf.admission.manager.AdmissionBrowserManager;
@@ -35,9 +41,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
-
-import java.util.*;
-
 
 @Component
 public class PatientBrowserManager {

--- a/src/main/java/org/isf/patient/service/PatientIoOperationRepository.java
+++ b/src/main/java/org/isf/patient/service/PatientIoOperationRepository.java
@@ -21,6 +21,9 @@
  */
 package org.isf.patient.service;
 
+import java.util.List;
+import java.util.Map;
+
 import org.isf.patient.model.Patient;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -29,9 +32,6 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
-import java.util.Map;
 
 @Repository
 public interface PatientIoOperationRepository extends JpaRepository<Patient, Integer>, PatientIoOperationRepositoryCustom {

--- a/src/main/java/org/isf/patient/service/PatientIoOperationRepositoryImpl.java
+++ b/src/main/java/org/isf/patient/service/PatientIoOperationRepositoryImpl.java
@@ -125,7 +125,7 @@ public class PatientIoOperationRepositoryImpl implements PatientIoOperationRepos
 				predicates.add(cb.between(keyPath.as(Date.class), birthDateFrom, birthDateTo));
 			} else {
 				if (entry.getValue() instanceof String) {
-					predicates.add(cb.like(keyPath, (String) entry.getValue() + "%"));
+					predicates.add(cb.like(cb.lower(keyPath), like(((String) entry.getValue()).toLowerCase())));
 				}
 			}
 		}

--- a/src/main/java/org/isf/patient/service/PatientIoOperationRepositoryImpl.java
+++ b/src/main/java/org/isf/patient/service/PatientIoOperationRepositoryImpl.java
@@ -21,23 +21,27 @@
  */
 package org.isf.patient.service;
 
-import org.isf.patient.model.Patient;
-import org.springframework.transaction.annotation.Transactional;
-
-import javax.persistence.EntityManager;
-import javax.persistence.PersistenceContext;
-import javax.persistence.criteria.*;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
+
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.CriteriaQuery;
+import javax.persistence.criteria.Path;
+import javax.persistence.criteria.Predicate;
+import javax.persistence.criteria.Root;
+
+import org.isf.patient.model.Patient;
+import org.springframework.transaction.annotation.Transactional;
 
 @Transactional
 public class PatientIoOperationRepositoryImpl implements PatientIoOperationRepositoryCustom {
 
 	@PersistenceContext
 	private EntityManager entityManager;
-
 
 	@SuppressWarnings("unchecked")
 	@Override
@@ -46,7 +50,6 @@ public class PatientIoOperationRepositoryImpl implements PatientIoOperationRepos
 				createQuery(buildSearchQuery(literal)).
 				getResultList();
 	}
-
 
 	private CriteriaQuery<Patient> buildSearchQuery(String regex) {
 		String[] words = getWordsToSearchForInPatientsRepository(regex);

--- a/src/main/java/org/isf/patient/service/PatientIoOperations.java
+++ b/src/main/java/org/isf/patient/service/PatientIoOperations.java
@@ -21,6 +21,10 @@
  */
 package org.isf.patient.service;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
 import org.hibernate.Hibernate;
 import org.isf.patient.model.Patient;
 import org.isf.patient.model.PatientMergedEvent;
@@ -32,10 +36,6 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-
 /**
  * ------------------------------------------
  * PatientIoOperations - dB operations for the patient entity
@@ -43,20 +43,20 @@ import java.util.Map;
  * modification history
  * 05/05/2005 - giacomo  - first beta version
  * 03/11/2006 - ross - added toString method. Gestione apici per
- *                     nome, cognome, citta', indirizzo e note
+ * nome, cognome, citta', indirizzo e note
  * 11/08/2008 - alessandro - added father & mother's names
  * 26/08/2008 - claudio    - added birth date
- * 							 modified age
+ * modified age
  * 01/01/2009 - Fabrizio   - changed the calls to PAT_AGE fields to
- *                           return again an int type
+ * return again an int type
  * 03/12/2009 - Alex       - added method for merge two patients history
  * ------------------------------------------
  */
 @Service
-@Transactional(rollbackFor=OHServiceException.class)
+@Transactional(rollbackFor = OHServiceException.class)
 @TranslateOHServiceException
-public class PatientIoOperations
-{
+public class PatientIoOperations {
+
 	public static final String NOT_DELETED_STATUS = "N";
 	@Autowired
 	private PatientIoOperationRepository repository;
@@ -124,7 +124,7 @@ public class PatientIoOperations
 	public Patient getPatient(String name) throws OHServiceException {
 		List<Patient> patients = repository.findByNameAndDeletedOrderByName(name, NOT_DELETED_STATUS);
 		if (!patients.isEmpty()) {
-			Patient patient = patients.get(patients.size()-1);
+			Patient patient = patients.get(patients.size() - 1);
 			Hibernate.initialize(patient.getPatientProfilePhoto());
 			return patient;
 		}
@@ -141,7 +141,7 @@ public class PatientIoOperations
 	public Patient getPatient(Integer code) throws OHServiceException {
 		List<Patient> patients = repository.findAllWhereIdAndDeleted(code, NOT_DELETED_STATUS);
 		if (!patients.isEmpty()) {
-			Patient patient = patients.get(patients.size()-1);
+			Patient patient = patients.get(patients.size() - 1);
 			Hibernate.initialize(patient.getPatientProfilePhoto());
 			return patient;
 		}
@@ -174,7 +174,6 @@ public class PatientIoOperations
 	}
 
 	/**
-	 *
 	 * Method that updates an existing {@link Patient} in the db
 	 *
 	 * @param patient - the {@link Patient} to update

--- a/src/test/java/org/isf/patient/test/Tests.java
+++ b/src/test/java/org/isf/patient/test/Tests.java
@@ -227,7 +227,7 @@ public class Tests extends OHCoreTestCase {
 		params.put("birthDate", new GregorianCalendar(1984, Calendar.AUGUST, 14).getTime());
 		params.put("address", "TestAddress");
 		ArrayList<Patient> patients = patientIoOperation.getPatients(params);
-		assertThat(patients.size() > 0).isTrue();
+		assertThat(patients.size()).isPositive();
 	}
 
 	@Test

--- a/src/test/java/org/isf/patient/test/Tests.java
+++ b/src/test/java/org/isf/patient/test/Tests.java
@@ -29,6 +29,9 @@ import java.lang.reflect.Field;
 import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Calendar;
+import java.util.GregorianCalendar;
+import java.util.HashMap;
+import java.util.Map;
 
 import org.assertj.core.api.Condition;
 import org.isf.OHCoreTestCase;
@@ -47,13 +50,6 @@ import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-
-import java.io.File;
-import java.lang.reflect.Field;
-import java.util.*;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class Tests extends OHCoreTestCase {
 

--- a/src/test/java/org/isf/patient/test/Tests.java
+++ b/src/test/java/org/isf/patient/test/Tests.java
@@ -223,7 +223,7 @@ public class Tests extends OHCoreTestCase {
 	public void testIoGetPatientsByParams() throws Exception {
 		_setupTestPatient(false);
 		Map<String, Object> params = new HashMap<String, Object>();
-		params.put("firstName", "TestFirstN");
+		params.put("firstName", "TESTFIRSTN");
 		params.put("birthDate", new GregorianCalendar(1984, Calendar.AUGUST, 14).getTime());
 		params.put("address", "TestAddress");
 		ArrayList<Patient> patients = patientIoOperation.getPatients(params);


### PR DESCRIPTION
The aim of this implementation is to add **basic search capabilities** on patient entity to support OH 20 UI requirements (https://openhospital.atlassian.net/browse/OP-323).

At the moment, supported search parameters are:

- birthdate
- address
- firstName
- secondName

This is [the first of two PR](https://openhospital.atlassian.net/browse/OP-487): the second one will be [on the oh-api project](https://openhospital.atlassian.net/browse/OP-489), but it _depends_ on this one.