### PR TITLE
Chore: code cleanup; remove unneeded throws clauses

### DIFF
--- a/src/main/java/org/isf/accounting/manager/BillBrowserManager.java
+++ b/src/main/java/org/isf/accounting/manager/BillBrowserManager.java
@@ -61,11 +61,8 @@ public class BillBrowserManager {
 	 * @param billPayments
 	 * @throws OHDataValidationException
 	 */
-	protected void validateBill(Bill bill,
-			List<BillItems> billItems,
-			List<BillPayments> billPayments) throws OHDataValidationException
-	{
-        List<OHExceptionMessage> errors = new ArrayList<>();
+	protected void validateBill(Bill bill, List<BillItems> billItems, List<BillPayments> billPayments) throws OHDataValidationException {
+		List<OHExceptionMessage> errors = new ArrayList<>();
         
         GregorianCalendar today = new GregorianCalendar();
 		GregorianCalendar upDate = new GregorianCalendar();
@@ -111,20 +108,19 @@ public class BillBrowserManager {
 	        		MessageBundle.getMessage("angal.newbill.abillwithanoutstandingbalancecannotbeclosed.msg"),
 	        		OHSeverityLevel.ERROR));
 		}
-		if(!errors.isEmpty()){
-	        throw new OHDataValidationException(errors);
-	    }
+		if (!errors.isEmpty()) {
+			throw new OHDataValidationException(errors);
+		}
     }
 	
 	/**
 	 * Returns all the stored {@link BillItems}.
 	 * @return a list of {@link BillItems} or null if an error occurs.
-	 * @throws OHServiceException 
 	 * @deprecated this method should always be called with a parameter.
 	 * See {@link #getItems(int) getItems} method.
 	 */
 	@Deprecated
