### PR TITLE
Chore: set date to next day

### DIFF
--- a/src/main/java/org/isf/admission/service/AdmissionIoOperations.java
+++ b/src/main/java/org/isf/admission/service/AdmissionIoOperations.java
@@ -21,6 +21,12 @@
  */
 package org.isf.admission.service;
 
+import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.GregorianCalendar;
+import java.util.List;
+import java.util.stream.Collectors;
+
 import org.hibernate.Hibernate;
 import org.isf.admission.model.Admission;
 import org.isf.admission.model.AdmittedPatient;
@@ -36,12 +42,6 @@ import org.isf.utils.exception.OHServiceException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.ArrayList;
-import java.util.Calendar;
-import java.util.GregorianCalendar;
-import java.util.List;
-import java.util.stream.Collectors;
 
 /**
  * ---------------------------------------------------------
@@ -249,14 +249,14 @@ public class AdmissionIoOperations
 			if (now.get(Calendar.MONTH) < 6) 
 			{
 				first = new GregorianCalendar(now.get(Calendar.YEAR) - 1, Calendar.JULY, 1);
-				last = new GregorianCalendar(now.get(Calendar.YEAR), Calendar.JUNE, 30);
+				last = new GregorianCalendar(now.get(Calendar.YEAR), Calendar.JULY, 1);
 			} 
 			else 
 			{
 				first = new GregorianCalendar(now.get(Calendar.YEAR), Calendar.JULY, 1);
-				last = new GregorianCalendar(now.get(Calendar.YEAR) + 1, Calendar.JUNE, 30);
-			}
+				last = new GregorianCalendar(now.get(Calendar.YEAR) + 1, Calendar.JULY, 1);
 
+			}
 		} 
 		else 
 		{


### PR DESCRIPTION
Set the end of the day range to the next day as the SQL code checks all parts of the date/time; currently it is set to June30, 0 minutes, 0 seconds thus anything occurring on June 30 is not retrieved in the search.  Setting it to July 1 makes it look like midnight on June 30 instead of 1 second into the day.