### PR TITLE
Chore: nullcheck of movement when variable previously dereferenced

### DIFF
--- a/src/main/java/org/isf/medicalstock/manager/MovStockInsertingManager.java
+++ b/src/main/java/org/isf/medicalstock/manager/MovStockInsertingManager.java
@@ -126,8 +126,7 @@ public class MovStockInsertingManager {
 			Lot lot = movement.getLot();
 			errors.addAll(validateLot(lot));
 
-			if (movement != null && movement.getType() != null && movement.getType().getType().contains("-") && movement.getQuantity() > lot
-					.getMainStoreQuantity()) {
+			if (movement.getType() != null && movement.getType().getType().contains("-") && movement.getQuantity() > lot.getMainStoreQuantity()) {
 				errors.add(new OHExceptionMessage(MessageBundle.getMessage("angal.common.error.title"),
 						MessageBundle.getMessage("angal.medicalstock.movementquantityisgreaterthanthequantityof.msg"),
 						OHSeverityLevel.ERROR));


### PR DESCRIPTION
Remove null check of variable `movement` as it was previously dereferenced a few lines (line 126) above.

Found with SpotBugs.