-	public List<BillItems> getItems() throws OHServiceException {
+	public List<BillItems> getItems() {
 		return ioOperations.getItems(0);
 	}
 
@@ -132,10 +128,11 @@ public class BillBrowserManager {
 	 * Retrieves all the {@link BillItems} associated to the passed {@link Bill} id.
 	 * @param billID the bill id.
 	 * @return a list of {@link BillItems} or <code>null</code> if an error occurred.
-	 * @throws OHServiceException 
 	 */
-	public List<BillItems> getItems(int billID) throws OHServiceException {
-		if (billID == 0) return new ArrayList<>();
+	public List<BillItems> getItems(int billID) {
+		if (billID == 0) {
+			return new ArrayList<>();
+		}
 		return ioOperations.getItems(billID);
 	}
 
@@ -145,9 +142,8 @@ public class BillBrowserManager {
 	 * @param dateTo
 	 * @param patient
 	 * @return the bills list
-	 * @throws OHServiceException 
 	 */
-	public List<Bill> getBills(GregorianCalendar dateFrom, GregorianCalendar dateTo,Patient patient) throws OHServiceException {
+	public List<Bill> getBills(GregorianCalendar dateFrom, GregorianCalendar dateTo,Patient patient) {
 		return ioOperations.getBillsBetweenDatesWherePatient(dateFrom, dateTo, patient);
 	}
 
@@ -157,21 +153,19 @@ public class BillBrowserManager {
 	 * @param dateTo
 	 * @param patient
 	 * @return the list of payments
-	 * @throws OHServiceException 
 	 */
-	public List<BillPayments> getPayments(GregorianCalendar dateFrom, GregorianCalendar dateTo,Patient patient) throws OHServiceException {
+	public List<BillPayments> getPayments(GregorianCalendar dateFrom, GregorianCalendar dateTo,Patient patient) {
 		return ioOperations.getPaymentsBetweenDatesWherePatient(dateFrom, dateTo, patient);
 	}
 	
 	/**
 	 * Retrieves all the stored {@link BillPayments}.
 	 * @return a list of bill payments or <code>null</code> if an error occurred.
-	 * @throws OHServiceException
 	 * @deprecated this method should always be called with a parameter.
 	 * See {@link #getPayments(int) getPayments} method.
 	 */
 	@Deprecated
-	public List<BillPayments> getPayments() throws OHServiceException {
+	public List<BillPayments> getPayments() {
 		return ioOperations.getPayments(0);
 	}
 
@@ -181,8 +175,10 @@ public class BillBrowserManager {
 	 * @return a list of {@link BillPayments} or <code>null</code> if an error occurred.
 	 * @throws OHServiceException 
 	 */
-	public List<BillPayments> getPayments(int billID) throws OHServiceException {
-		if (billID == 0) return new ArrayList<>();
+	public List<BillPayments> getPayments(int billID) {
+		if (billID == 0) {
+			return new ArrayList<>();
+		}
 		return ioOperations.getPayments(billID);
 	}
 	
@@ -195,16 +191,16 @@ public class BillBrowserManager {
 	 * @throws OHServiceException 
 	 */
 	@Transactional(rollbackFor=OHServiceException.class)
-	public boolean newBill(
-			Bill newBill,
-			List<BillItems> billItems,
-			List<BillPayments> billPayments) throws OHServiceException
-	{
+	public boolean newBill(Bill newBill, List<BillItems> billItems, List<BillPayments> billPayments) throws OHServiceException {
 		validateBill(newBill, billItems, billPayments);
 		int billId = newBill(newBill);
 		boolean result = billId > 0;
-		if (!billItems.isEmpty()) result = newBillItems(billId, billItems);
-		if (!billPayments.isEmpty()) result = result && newBillPayments(billId, billPayments);
+		if (!billItems.isEmpty()) {
+			result = newBillItems(billId, billItems);
+		}
+		if (!billPayments.isEmpty()) {
+			result = result && newBillPayments(billId, billPayments);
+		}
 		return result;
 	}
 
@@ -212,9 +208,8 @@ public class BillBrowserManager {
 	 * Stores a new {@link Bill}.
 	 * @param newBill the bill to store.
 	 * @return the generated id.
-	 * @throws OHServiceException
 	 */
-	private int newBill(Bill newBill) throws OHServiceException {
+	private int newBill(Bill newBill) {
 		return ioOperations.newBill(newBill);
 	}
 
@@ -223,9 +218,8 @@ public class BillBrowserManager {
 	 * @param billID the bill id.
 	 * @param billItems the bill items to store.
 	 * @return <code>true</code> if the {@link BillItems} have been store, <code>false</code> otherwise.
-	 * @throws OHServiceException
 	 */
-	private boolean newBillItems(int billID, List<BillItems> billItems) throws OHServiceException {
+	private boolean newBillItems(int billID, List<BillItems> billItems) {
 		return ioOperations.newBillItems(ioOperations.getBill(billID), billItems);
 	}
 	
@@ -234,9 +228,8 @@ public class BillBrowserManager {
 	 * @param billID the bill id.
 	 * @param payItems the bill payments.
 	 * @return <code>true</code> if the payments have been stored, <code>false</code> otherwise.
-	 * @throws OHServiceException
 	 */
-	private boolean newBillPayments(int billID, List<BillPayments> payItems) throws OHServiceException {
+	private boolean newBillPayments(int billID, List<BillPayments> payItems) {
 		return ioOperations.newBillPayments(ioOperations.getBill(billID), payItems);
 	}
 	
@@ -249,15 +242,12 @@ public class BillBrowserManager {
 	 * @throws OHServiceException
 	 */
 	@Transactional(rollbackFor=OHServiceException.class)
-	public boolean updateBill(Bill updateBill,
-			List<BillItems> billItems,
-			List<BillPayments> billPayments) throws OHServiceException {
+	public boolean updateBill(Bill updateBill, List<BillItems> billItems, List<BillPayments> billPayments) throws OHServiceException {
 		validateBill(updateBill, billItems, billPayments);
 		boolean result = updateBill(updateBill);
 		result = result && newBillItems(updateBill.getId(), billItems);
 		result = result && newBillPayments(updateBill.getId(), billPayments);
 		return result;
-
 	}
 
 	/**
@@ -266,7 +256,7 @@ public class BillBrowserManager {
 	 * @return <code>true</code> if the bill has been updated, <code>false</code> otherwise.
 	 * @throws OHServiceException 
 	 */
-	private boolean updateBill(Bill updateBill) throws OHServiceException {
+	private boolean updateBill(Bill updateBill) {
 		return ioOperations.updateBill(updateBill);
 	}
 	
@@ -274,20 +264,18 @@ public class BillBrowserManager {
 	 * Returns all the pending {@link Bill}s for the specified patient.
 	 * @param patID the patient id.
 	 * @return the list of pending bills or <code>null</code> if an error occurred.
-	 * @throws OHServiceException 
 	 */
-	public List<Bill> getPendingBills(int patID) throws OHServiceException {
+	public List<Bill> getPendingBills(int patID) {
 		return ioOperations.getPendingBills(patID);
 	}
 
 	/**
 	 * Get all the {@link Bill}s.
 	 * @return a list of bills or <code>null</code> if an error occurred.
-	 * @throws OHServiceException
 	 * @deprecated this method should not be called for its potentially huge resultset
 	 */
 	@Deprecated
-	public List<Bill> getBills() throws OHServiceException {
+	public List<Bill> getBills() {
 		return ioOperations.getBills();
 	}
 	
@@ -295,18 +283,16 @@ public class BillBrowserManager {
 	 * Get the {@link Bill} with specified billID
 	 * @param billID
 	 * @return the {@link Bill} or <code>null</code> if an error occurred.
-	 * @throws OHServiceException 
 	 */
-	public Bill getBill(int billID) throws OHServiceException {
+	public Bill getBill(int billID) {
 		return ioOperations.getBill(billID);
 	}
 
 	/**
 	 * Returns all user ids related to a {@link BillPayments}.
 	 * @return a list of user id or <code>null</code> if an error occurred.
-	 * @throws OHServiceException 
 	 */
-	public List<String> getUsers() throws OHServiceException {
+	public List<String> getUsers() {
 		return ioOperations.getUsers();
 	}
 
@@ -314,9 +300,8 @@ public class BillBrowserManager {
 	 * Deletes the specified {@link Bill}.
 	 * @param deleteBill the bill to delete.
 	 * @return <code>true</code> if the bill has been deleted, <code>false</code> otherwise.
-	 * @throws OHServiceException 
 	 */
-	public boolean deleteBill(Bill deleteBill) throws OHServiceException {
+	public boolean deleteBill(Bill deleteBill) {
 		return ioOperations.deleteBill(deleteBill);
 	}
 
@@ -325,9 +310,8 @@ public class BillBrowserManager {
 	 * @param dateFrom the low date range endpoint, inclusive. 
 	 * @param dateTo the high date range endpoint, inclusive.
 	 * @return a list of retrieved {@link Bill}s or <code>null</code> if an error occurred.
-	 * @throws OHServiceException 
 	 */
-	public List<Bill> getBills(GregorianCalendar dateFrom, GregorianCalendar dateTo) throws OHServiceException {
+	public List<Bill> getBills(GregorianCalendar dateFrom, GregorianCalendar dateTo) {
 		return ioOperations.getBillsBetweenDates(dateFrom, dateTo);
 	}
 
@@ -335,10 +319,11 @@ public class BillBrowserManager {
 	 * Gets all the {@link Bill}s associated to the passed {@link BillPayments}.
 	 * @param billPayments the {@link BillPayments} associated to the bill to retrieve.
 	 * @return a list of {@link Bill} associated to the passed {@link BillPayments} or <code>null</code> if an error occurred.
-	 * @throws OHServiceException 
 	 */
-	public List<Bill> getBills(List<BillPayments> billPayments) throws OHServiceException {
-		if (billPayments.isEmpty()) return new ArrayList<>();
+	public List<Bill> getBills(List<BillPayments> billPayments) {
+		if (billPayments.isEmpty()) {
+			return new ArrayList<>();
+		}
 		return ioOperations.getBills(billPayments);
 	}
 
@@ -347,9 +332,8 @@ public class BillBrowserManager {
 	 * @param dateFrom low endpoint, inclusive, for the date range. 
 	 * @param dateTo high endpoint, inclusive, for the date range.
 	 * @return a list of {@link BillPayments} for the specified date range or <code>null</code> if an error occurred.
-	 * @throws OHServiceException 
 	 */
-	public List<BillPayments> getPayments(GregorianCalendar dateFrom, GregorianCalendar dateTo) throws OHServiceException {
+	public List<BillPayments> getPayments(GregorianCalendar dateFrom, GregorianCalendar dateTo) {
 		return ioOperations.getPayments(dateFrom, dateTo);
 	}
 
@@ -357,9 +341,8 @@ public class BillBrowserManager {
 	 * Retrieves all the {@link BillPayments} associated to the passed {@link Bill} list.
 	 * @param billArray the bill array list of {@link Bill}s.
 	 * @return a list of {@link BillPayments} associated to the passed bill list or <code>null</code> if an error occurred. 
-	 * @throws OHServiceException 
 	 */
-	public List<BillPayments> getPayments(List<Bill> billArray) throws OHServiceException {
+	public List<BillPayments> getPayments(List<Bill> billArray) {
 		return ioOperations.getPayments(billArray);
 	}
 
@@ -367,9 +350,8 @@ public class BillBrowserManager {
 	 * Retrieves all the {@link Bill}s associated to the specified {@link Patient}.
 	 * @param patID - the Patient's ID
 	 * @return the list of {@link Bill}s
-	 * @throws OHServiceException 
 	 */
-	public List<Bill> getPendingBillsAffiliate(int patID) throws OHServiceException {
+	public List<Bill> getPendingBillsAffiliate(int patID) {
 		return ioOperations.getPendingBillsAffiliate(patID);
 	}
 
@@ -377,9 +359,8 @@ public class BillBrowserManager {
 	 * Returns all the distinct stored {@link BillItems}.
 	 * 
 	 * @return a list of  distinct {@link BillItems} or null if an error occurs.
-	 * @throws OHServiceException 
 	 */
-	public List<BillItems> getDistinctItems() throws OHServiceException{
+	public List<BillItems> getDistinctItems() {
 		return ioOperations.getDistictsBillItems();
 	}
 	
@@ -389,9 +370,8 @@ public class BillBrowserManager {
 	 * @param dateTo
 	 * @param billItem
 	 * @return
-	 * @throws OHServiceException 
 	 */
-	public List<Bill> getBills(GregorianCalendar dateFrom, GregorianCalendar dateTo,BillItems billItem) throws OHServiceException {
+	public List<Bill> getBills(GregorianCalendar dateFrom, GregorianCalendar dateTo,BillItems billItem) {
 		return ioOperations.getBillsBetweenDatesWhereBillItem(dateFrom, dateTo, billItem);
 	}
 }

--- a/src/main/java/org/isf/accounting/service/AccountingIoOperations.java
+++ b/src/main/java/org/isf/accounting/service/AccountingIoOperations.java
@@ -58,40 +58,36 @@ public class AccountingIoOperations {
 	 * Returns all the pending {@link Bill}s for the specified patient.
 	 * @param patID the patient id.
 	 * @return the list of pending bills.
-	 * @throws OHServiceException if an error occurs retrieving the pending bills.
 	 */
-	public List<Bill> getPendingBills(int patID) throws OHServiceException {
-		if (patID != 0)
-			return new ArrayList<>(billRepository.findByStatusAndBillPatientCodeOrderByDateDesc("O", patID));
-
-		return new ArrayList<>(billRepository.findByStatusOrderByDateDesc("O"));
+	public List<Bill> getPendingBills(int patID) {
+		if (patID != 0) {
+			return billRepository.findByStatusAndBillPatientCodeOrderByDateDesc("O", patID);
+		}
+		return billRepository.findByStatusOrderByDateDesc("O");
 	}
 	
 	/**
 	 * Get all the {@link Bill}s.
 	 * @return a list of bills.
-	 * @throws OHServiceException if an error occurs retrieving the bills.
 	 */
-	public List<Bill> getBills() throws OHServiceException {
-		return new ArrayList<>(billRepository.findAllByOrderByDateDesc());
+	public List<Bill> getBills() {
+		return billRepository.findAllByOrderByDateDesc();
 	}
 	
 	/**
 	 * Get the {@link Bill} with specified billID.
 	 * @param billID
 	 * @return the {@link Bill}.
-	 * @throws OHServiceException if an error occurs retrieving the bill.
 	 */
-	public Bill getBill(int billID) throws OHServiceException {
+	public Bill getBill(int billID) {
 		return billRepository.findOne(billID);
 	}
 
 	/**
 	 * Returns all user ids from {@link BillPayments}.
 	 * @return a list of user id.
-	 * @throws OHServiceException if an error occurs retrieving the users list.
 	 */
-    public List<String> getUsers() throws OHServiceException {
+    public List<String> getUsers() {
     	Set<String> accountingUsers = new TreeSet<>(String::compareTo);
     	accountingUsers.addAll(billRepository.findUserDistinctByOrderByUserAsc());
     	accountingUsers.addAll(billPaymentRepository.findUserDistinctByOrderByUserAsc());
@@ -103,18 +99,12 @@ public class AccountingIoOperations {
 	 * the stored {@link BillItems} if no id is provided. 
 	 * @param billID the bill id or <code>0</code>.
 	 * @return a list of {@link BillItems} associated to the bill id or all the stored bill items.
-	 * @throws OHServiceException if an error occurs retrieving the bill items.
 	 */
-	public List<BillItems> getItems(int billID) throws OHServiceException {
-		List<BillItems> billItems = null;
-
+	public List<BillItems> getItems(int billID) {
 		if (billID != 0) {
-			billItems = new ArrayList<>(billItemsRepository.findByBill_idOrderByIdAsc(billID));
-		} else {
-			billItems = new ArrayList<>(billItemsRepository.findAllByOrderByIdAsc());
+			return billItemsRepository.findByBill_idOrderByIdAsc(billID);
 		}
-
-		return billItems;
+		return billItemsRepository.findAllByOrderByIdAsc();
 	}
 
 	/**
@@ -122,14 +112,9 @@ public class AccountingIoOperations {
 	 * @param dateFrom low endpoint, inclusive, for the date range. 
 	 * @param dateTo high endpoint, inclusive, for the date range.
 	 * @return a list of {@link BillPayments} for the specified date range.
-	 * @throws OHServiceException if an error occurs retrieving the bill payments.
 	 */
-	public List<BillPayments> getPayments(
-		GregorianCalendar dateFrom, 
-		GregorianCalendar dateTo) throws OHServiceException {
-
-		return new ArrayList<>(
-				billPaymentRepository.findByDateBetweenOrderByIdAscDateAsc(TimeTools.getBeginningOfDay(dateFrom), TimeTools.getBeginningOfNextDay(dateTo)));
+	public List<BillPayments> getPayments(GregorianCalendar dateFrom, GregorianCalendar dateTo) {
+		return billPaymentRepository.findByDateBetweenOrderByIdAscDateAsc(TimeTools.getBeginningOfDay(dateFrom), TimeTools.getBeginningOfNextDay(dateTo));
 	}
 
 	/**
@@ -137,29 +122,20 @@ public class AccountingIoOperations {
 	 * the stored {@link BillPayments} if no id is indicated.
 	 * @param billID the bill id or <code>0</code>.
 	 * @return the list of bill payments.
-	 * @throws OHServiceException if an error occurs retrieving the bill payments.
 	 */
-	public List<BillPayments> getPayments(
-			int billID) throws OHServiceException {
-		List<BillPayments> payments = null;
-
+	public List<BillPayments> getPayments(int billID) {
 		if (billID != 0) {
-			payments = (ArrayList<BillPayments>) billPaymentRepository.findAllWherBillIdByOrderByBillAndDate(billID);
-		} else {
-			payments = (ArrayList<BillPayments>) billPaymentRepository.findAllByOrderByBillAndDate();
+			return billPaymentRepository.findAllWherBillIdByOrderByBillAndDate(billID);
 		}
-
-		return payments;
+		return billPaymentRepository.findAllByOrderByBillAndDate();
 	}
 
 	/**
 	 * Stores a new {@link Bill}.
 	 * @param newBill the bill to store.
 	 * @return the generated {@link Bill} id.
-	 * @throws OHServiceException if an error occurs storing the bill.
 	 */
-	public int newBill(Bill newBill) throws OHServiceException {
-
+	public int newBill(Bill newBill) {
 		return billRepository.save(newBill).getId();
 	}
 
@@ -168,131 +144,57 @@ public class AccountingIoOperations {
 	 * @param bill the bill.
 	 * @param billItems the bill items to store.
 	 * @return <code>true</code> if the {@link BillItems} have been store, <code>false</code> otherwise.
-	 * @throws OHServiceException if an error occurs during the store operation.
 	 */
-	public boolean newBillItems(
-			Bill bill,
-			List<BillItems> billItems) throws OHServiceException
-	{
-		boolean result = true;
-		
-		
-		result = _deleteBillsInsideBillItems(bill.getId());
-		
-		result &= _insertNewBillInsideBillItems(bill, billItems);
+	public boolean newBillItems(Bill bill, List<BillItems> billItems) {
 
-		return result;
-	}
-	
-	private boolean _deleteBillsInsideBillItems(
-			int id) throws OHServiceException 
-    {	
-		boolean result = true;
-        		
-		
-		billItemsRepository.deleteWhereId(id);
-		
-        return result;
-    }
-	
-	private boolean _insertNewBillInsideBillItems(
-			Bill bill,
-			List<BillItems> billItems) throws OHServiceException
-    {	
-		boolean result = true;
-        		
-		
-		for (BillItems item : billItems) 
-		{
+		// deleteBillsInsideBillItems(bill.getId());
+		billItemsRepository.deleteWhereId(bill.getId());
+
+		// insertNewBillInsideBillItems(bill, billItems);
+		for (BillItems item : billItems) {
 			item.setBill(bill);
 			billItemsRepository.save(item);
 		}
-		
-		return result;
-    }
-	
+		return true;
+	}
+
 	/**
 	 * Stores a list of {@link BillPayments} associated to a {@link Bill}.
 	 * @param bill the bill.
 	 * @param payItems the bill payments.
 	 * @return <code>true</code> if the payment have stored, <code>false</code> otherwise.
-	 * @throws OHServiceException if an error occurs during the store procedure.
 	 */
-	public boolean newBillPayments(
-			Bill bill, 
-			List<BillPayments> payItems) throws OHServiceException
-	{
-		boolean result = true;
-		
-		
-		result = _deleteBillsInsideBillPayments(bill.getId());
-		
-		result &= _insertNewBillInsideBillPayments(bill, payItems);
+	public boolean newBillPayments(Bill bill, List<BillPayments> payItems) {
 
-		return result;
-	}
-	
-	private boolean _deleteBillsInsideBillPayments(
-			int id) throws OHServiceException 
-    {	
-		boolean result = true;
-        		
-		
-		billPaymentRepository.deleteWhereId(id);
-		
-        return result;
-    }
-	
-	private boolean _insertNewBillInsideBillPayments(
-			Bill bill,
-			List<BillPayments> billPayments) throws OHServiceException
-    {	
+		// deleteBillsInsideBillPayments(bill.getId());
+		billPaymentRepository.deleteWhereId(bill.getId());
 
-		boolean result = true;
-        		
-		
-		for (BillPayments payment : billPayments) 
-		{
+		// insertNewBillInsideBillPayments(bill, payItems);
+		for (BillPayments payment : payItems) {
 			payment.setBill(bill);
 			billPaymentRepository.save(payment);
 		}
-		
-		return result;
-    }
-	
+		return true;
+	}
+
 	/**
 	 * Updates the specified {@link Bill}.
 	 * @param updateBill the bill to update.
 	 * @return <code>true</code> if the bill has been updated, <code>false</code> otherwise.
-	 * @throws OHServiceException if an error occurs during the update.
 	 */
-	public boolean updateBill(
-			Bill updateBill) throws OHServiceException 
-	{
-		boolean result = true;
-	
-
+	public boolean updateBill(Bill updateBill) {
 		Bill savedBill = billRepository.save(updateBill);
-		result = (savedBill != null);
-				
-		return result;
+		return savedBill != null;
 	}
 
 	/**
 	 * Deletes the specified {@link Bill}.
 	 * @param deleteBill the bill to delete.
 	 * @return <code>true</code> if the bill has been deleted, <code>false</code> otherwise.
-	 * @throws OHServiceException if an error occurs deleting the bill.
 	 */
-	public boolean deleteBill(
-			Bill deleteBill) throws OHServiceException 
-	{
-		boolean result = true;
-        		
-		
+	public boolean deleteBill(Bill deleteBill) {
 		billRepository.updateDeleteWhereId(deleteBill.getId());
-		
-		return result;
+		return true;
 	}
 
 	/**
@@ -300,11 +202,10 @@ public class AccountingIoOperations {
 	 * @param dateFrom the low date range endpoint, inclusive. 
 	 * @param dateTo the high date range endpoint, inclusive.
 	 * @return a list of retrieved {@link Bill}s.
-	 * @throws OHServiceException if an error occurs retrieving the bill list.
 	 * @deprecated use {@link #getBillsBetweenDates(GregorianCalendar, GregorianCalendar)}
 	 */
 	@Deprecated
-	public List<Bill> getBills(GregorianCalendar dateFrom, GregorianCalendar dateTo) throws OHServiceException {
+	public List<Bill> getBills(GregorianCalendar dateFrom, GregorianCalendar dateTo) {
 		return getBillsBetweenDates(dateFrom, dateTo);
 	}
 
@@ -313,24 +214,21 @@ public class AccountingIoOperations {
 	 * @param dateFrom the low date range endpoint, inclusive.
 	 * @param dateTo the high date range endpoint, inclusive.
 	 * @return a list of retrieved {@link Bill}s.
-	 * @throws OHServiceException if an error occurs retrieving the bill list.
 	 */
-	public List<Bill> getBillsBetweenDates(GregorianCalendar dateFrom, GregorianCalendar dateTo) throws OHServiceException {
-		return new ArrayList<>(billRepository.findByDateBetween(TimeTools.getBeginningOfDay(dateFrom), TimeTools.getBeginningOfNextDay(dateTo)));
+	public List<Bill> getBillsBetweenDates(GregorianCalendar dateFrom, GregorianCalendar dateTo) {
+		return billRepository.findByDateBetween(TimeTools.getBeginningOfDay(dateFrom), TimeTools.getBeginningOfNextDay(dateTo));
 	}
 
 	/**
 	 * Gets all the {@link Bill}s associated to the passed {@link BillPayments}.
 	 * @param payments the {@link BillPayments} associated to the bill to retrieve.
 	 * @return a list of {@link Bill} associated to the passed {@link BillPayments}.
-	 * @throws OHServiceException if an error occurs retrieving the bill list.
 	 */
-	public List<Bill> getBills(List<BillPayments> payments) throws OHServiceException {
+	public List<Bill> getBills(List<BillPayments> payments) {
 		Set<Bill> bills = new TreeSet<>((o1, o2) -> o1.getId() == o2.getId() ? 0 : -1);
 		for (BillPayments bp : payments) {
 			bills.add(bp.getBill());
 		}
-
 		return new ArrayList<>(bills);
 	}
 
@@ -338,10 +236,9 @@ public class AccountingIoOperations {
 	 * Retrieves all the {@link BillPayments} associated to the passed {@link Bill} list.
 	 * @param bills the bill list.
 	 * @return a list of {@link BillPayments} associated to the passed bill list.
-	 * @throws OHServiceException if an error occurs retrieving the payments.
 	 */
-	public List<BillPayments> getPayments(List<Bill> bills) throws OHServiceException {
-		return new ArrayList<>(billPaymentRepository.findAllByBillIn(bills));
+	public List<BillPayments> getPayments(List<Bill> bills) {
+		return billPaymentRepository.findAllByBillIn(bills);
 	}
 	
 	/**
@@ -350,12 +247,10 @@ public class AccountingIoOperations {
 	 * @param dateTo
 	 * @param patient
 	 * @return
-	 * @throws OHServiceException
 	 * @deprecated use {@link #getPaymentsBetweenDatesWherePatient(GregorianCalendar, GregorianCalendar, Patient)}
 	 */
 	@Deprecated
-	public List<BillPayments> getPayments(GregorianCalendar dateFrom, GregorianCalendar dateTo, Patient patient)
-			throws OHServiceException {
+	public List<BillPayments> getPayments(GregorianCalendar dateFrom, GregorianCalendar dateTo, Patient patient) {
 		return getPaymentsBetweenDatesWherePatient(dateFrom, dateTo, patient);
 	}
 
@@ -365,10 +260,8 @@ public class AccountingIoOperations {
 	 * @param dateTo
 	 * @param patient
 	 * @return
-	 * @throws OHServiceException
 	 */
-	public List<BillPayments> getPaymentsBetweenDatesWherePatient(GregorianCalendar dateFrom, GregorianCalendar dateTo, Patient patient)
-			throws OHServiceException {
+	public List<BillPayments> getPaymentsBetweenDatesWherePatient(GregorianCalendar dateFrom, GregorianCalendar dateTo, Patient patient) {
 		return billPaymentRepository.findByDateAndPatient(dateFrom, dateTo, patient.getCode());
 	}
 
@@ -378,11 +271,10 @@ public class AccountingIoOperations {
 	 * @param dateTo
 	 * @param patient
 	 * @return the bill list
-	 * @throws OHServiceException
 	 * @deprecated use {@link #getBillsBetweenDatesWherePatient(GregorianCalendar, GregorianCalendar, Patient)}
 	 */
 	@Deprecated
-	public List<Bill> getBills(GregorianCalendar dateFrom, GregorianCalendar dateTo, Patient patient) throws OHServiceException {
+	public List<Bill> getBills(GregorianCalendar dateFrom, GregorianCalendar dateTo, Patient patient) {
 		return getBillsBetweenDatesWherePatient(dateFrom, dateTo, patient);
 	}
 
@@ -392,9 +284,8 @@ public class AccountingIoOperations {
 	 * @param dateTo
 	 * @param patient
 	 * @return the bill list
-	 * @throws OHServiceException
 	 */
-	public List<Bill> getBillsBetweenDatesWherePatient(GregorianCalendar dateFrom, GregorianCalendar dateTo, Patient patient) throws OHServiceException {
+	public List<Bill> getBillsBetweenDatesWherePatient(GregorianCalendar dateFrom, GregorianCalendar dateTo, Patient patient) {
 		return billRepository.findByDateAndPatient(dateFrom, dateTo, patient.getCode());
 	}
 
@@ -402,9 +293,8 @@ public class AccountingIoOperations {
 	 * 
 	 * @param patID
 	 * @return
-	 * @throws OHServiceException
 	 */
-	public List<Bill> getPendingBillsAffiliate(int patID) throws OHServiceException {
+	public List<Bill> getPendingBillsAffiliate(int patID) {
 		return billRepository.findAllPendindBillsByBillPatient(patID);
 	}
 
@@ -412,9 +302,8 @@ public class AccountingIoOperations {
 	 *
 	 * @param patID
 	 * @return
-	 * @throws OHServiceException
 	 */
-	public List<Bill> getAllPatientsBills(int patID) throws OHServiceException {
+	public List<Bill> getAllPatientsBills(int patID) {
 		return billRepository.findByBillPatientCode(patID);
 	}
 
@@ -422,9 +311,8 @@ public class AccountingIoOperations {
 	 * Return distinct BillItems
 	 * added by u2g
 	 * @return BillItems list 
-	 * @throws OHServiceException
 	 */
-	public List<BillItems> getDistictsBillItems() throws OHServiceException {
+	public List<BillItems> getDistictsBillItems() {
 		return billItemsRepository.findAllGroupByDescription();
 	}
 	
@@ -437,11 +325,9 @@ public class AccountingIoOperations {
 	 * @param dateTo
 	 * @param billItem
 	 * @return the bill list
-	 * @throws OHServiceException
-	 * @deprecated use {@link #getBillsBetweenDatesWhereBillItem(GregorianCalendar, GregorianCalendar, BillItems)}
 	 */
 	@Deprecated
-	public List<Bill> getBills(GregorianCalendar dateFrom, GregorianCalendar dateTo, BillItems billItem) throws OHServiceException {
+	public List<Bill> getBills(GregorianCalendar dateFrom, GregorianCalendar dateTo, BillItems billItem) {
 		return getBillsBetweenDatesWhereBillItem(dateFrom, dateTo, billItem);
 	}
 
@@ -452,16 +338,11 @@ public class AccountingIoOperations {
 	 * @param dateTo
 	 * @param billItem
 	 * @return the bill list
-	 * @throws OHServiceException
 	 */
-	public List<Bill> getBillsBetweenDatesWhereBillItem(GregorianCalendar dateFrom, GregorianCalendar dateTo, BillItems billItem) throws OHServiceException {
-		List<Bill> bills = null;
-		if(billItem == null) {
-			bills = (ArrayList<Bill>) billRepository.findByDateBetween(TimeTools.getBeginningOfDay(dateFrom), TimeTools.getBeginningOfNextDay(dateTo));
+	public List<Bill> getBillsBetweenDatesWhereBillItem(GregorianCalendar dateFrom, GregorianCalendar dateTo, BillItems billItem) {
+		if (billItem == null) {
+			return billRepository.findByDateBetween(TimeTools.getBeginningOfDay(dateFrom), TimeTools.getBeginningOfNextDay(dateTo));
 		}
-		else {
-			bills = (ArrayList<Bill>)billRepository.findAllWhereDatesAndBillItem(TimeTools.getBeginningOfDay(dateFrom), TimeTools.getBeginningOfNextDay(dateTo), billItem.getItemDescription());
-		}
-		return bills;
+		return billRepository.findAllWhereDatesAndBillItem(TimeTools.getBeginningOfDay(dateFrom), TimeTools.getBeginningOfNextDay(dateTo), billItem.getItemDescription());
 	}
 }

--- a/src/main/java/org/isf/accounting/service/AccountingPatientMergedEventListener.java
+++ b/src/main/java/org/isf/accounting/service/AccountingPatientMergedEventListener.java
@@ -21,15 +21,14 @@
  */
 package org.isf.accounting.service;
 
+import java.util.List;
+
 import org.isf.accounting.model.Bill;
 import org.isf.patient.model.PatientMergedEvent;
-import org.isf.utils.exception.OHServiceException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
 
 @Component
 public class AccountingPatientMergedEventListener {
@@ -38,7 +37,7 @@ public class AccountingPatientMergedEventListener {
 
 	@EventListener
 	@Transactional
-	public void handle(PatientMergedEvent patientMergedEvent) throws OHServiceException {
+	public void handle(PatientMergedEvent patientMergedEvent) {
 		List<Bill> bills = accountingIoOperations.getAllPatientsBills(patientMergedEvent.getObsoletePatient().getCode());
 		for (Bill bill : bills) {
 			bill.setBillPatient(patientMergedEvent.getMergedPatient());

--- a/src/main/java/org/isf/admission/manager/AdmissionBrowserManager.java
+++ b/src/main/java/org/isf/admission/manager/AdmissionBrowserManager.java
@@ -53,9 +53,8 @@ public class AdmissionBrowserManager {
 	 * Returns all patients with ward in which they are admitted.
 	 *
 	 * @return the patient list with associated ward or {@code null} if the operation fails.
-	 * @throws OHServiceException
 	 */
-	public List<AdmittedPatient> getAdmittedPatients() throws OHServiceException {
+	public List<AdmittedPatient> getAdmittedPatients() {
 		return new ArrayList<>(ioOperations.getAdmittedPatients());
 	}
 
@@ -64,9 +63,8 @@ public class AdmissionBrowserManager {
 	 *
 	 * @param searchTerms the search terms to use for filter the patient list, {@code null} if no filter have to be applied.
 	 * @return the filtered patient list or {@code null} if the operation fails.
-	 * @throws OHServiceException
 	 */
-	public List<AdmittedPatient> getAdmittedPatients(String searchTerms) throws OHServiceException {
+	public List<AdmittedPatient> getAdmittedPatients(String searchTerms) {
 		return new ArrayList<>(ioOperations.getAdmittedPatients(searchTerms));
 	}
 
@@ -77,10 +75,9 @@ public class AdmissionBrowserManager {
 	 * @param dischargeRange (two-dimensions array) the patient admission dates range, both {@code null} if no filter have to be applied.
 	 * @param searchTerms the search terms to use for filter the patient list, {@code null} if no filter have to be applied.
 	 * @return the filtered patient list.
-	 * @throws OHServiceException if an error occurs during database request.
 	 */
 	public List<AdmittedPatient> getAdmittedPatients(GregorianCalendar[] admissionRange, //
-			GregorianCalendar[] dischargeRange, String searchTerms) throws OHServiceException {
+			GregorianCalendar[] dischargeRange, String searchTerms) {
 		return new ArrayList<>(ioOperations.getAdmittedPatients(searchTerms, admissionRange, dischargeRange));
 	}
 
@@ -93,9 +90,8 @@ public class AdmissionBrowserManager {
 	 *
 	 * @param id the admission id.
 	 * @return the admission with the specified id, {@code null} otherwise.
-	 * @throws OHServiceException
 	 */
-	public Admission getAdmission(int id) throws OHServiceException {
+	public Admission getAdmission(int id) {
 		return ioOperations.getAdmission(id);
 	}
 
@@ -104,9 +100,8 @@ public class AdmissionBrowserManager {
 	 *
 	 * @param patient the patient target of the admission.
 	 * @return the patient admission or {@code null} if the operation fails.
-	 * @throws OHServiceException
 	 */
-	public Admission getCurrentAdmission(Patient patient) throws OHServiceException {
+	public Admission getCurrentAdmission(Patient patient) {
 		return ioOperations.getCurrentAdmission(patient);
 	}
 
@@ -115,9 +110,8 @@ public class AdmissionBrowserManager {
 	 *
 	 * @param patient the patient.
 	 * @return the admission list or {@code null} if the operation fails.
-	 * @throws OHServiceException
 	 */
-	public List<Admission> getAdmissions(Patient patient) throws OHServiceException {
+	public List<Admission> getAdmissions(Patient patient) {
 		return ioOperations.getAdmissions(patient);
 	}
 
@@ -126,9 +120,8 @@ public class AdmissionBrowserManager {
 	 *
 	 * @param wardId the ward id.
 	 * @return the next prog
-	 * @throws OHServiceException
 	 */
-	public int getNextYProg(String wardId) throws OHServiceException {
+	public int getNextYProg(String wardId) {
 		return ioOperations.getNextYProg(wardId);
 	}
 
@@ -136,9 +129,8 @@ public class AdmissionBrowserManager {
 	 * Lists the {@link AdmissionType}s.
 	 *
 	 * @return the admission types  or {@code null} if the operation fails.
-	 * @throws OHServiceException
 	 */
-	public List<AdmissionType> getAdmissionType() throws OHServiceException {
+	public List<AdmissionType> getAdmissionType() {
 		return ioOperations.getAdmissionType();
 	}
 
@@ -146,9 +138,8 @@ public class AdmissionBrowserManager {
 	 * Lists the {@link DischargeType}s.
 	 *
 	 * @return the discharge types  or {@code null} if the operation fails.
-	 * @throws OHServiceException
 	 */
-	public List<DischargeType> getDischargeType() throws OHServiceException {
+	public List<DischargeType> getDischargeType() {
 		return ioOperations.getDischargeType();
 	}
 
@@ -193,9 +184,8 @@ public class AdmissionBrowserManager {
 	 *
 	 * @param admissionId the admission id.
 	 * @return <code>true</code> if the record has been set to delete.
-	 * @throws OHServiceException
 	 */
-	public boolean setDeleted(int admissionId) throws OHServiceException {
+	public boolean setDeleted(int admissionId) {
 		return ioOperations.setDeleted(admissionId);
 	}
 
@@ -204,9 +194,8 @@ public class AdmissionBrowserManager {
 	 *
 	 * @param wardId the ward id.
 	 * @return the number of used beds.
-	 * @throws OHServiceException
 	 */
-	public int getUsedWardBed(String wardId) throws OHServiceException {
+	public int getUsedWardBed(String wardId) {
 		return ioOperations.getUsedWardBed(wardId);
 	}
 
@@ -215,9 +204,8 @@ public class AdmissionBrowserManager {
 	 *
 	 * @param id the patient id.
 	 * @return <code>true</code> if the photo has been deleted, <code>false</code> otherwise.
-	 * @throws OHServiceException
 	 */
-	public boolean deletePatientPhoto(int id) throws OHServiceException {
+	public boolean deletePatientPhoto(int id) {
 		return ioOperations.deletePatientPhoto(id);
 	}
 
@@ -226,7 +214,7 @@ public class AdmissionBrowserManager {
 	 *
 	 * @param admission
 	 * @param insert <code>true</code> or updated <code>false</code>
-	 * @throws OHDataValidationException
+	 * @throws OHServiceException
 	 */
 	protected void validateAdmission(Admission admission, boolean insert) throws OHServiceException {
 		List<OHExceptionMessage> errors = new ArrayList<>();
@@ -270,7 +258,7 @@ public class AdmissionBrowserManager {
 			}
 		}
 
-		Admission last = null;
+		Admission last;
 		if (!admList.isEmpty()) {
 			last = admList.get(admList.size() - 1);
 		} else {

--- a/src/main/java/org/isf/admission/service/AdmissionIoOperationRepositoryCustom.java
+++ b/src/main/java/org/isf/admission/service/AdmissionIoOperationRepositoryCustom.java
@@ -21,12 +21,11 @@
  */
 package org.isf.admission.service;
 
-import org.isf.admission.model.Admission;
-import org.isf.patient.model.Patient;
-
 import java.util.GregorianCalendar;
 import java.util.Optional;
 
+import org.isf.admission.model.Admission;
+import org.isf.patient.model.Patient;
 
 public interface AdmissionIoOperationRepositoryCustom {
 
@@ -45,8 +44,7 @@ public interface AdmissionIoOperationRepositoryCustom {
 		 */
 		private final Integer admissionId;
 
-		public PatientAdmission(final Integer patientId,
-								final Integer admissionId) {
+		public PatientAdmission(final Integer patientId, final Integer admissionId) {
 			this.patientId = patientId;
 			this.admissionId = admissionId;
 		}

--- a/src/main/java/org/isf/admission/service/AdmissionIoOperations.java
+++ b/src/main/java/org/isf/admission/service/AdmissionIoOperations.java
@@ -75,9 +75,8 @@ public class AdmissionIoOperations
 	/**
 	 * Returns all patients with ward in which they are admitted.
 	 * @return the patient list with associated ward.
-	 * @throws OHServiceException if an error occurs during database request.
 	 */
-	public List<AdmittedPatient> getAdmittedPatients() throws OHServiceException {
+	public List<AdmittedPatient> getAdmittedPatients() {
 		return getAdmittedPatients(null);
 	}
 
@@ -85,9 +84,8 @@ public class AdmissionIoOperations
 	 * Returns all patients with ward in which they are admitted filtering the list using the passed search term.
 	 * @param searchTerms the search terms to use for filter the patient list, {@code null} if no filter is to be applied.
 	 * @return the filtered patient list.
-	 * @throws OHServiceException if an error occurs during database request.
 	 */
-	public List<AdmittedPatient> getAdmittedPatients(String searchTerms) throws OHServiceException {
+	public List<AdmittedPatient> getAdmittedPatients(String searchTerms) {
 		return patientRepository.findByFieldsContainingWordsFromLiteral(searchTerms).stream()
 			.map(patient -> new AdmittedPatient(patient, repository.findOneWherePatientIn(patient.getCode())))
 			.collect(Collectors.toList());
@@ -99,11 +97,10 @@ public class AdmissionIoOperations
 	 * @param dischargeRange (two-dimensions array) the patient discharge dates range, both {@code null} if no filter is to be applied.
 	 * @param searchTerms the search terms to use for filter the patient list, {@code null} if no filter is to be applied.
 	 * @return the filtered patient list.
-	 * @throws OHServiceException if an error occurs during database request.
 	 */
 	public List<AdmittedPatient> getAdmittedPatients(
 			String searchTerms, GregorianCalendar[] admissionRange,
-			GregorianCalendar[] dischargeRange) throws OHServiceException {
+			GregorianCalendar[] dischargeRange) {
 		return patientRepository.findByFieldsContainingWordsFromLiteral(searchTerms).stream()
 			.map(patient -> new AdmittedPatient(patient, repository.findOneByPatientAndDateRanges(patient, admissionRange, dischargeRange).orElse(null)))
 			.filter(admittedPatient -> (isRangeSet(admissionRange) || isRangeSet(dischargeRange)) ? 
@@ -132,9 +129,8 @@ public class AdmissionIoOperations
 	 * Returns the current admission (or null if none) for the specified patient.
 	 * @param patient the patient target of the admission.
 	 * @return the patient admission.
-	 * @throws OHServiceException if an error occurs during database request.
 	 */
-	public Admission getCurrentAdmission(Patient patient) throws OHServiceException	{
+	public Admission getCurrentAdmission(Patient patient) {
 		return repository.findOneWherePatientIn(patient.getCode());
 	}
 
@@ -142,9 +138,8 @@ public class AdmissionIoOperations
 	 * Returns the admission with the selected id.
 	 * @param id the admission id.
 	 * @return the admission with the specified id, {@code null} otherwise.
-	 * @throws OHServiceException if an error occurs during database request.
 	 */
-	public Admission getAdmission(int id) throws OHServiceException {
+	public Admission getAdmission(int id) {
 		return repository.findOne(id);
 	}
 
@@ -152,9 +147,8 @@ public class AdmissionIoOperations
 	 * Returns all the admissions for the specified patient.
 	 * @param patient the patient.
 	 * @return the admission list.
-	 * @throws OHServiceException if an error occurs during database request.
 	 */
-	public List<Admission> getAdmissions(Patient patient) throws OHServiceException {
+	public List<Admission> getAdmissions(Patient patient) {
 		return repository.findAllWherePatientByOrderByDate(patient.getCode());
 	}
 	
@@ -162,31 +156,19 @@ public class AdmissionIoOperations
 	 * Inserts a new admission.
 	 * @param admission the admission to insert.
 	 * @return <code>true</code> if the admission has been successfully inserted, <code>false</code> otherwise.
-	 * @throws OHServiceException if an error occurs during the insertion.
 	 */
-	public boolean newAdmission(
-			Admission admission) throws OHServiceException 
-	{
-		boolean result = true;
-	
-
+	public boolean newAdmission(Admission admission) {
 		Admission savedAdmission = repository.save(admission);
-		result = (savedAdmission != null);
-		
-		return result;
+		return savedAdmission != null;
 	}
 
 	/**
 	 * Inserts a new {@link Admission} and the returns the generated id.
 	 * @param admission the admission to insert.
 	 * @return the generated id.
-	 * @throws OHServiceException if an error occurs during the insertion.
 	 */
-	public int newAdmissionReturnKey(
-			Admission admission) throws OHServiceException 
-	{
+	public int newAdmissionReturnKey(Admission admission) {
 		newAdmission(admission);
-		
 		return admission.getId();
 	}
 
@@ -194,35 +176,25 @@ public class AdmissionIoOperations
 	 * Updates the specified {@link Admission} object.
 	 * @param admission the admission object to update.
 	 * @return <code>true</code> if has been updated, <code>false</code> otherwise.
-	 * @throws OHServiceException if an error occurs.
 	 */
-	public boolean updateAdmission(
-			Admission admission) throws OHServiceException 
-	{
-		boolean result = true;
-	
-
+	public boolean updateAdmission(Admission admission) {
 		Admission savedAdmission = repository.save(admission);
-		result = (savedAdmission != null);
-		
-		return result;
+		return savedAdmission != null;
 	}
 
 	/**
 	 * Lists the {@link AdmissionType}s.
 	 * @return the admission types.
-	 * @throws OHServiceException 
 	 */
-	public List<AdmissionType> getAdmissionType() throws OHServiceException {
+	public List<AdmissionType> getAdmissionType() {
 		return typeRepository.findAll();
 	}
 
 	/**
 	 * Lists the {@link DischargeType}s.
 	 * @return the discharge types.
-	 * @throws OHServiceException 
 	 */
-	public List<DischargeType> getDischargeType() throws OHServiceException {
+	public List<DischargeType> getDischargeType() {
 		return dischargeRepository.findAll();
 	}
 
@@ -230,42 +202,32 @@ public class AdmissionIoOperations
 	 * Returns the next prog in the year for a certain ward.
 	 * @param wardId the ward id.
 	 * @return the next prog.
-	 * @throws OHServiceException if an error occurs retrieving the value.
 	 */
-	public int getNextYProg(
-			String wardId) throws OHServiceException 
-	{
+	public int getNextYProg(String wardId) {
 		int next = 1;
 		GregorianCalendar now = getNow();
-		GregorianCalendar first = null;
-		GregorianCalendar last = null;
-		
-		if (wardId.equalsIgnoreCase("M") && GeneralData.MATERNITYRESTARTINJUNE) 
-		{
-			if (now.get(Calendar.MONTH) < 6) 
-			{
+		GregorianCalendar first;
+		GregorianCalendar last;
+
+		if (wardId.equalsIgnoreCase("M") && GeneralData.MATERNITYRESTARTINJUNE) {
+			if (now.get(Calendar.MONTH) < 6) {
 				first = new GregorianCalendar(now.get(Calendar.YEAR) - 1, Calendar.JULY, 1);
 				last = new GregorianCalendar(now.get(Calendar.YEAR), Calendar.JULY, 1);
-			} 
-			else 
-			{
+			} else {
 				first = new GregorianCalendar(now.get(Calendar.YEAR), Calendar.JULY, 1);
 				last = new GregorianCalendar(now.get(Calendar.YEAR) + 1, Calendar.JULY, 1);
 
 			}
-		} 
-		else 
-		{
+		} else {
 			first = new GregorianCalendar(now.get(Calendar.YEAR), 0, 1);
 			last = new GregorianCalendar(now.get(Calendar.YEAR), 11, 31);
 		}
-		
+
 		List<Admission> admissions = repository.findAllWhereWardAndDates(wardId, first, last);
-		if (!admissions.isEmpty())
-		{
-			next = admissions.get(0).getYProg() + 1; 		
-		} 
-		
+		if (!admissions.isEmpty()) {
+			next = admissions.get(0).getYProg() + 1;
+		}
+
 		return next;
 	}
 
@@ -297,34 +259,21 @@ public class AdmissionIoOperations
 	 * Sets an admission record to deleted.
 	 * @param admissionId the admission id.
 	 * @return <code>true</code> if the record has been set to delete.
-	 * @throws OHServiceException if an error occurs.
 	 */
-	public boolean setDeleted(
-			int admissionId) throws OHServiceException 
-	{
-		boolean result = true;
-		
-		
-		Admission foundAdmission = repository.findOne(admissionId);  
+	public boolean setDeleted(int admissionId) {
+		Admission foundAdmission = repository.findOne(admissionId);
 		foundAdmission.setDeleted("Y");
 		Admission savedAdmission = repository.save(foundAdmission);
-		result = (savedAdmission != null);    	
-    	
-		return result;
+		return savedAdmission != null;
 	}
 
 	/**
 	 * Counts the number of used bed for the specified ward.
 	 * @param wardId the ward id.
 	 * @return the number of used beds.
-	 * @throws OHServiceException if an error occurs retrieving the bed count.
 	 */
-	public int getUsedWardBed(
-			String wardId) throws OHServiceException 
-	{
-    	List<Admission> admissionList = repository.findAllWhereWardIn(wardId);
-		
-
+	public int getUsedWardBed(String wardId) {
+		List<Admission> admissionList = repository.findAllWhereWardIn(wardId);
 		return admissionList.size();
 	}
 
@@ -332,21 +281,13 @@ public class AdmissionIoOperations
 	 * Deletes the patient photo.
 	 * @param patientId the patient id.
 	 * @return <code>true</code> if the photo has been deleted, <code>false</code> otherwise.
-	 * @throws OHServiceException if an error occurs.
 	 */
-	public boolean deletePatientPhoto(
-			int patientId) throws OHServiceException
-	{
-		boolean result = true;
-		
-		
+	public boolean deletePatientPhoto(int patientId) {
 		Patient foundPatient = patientRepository.findOne(patientId);
 		if (foundPatient.getPatientProfilePhoto() != null && foundPatient.getPatientProfilePhoto().getPhoto() != null) {
 			foundPatient.getPatientProfilePhoto().setPhoto(null);
 		}
-        Patient savedPatient = patientRepository.save(foundPatient);
-		result = (savedPatient != null);    
-		
-		return result;
+		Patient savedPatient = patientRepository.save(foundPatient);
+		return savedPatient != null;
 	}
 }

--- a/src/main/java/org/isf/admission/service/AdmissionPatientMergedEventListener.java
+++ b/src/main/java/org/isf/admission/service/AdmissionPatientMergedEventListener.java
@@ -21,14 +21,13 @@
  */
 package org.isf.admission.service;
 
+import java.util.List;
+
 import org.isf.admission.model.Admission;
 import org.isf.patient.model.PatientMergedEvent;
-import org.isf.utils.exception.OHServiceException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
-
-import java.util.List;
 
 @Component
 public class AdmissionPatientMergedEventListener {
@@ -36,7 +35,7 @@ public class AdmissionPatientMergedEventListener {
 	AdmissionIoOperations admissionIoOperations;
 
 	@EventListener
-	public void handle(PatientMergedEvent patientMergedEvent) throws OHServiceException {
+	public void handle(PatientMergedEvent patientMergedEvent) {
 		List<Admission> admissions = admissionIoOperations.getAdmissions(patientMergedEvent.getObsoletePatient());
 		for (Admission admission : admissions) {
 			admission.setPatient(patientMergedEvent.getMergedPatient());

--- a/src/test/java/org/isf/accounting/test/TestBill.java
+++ b/src/test/java/org/isf/accounting/test/TestBill.java
@@ -28,7 +28,6 @@ import java.util.GregorianCalendar;
 import org.isf.accounting.model.Bill;
 import org.isf.patient.model.Patient;
 import org.isf.priceslist.model.PriceList;
-import org.isf.utils.exception.OHException;
 
 public class TestBill {
 
@@ -43,7 +42,7 @@ public class TestBill {
 	private static Double balance = 20.20;
 	private static String user = "TestUser";
 
-	public Bill setup(PriceList priceList, Patient patient, boolean usingSet) throws OHException {
+	public Bill setup(PriceList priceList, Patient patient, boolean usingSet) {
 		Bill bill;
 
 		if (usingSet) {

--- a/src/test/java/org/isf/accounting/test/TestBillItems.java
+++ b/src/test/java/org/isf/accounting/test/TestBillItems.java
@@ -26,7 +26,6 @@ import static org.assertj.core.data.Offset.offset;
 
 import org.isf.accounting.model.Bill;
 import org.isf.accounting.model.BillItems;
-import org.isf.utils.exception.OHException;
 
 public class TestBillItems {
 
@@ -36,7 +35,7 @@ public class TestBillItems {
 	private static double itemAmount = 10.10;
 	private static int itemQuantity = 20;
 
-	public BillItems setup(Bill bill, boolean usingSet) throws OHException {
+	public BillItems setup(Bill bill, boolean usingSet) {
 		BillItems billItem;
 
 		if (usingSet) {

--- a/src/test/java/org/isf/accounting/test/TestBillPayments.java
+++ b/src/test/java/org/isf/accounting/test/TestBillPayments.java
@@ -28,7 +28,6 @@ import java.util.GregorianCalendar;
 
 import org.isf.accounting.model.Bill;
 import org.isf.accounting.model.BillPayments;
-import org.isf.utils.exception.OHException;
 
 public class TestBillPayments {
 
@@ -36,7 +35,7 @@ public class TestBillPayments {
 	private static double paymentAmount = 10.10;
 	private static String paymentUser = "TestUser";
 
-	public BillPayments setup(Bill bill, boolean usingSet) throws OHException {
+	public BillPayments setup(Bill bill, boolean usingSet) {
 		BillPayments billPayment;
 
 		if (usingSet) {

--- a/src/test/java/org/isf/accounting/test/Tests.java
+++ b/src/test/java/org/isf/accounting/test/Tests.java
@@ -667,7 +667,7 @@ public class Tests extends OHCoreTestCase {
 	}
 
 	@Test
-	public void mgrGetBillsPaymentEmpty() throws Exception {
+	public void mgrGetBillsPaymentEmpty() {
 		List<Bill> bills = billBrowserManager.getBills(new ArrayList<>());
 		assertThat(bills).isEmpty();
 	}
@@ -786,7 +786,7 @@ public class Tests extends OHCoreTestCase {
 		return bill.getId();
 	}
 
-	private void _checkBillIntoDb(int id) throws OHException {
+	private void _checkBillIntoDb(int id) {
 		Bill foundBill = accountingBillIoOperationRepository.findOne(id);
 		testBill.check(foundBill);
 		testPriceList.check(foundBill.getPriceList());
@@ -805,7 +805,7 @@ public class Tests extends OHCoreTestCase {
 		return billItem.getId();
 	}
 
-	private void _checkBillItemsIntoDb(int id) throws OHException {
+	private void _checkBillItemsIntoDb(int id) {
 		BillItems foundBillItem = accountingBillItemsIoOperationRepository.findOne(id);
 		testBillItems.check(foundBillItem);
 		testBill.check(foundBillItem.getBill());
@@ -825,7 +825,7 @@ public class Tests extends OHCoreTestCase {
 		return billPayment.getId();
 	}
 
-	private void _checkBillPaymentsIntoDb(int id) throws OHException {
+	private void _checkBillPaymentsIntoDb(int id) {
 		BillPayments foundBillPayment = accountingBillPaymentIoOperationRepository.findOne(id);
 		testBillPayments.check(foundBillPayment);
 		testBill.check(foundBillPayment.getBill());

--- a/src/test/java/org/isf/admission/test/TestAdmission.java
+++ b/src/test/java/org/isf/admission/test/TestAdmission.java
@@ -34,7 +34,6 @@ import org.isf.dlvrtype.model.DeliveryType;
 import org.isf.operation.model.Operation;
 import org.isf.patient.model.Patient;
 import org.isf.pregtreattype.model.PregnantTreatmentType;
-import org.isf.utils.exception.OHException;
 import org.isf.ward.model.Ward;
 
 public class TestAdmission {
@@ -74,7 +73,7 @@ public class TestAdmission {
 			PregnantTreatmentType pregTreatmentType,
 			DeliveryType deliveryType,
 			DeliveryResultType deliveryResult,
-			boolean usingSet) throws OHException {
+			boolean usingSet) {
 		Admission admission;
 
 		if (usingSet) {

--- a/src/test/java/org/isf/admission/test/Tests.java
+++ b/src/test/java/org/isf/admission/test/Tests.java
@@ -506,7 +506,7 @@ public class Tests extends OHCoreTestCase {
 	}
 
 	@Test
-	public void testIoLoadAdmittedPatientNotThere() throws Exception {
+	public void testIoLoadAdmittedPatientNotThere() {
 		assertThat(admissionIoOperation.loadAdmittedPatient(-1)).isNull();
 	}
 
@@ -806,7 +806,7 @@ public class Tests extends OHCoreTestCase {
 	}
 
 	@Test
-	public void testMgrLoadAdmittedPatientsNotThere() throws Exception {
+	public void testMgrLoadAdmittedPatientsNotThere() {
 		assertThat(admissionBrowserManager.loadAdmittedPatients(-1)).isNull();
 	}
 
@@ -1082,7 +1082,7 @@ public class Tests extends OHCoreTestCase {
 	}
 
 	@Test
-	public void testIoAdmissionIoOperationRepositoryCustom() throws Exception {
+	public void testIoAdmissionIoOperationRepositoryCustom() {
 		MyAdmissionIoOperationRepositoryCustom myAdmissionIoOperationRepositoryCustom = new MyAdmissionIoOperationRepositoryCustom();
 		AdmissionIoOperationRepositoryCustom.PatientAdmission patientAdmission =
 				new AdmissionIoOperationRepositoryCustom.PatientAdmission(1, 2);
@@ -1102,7 +1102,7 @@ public class Tests extends OHCoreTestCase {
 		return _setupTestAdmission(usingSet, false);
 	}
 
-	private int _setupTestAdmission(boolean usingSet, boolean maternity) throws OHException, InterruptedException {
+	private int _setupTestAdmission(boolean usingSet, boolean maternity) throws OHException {
 		Ward ward = testWard.setup(false, maternity);
 		Patient patient = testPatient.setup(false);
 		AdmissionType admissionType = testAdmissionType.setup(false);
@@ -1143,7 +1143,7 @@ public class Tests extends OHCoreTestCase {
 		return admission.getId();
 	}
 
-	private void _checkAdmissionIntoDb(int id) throws OHServiceException {
+	private void _checkAdmissionIntoDb(int id) {
 		Admission foundAdmission = admissionIoOperation.getAdmission(id);
 		testAdmission.check(foundAdmission);
 	}


### PR DESCRIPTION
The primary purpose of this PR is to remove unneeded `throws OHServiceException` clauses in the `accounting` and `admission` packages.

In the process other smaller changes where made like simplifying methods, inlining single line private methods into the single calling routine, some formatting, and other related removal of code smells.

All the Core junit tests pass after these changes.

When this PR is committed it will cause compile errors in the GUI project for which I'm going to submit another PR.