### PR TITLE
Chore: use List.sort() instead of Collections.sort()

### DIFF
--- a/src/main/java/org/isf/dicom/manager/FileSystemDicomManager.java
+++ b/src/main/java/org/isf/dicom/manager/FileSystemDicomManager.java
@@ -611,7 +611,7 @@ public class FileSystemDicomManager implements DicomManagerInterface {
 				rv.addElement(fileDicom);
 
 		FileDicom[] ret = new FileDicom[rv.size()];
-		Collections.sort(rv, new DicomDateComparator());
+		rv.sort(new DicomDateComparator());
 		Collections.reverse(rv);
 		rv.copyInto(ret);
 

--- a/src/main/java/org/isf/examination/manager/ExaminationBrowserManager.java
+++ b/src/main/java/org/isf/examination/manager/ExaminationBrowserManager.java
@@ -22,7 +22,6 @@
 package org.isf.examination.manager;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.GregorianCalendar;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
@@ -103,7 +102,7 @@ public class ExaminationBrowserManager {
 		if (auscultationHashMap == null)
 			buildAuscultationHashMap();
 		ArrayList<String> auscultationDescriptionList = new ArrayList<>(auscultationHashMap.values());
-		Collections.sort(auscultationDescriptionList, new DefaultSorter(MessageBundle.getMessage("angal.examination.auscultation.normal")));
+		auscultationDescriptionList.sort(new DefaultSorter(MessageBundle.getMessage("angal.examination.auscultation.normal")));
 		return auscultationDescriptionList;
 	}
 
@@ -216,7 +215,7 @@ public class ExaminationBrowserManager {
 		if (diuresisDescriptionHashMap == null)
 			buildDiuresisDescriptionHashMap();
 		ArrayList<String> diuresisDescriptionList = new ArrayList<>(diuresisDescriptionHashMap.values());
-		Collections.sort(diuresisDescriptionList, new DefaultSorter(MessageBundle.getMessage("angal.examination.diuresis.physiological")));
+		diuresisDescriptionList.sort(new DefaultSorter(MessageBundle.getMessage("angal.examination.diuresis.physiological")));
 		return diuresisDescriptionList;
 	}
 
@@ -233,7 +232,7 @@ public class ExaminationBrowserManager {
 		if (bowelDescriptionHashMap == null)
 			buildBowelDescriptionHashMap();
 		ArrayList<String> bowelDescriptionList = new ArrayList<>(bowelDescriptionHashMap.values());
-		Collections.sort(bowelDescriptionList, new DefaultSorter(MessageBundle.getMessage("angal.examination.bowel.regular")));
+		bowelDescriptionList.sort(new DefaultSorter(MessageBundle.getMessage("angal.examination.bowel.regular")));
 		return bowelDescriptionList;
 	}
 

--- a/src/main/java/org/isf/lab/manager/LabManager.java
+++ b/src/main/java/org/isf/lab/manager/LabManager.java
@@ -22,7 +22,6 @@
 package org.isf.lab.manager;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.GregorianCalendar;
 import java.util.HashMap;
 import java.util.List;
@@ -464,7 +463,7 @@ public class LabManager {
 		if (materialHashMap == null)
 			buildMaterialHashMap();
 		ArrayList<String> materialDescriptionList = new ArrayList<>(materialHashMap.values());
-		Collections.sort(materialDescriptionList, new DefaultSorter(MessageBundle.getMessage("angal.lab.undefined")));
+		materialDescriptionList.sort(new DefaultSorter(MessageBundle.getMessage("angal.lab.undefined")));
 		return materialDescriptionList;
 	}
 

--- a/src/main/java/org/isf/medicalstockward/manager/MovWardBrowserManager.java
+++ b/src/main/java/org/isf/medicalstockward/manager/MovWardBrowserManager.java
@@ -227,7 +227,7 @@ public class MovWardBrowserManager {
 		for (MovementWard mov : wardOutcomes) {
 			movPrint.add(new MovementWardForPrint(mov));
 		}
-		Collections.sort(movPrint, new ComparatorMovementWardForPrint());
+		movPrint.sort(new ComparatorMovementWardForPrint());
 		return movPrint;
 	}
 
@@ -236,7 +236,7 @@ public class MovWardBrowserManager {
 		for (Movement mov : wardIncomes) {
 			movPrint.add(new MovementForPrint(mov));
 		}
-		Collections.sort(movPrint, new ComparatorMovementForPrint());
+		movPrint.sort(new ComparatorMovementForPrint());
 		return movPrint;
 	}
 

--- a/src/main/java/org/isf/operation/manager/OperationBrowserManager.java
+++ b/src/main/java/org/isf/operation/manager/OperationBrowserManager.java
@@ -22,7 +22,6 @@
 package org.isf.operation.manager;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.LinkedHashMap;
 
 import org.isf.generaldata.MessageBundle;
@@ -178,7 +177,7 @@ public class OperationBrowserManager {
 	public ArrayList<String> getResultDescriptionList() {
 		if (resultsListHashMap == null) buildResultHashMap();
 		ArrayList<String> resultDescriptionList = new ArrayList<>(resultsListHashMap.values());
-		Collections.sort(resultDescriptionList,  new DefaultSorter(MessageBundle.getMessage("angal.operation.result.success")));
+		resultDescriptionList.sort(new DefaultSorter(MessageBundle.getMessage("angal.operation.result.success")));
 		return resultDescriptionList;
 	}
 	


### PR DESCRIPTION
Starting with JDK 8 `Collections.sort()` internally calls `List.sort()`.  To save an extra method call just use `List.sort()` directly.

Found with IntelliJ Analyze plugin.