### PR TITLE
Chore: Bump license.maven.plugin.version from 4.0 to 4.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<spring.framework.version>4.3.28.RELEASE</spring.framework.version>
-		<license.maven.plugin.version>4.0</license.maven.plugin.version>
+		<license.maven.plugin.version>4.1</license.maven.plugin.version>
 	</properties>
 
 	<build>


### PR DESCRIPTION
Updates license-maven-plugin from 4.0 to 4.1 to match dependabot change to GUI and API projects.