### PR TITLE
Make configuration classes final as security pattern

### DIFF
--- a/src/main/java/org/isf/generaldata/ConfigurationProperties.java
+++ b/src/main/java/org/isf/generaldata/ConfigurationProperties.java
@@ -66,7 +66,7 @@ public abstract class ConfigurationProperties {
 	 * @param fileProperties - the file name (to be available in the classpath)
 	 * @param logger - the {@link Logger} of the concrete class
 	 */
-	public static Properties loadPropertiesFile(String fileProperties, Logger logger) {
+	public static final Properties loadPropertiesFile(String fileProperties, Logger logger) {
 		return loadPropertiesFile(fileProperties, logger, false);
 	}
 
@@ -77,7 +77,7 @@ public abstract class ConfigurationProperties {
 	 * @param exitOnFail - if {@code true} the application will exit if configuration 
 	 * is missing, otherwise default values will be used
 	 */
-	private static Properties loadPropertiesFile(String fileProperties, Logger logger, boolean exitOnFail) {
+	private static final Properties loadPropertiesFile(String fileProperties, Logger logger, boolean exitOnFail) {
 		Properties prop = new Properties();
 		InputStream in = Thread.currentThread().getContextClassLoader().getResourceAsStream(fileProperties);
 		try {

--- a/src/main/java/org/isf/generaldata/ExaminationParameters.java
+++ b/src/main/java/org/isf/generaldata/ExaminationParameters.java
@@ -26,7 +26,7 @@ package org.isf.generaldata;
  *
  * @author Mwithi
  */
-public class ExaminationParameters extends ConfigurationProperties {
+public final class ExaminationParameters extends ConfigurationProperties {
 	
 	private static final String FILE_PROPERTIES = "examination.properties";
 	

--- a/src/main/java/org/isf/generaldata/GeneralData.java
+++ b/src/main/java/org/isf/generaldata/GeneralData.java
@@ -37,7 +37,7 @@ package org.isf.generaldata;
  * 29/12/2011 - Nicola   - added XMPPMODULEENABLED to enable/disable communication module
  * -------------------------------------------
  */
-public class GeneralData extends ConfigurationProperties {
+public final class GeneralData extends ConfigurationProperties {
 	
 	private static final String FILE_PROPERTIES = "generalData.properties";
 	private static final boolean EXIT_ON_FAIL = true;

--- a/src/main/java/org/isf/generaldata/SmsParameters.java
+++ b/src/main/java/org/isf/generaldata/SmsParameters.java
@@ -21,7 +21,7 @@
  */
 package org.isf.generaldata;
 
-public class SmsParameters extends ConfigurationProperties {
+public final class SmsParameters extends ConfigurationProperties {
 	
 	private static final String FILE_PROPERTIES = "sms.properties";
 

--- a/src/main/java/org/isf/generaldata/TxtPrinter.java
+++ b/src/main/java/org/isf/generaldata/TxtPrinter.java
@@ -21,7 +21,7 @@
  */
 package org.isf.generaldata;
 
-public class TxtPrinter extends ConfigurationProperties {
+public final class TxtPrinter extends ConfigurationProperties {
 	
 	private static final String FILE_PROPERTIES = "txtPrinter.properties";
 

--- a/src/main/java/org/isf/generaldata/Version.java
+++ b/src/main/java/org/isf/generaldata/Version.java
@@ -21,7 +21,7 @@
  */
 package org.isf.generaldata;
 
-public class Version extends ConfigurationProperties {
+public final class Version extends ConfigurationProperties {
 
 	private static final String FILE_PROPERTIES = "version.properties";
 	private final static boolean EXIT_ON_FAIL = true;

--- a/src/main/java/org/isf/generaldata/XmppData.java
+++ b/src/main/java/org/isf/generaldata/XmppData.java
@@ -21,7 +21,7 @@
  */
 package org.isf.generaldata;
 
-public class XmppData extends ConfigurationProperties {
+public final class XmppData extends ConfigurationProperties {
 	
 	private static final String FILE_PROPERTIES = "xmpp.properties";
 	


### PR DESCRIPTION
In order to prevent configuration methods and properties ovverride, all configuration classes are modified as final