### PR TITLE
Chore: use diamond notation

### DIFF
--- a/src/main/java/org/isf/patient/service/PatientIoOperationRepositoryImpl.java
+++ b/src/main/java/org/isf/patient/service/PatientIoOperationRepositoryImpl.java
@@ -114,7 +114,7 @@ public class PatientIoOperationRepositoryImpl implements PatientIoOperationRepos
 		Predicate deletedNull = cb.isNull(patient.get("deleted"));
 		Predicate notDeleted = cb.or(deletedN, deletedNull);
 
-		List<Predicate> predicates = new ArrayList<Predicate>();
+		List<Predicate> predicates = new ArrayList<>();
 		predicates.add(notDeleted);
 		for (Map.Entry<String, Object> entry : params.entrySet()) {
 			Path<String> keyPath = patient.get(entry.getKey());

--- a/src/main/java/org/isf/patient/service/PatientIoOperations.java
+++ b/src/main/java/org/isf/patient/service/PatientIoOperations.java
@@ -93,7 +93,7 @@ public class PatientIoOperations {
 	public ArrayList<Patient> getPatients(Map<String, Object> parameters) throws OHServiceException {
 
 		ArrayList<Patient> pPatient = null;
-		pPatient = new ArrayList<Patient>(repository.getPatientsByParams(parameters));
+		pPatient = new ArrayList<>(repository.getPatientsByParams(parameters));
 
 		return pPatient;
 	}

--- a/src/test/java/org/isf/patient/test/Tests.java
+++ b/src/test/java/org/isf/patient/test/Tests.java
@@ -222,7 +222,7 @@ public class Tests extends OHCoreTestCase {
 	@Test
 	public void testIoGetPatientsByParams() throws Exception {
 		_setupTestPatient(false);
-		Map<String, Object> params = new HashMap<String, Object>();
+		Map<String, Object> params = new HashMap<>();
 		params.put("firstName", "TESTFIRSTN");
 		params.put("birthDate", new GregorianCalendar(1984, Calendar.AUGUST, 14).getTime());
 		params.put("address", "TestAddress");


### PR DESCRIPTION
Replace type specification and use diamond notation that is available starting with Java 7.

Note:  this is in code pushed earlier today.