### PR TITLE
Chore: fix if test

### DIFF
--- a/src/main/java/org/isf/medicalstock/manager/MovStockInsertingManager.java
+++ b/src/main/java/org/isf/medicalstock/manager/MovStockInsertingManager.java
@@ -95,14 +95,14 @@ public class MovStockInsertingManager {
 			// Check supplier
 			if (chargingType) {
 				Object supplier = movement.getSupplier();
-				if (supplier instanceof String) {
+				if (null == supplier) {
 					errors.add(new OHExceptionMessage(MessageBundle.getMessage("angal.common.error.title"),
 							MessageBundle.getMessage("angal.medicalstock.multiplecharging.pleaseselectasupplier.msg"),
 							OHSeverityLevel.ERROR));
 				}
 			} else {
 				Object ward = movement.getWard();
-				if (ward instanceof String) {
+				if (null == ward) {
 					errors.add(new OHExceptionMessage(MessageBundle.getMessage("angal.common.error.title"),
 							MessageBundle.getMessage("angal.medicalstock.multipledischarging.pleaseselectaward.msg"),
 							OHSeverityLevel.ERROR));

--- a/src/test/java/org/isf/medicalstock/test/Tests.java
+++ b/src/test/java/org/isf/medicalstock/test/Tests.java
@@ -818,7 +818,7 @@ public class Tests extends OHCoreTestCase {
 				.isInstanceOf(OHDataValidationException.class)
 				.has(
 						new Condition<Throwable>(
-								(e -> ((OHServiceException) e).getMessages().size() == 2), "Expecting two validation errors")
+								(e -> ((OHServiceException) e).getMessages().size() == 3), "Expecting two validation errors")
 				);
 	}
 


### PR DESCRIPTION
The `getSupplier()` and `getWard()` will always return on object of the correct type or the value `null`.  The test should be for `null` indicating that a supplier or ward must be selected.