### PR TITLE
enable sql file execution which starts with 7*

### DIFF
--- a/Dockerfile-ohdb
+++ b/Dockerfile-ohdb
@@ -21,6 +21,7 @@ COPY sql/step_3* /docker-entrypoint-initdb.d/
 COPY sql/step_4* /docker-entrypoint-initdb.d/
 COPY sql/step_5* /docker-entrypoint-initdb.d/
 COPY sql/step_6* /docker-entrypoint-initdb.d/
+COPY sql/step_7* /docker-entrypoint-initdb.d/
 COPY sql/data_en/* data_en/
 #COPY sql/data_es/* data_es/
 #COPY sql/data_it/* data_it/


### PR DESCRIPTION
problem: when I generate DB, the scripts that starts with prefix 7* are not executed