### PR TITLE
Chore: remove redundant 'new' expression in constant array creation

### DIFF
--- a/src/main/java/org/isf/utils/excel/ExcelExporter.java
+++ b/src/main/java/org/isf/utils/excel/ExcelExporter.java
@@ -119,7 +119,7 @@ public class ExcelExporter {
 	 * @throws IOException
 	 */
 	private void writeBOM(FileOutputStream fileStream) throws IOException {
-		byte[] bom = new byte[] { (byte) 0xEF, (byte) 0xBB, (byte) 0xBF };
+		byte[] bom = { (byte) 0xEF, (byte) 0xBB, (byte) 0xBF };
 		fileStream.write(bom);
 	}
 

--- a/src/main/java/org/isf/utils/file/FileTools.java
+++ b/src/main/java/org/isf/utils/file/FileTools.java
@@ -57,7 +57,7 @@ public class FileTools {
 	// HOUR:  (0[0-9]|1[0-9]|2[0-3])
 	// MIN:   ([0-5][0-9])
 
-	private static final String[][] dateTimeFormats = new String[][] {
+	private static final String[][] dateTimeFormats = {
 			{ "yyyy-MM-dd_HHmmss", "(?<![0-9])(\\d{4}-\\d{2}-\\d{2}_\\d{6})(?![0-9])" },
 			{ "yyyy-MM-dd HHmmss", "(?<![0-9])(\\d{4}-\\d{2}-\\d{2} \\d{6})(?![0-9])" },
 			{ "yyyy-MM-dd_HHmm", "(?<![0-9])(\\d{4}-\\d{2}-\\d{2}_\\d{4})(?![0-9])" },

--- a/src/test/java/org/isf/therapy/test/Tests.java
+++ b/src/test/java/org/isf/therapy/test/Tests.java
@@ -294,7 +294,7 @@ public class Tests extends OHCoreTestCase {
 		medicalsIoOperationRepository.saveAndFlush(medical);
 		patientIoOperationRepository.saveAndFlush(patient);
 
-		LocalDateTime[] dates = new LocalDateTime[] { LocalDateTime.now(), LocalDateTime.now() };
+		LocalDateTime[] dates = { LocalDateTime.now(), LocalDateTime.now() };
 		Therapy therapy = new Therapy(1, patient.getCode(), dates, medical, 10.0, "", 1, "TestNote", true, true);
 
 		ArrayList<Therapy> therapies = new ArrayList<>();
@@ -315,7 +315,7 @@ public class Tests extends OHCoreTestCase {
 		medicalsIoOperationRepository.saveAndFlush(medical);
 		patientIoOperationRepository.saveAndFlush(patient);
 
-		LocalDateTime[] dates = new LocalDateTime[] { LocalDateTime.now(), LocalDateTime.now() };
+		LocalDateTime[] dates = { LocalDateTime.now(), LocalDateTime.now() };
 		Therapy therapy = new Therapy(1, patient.getCode(), dates, medical, 1.0, "", 1, "TestNote", true, true);
 
 		ArrayList<Therapy> therapies = new ArrayList<>();
@@ -335,7 +335,7 @@ public class Tests extends OHCoreTestCase {
 
 		LocalDateTime yesterday = TimeTools.getDateToday0().minusDays(1);
 
-		LocalDateTime[] dates = new LocalDateTime[] { yesterday, yesterday };
+		LocalDateTime[] dates = { yesterday, yesterday };
 		Therapy therapy = new Therapy(1, patient.getCode(), dates, medical, 10.0, "", 1, "TestNote", true, true);
 
 		ArrayList<Therapy> therapies = new ArrayList<>();
@@ -392,7 +392,7 @@ public class Tests extends OHCoreTestCase {
 		medicalsIoOperationRepository.saveAndFlush(medical);
 		patientIoOperationRepository.saveAndFlush(patient);
 
-		LocalDateTime[] dates = new LocalDateTime[] { LocalDateTime.now(), LocalDateTime.now() };
+		LocalDateTime[] dates = { LocalDateTime.now(), LocalDateTime.now() };
 		Therapy therapy = new Therapy(1, patient.getCode(), dates, medical, 10.0, "", 1, "TestNote", true, true);
 
 		assertThat(therapy.getTherapyID()).isEqualTo(1);
@@ -402,7 +402,7 @@ public class Tests extends OHCoreTestCase {
 		assertThat(therapy.getDates()).isNotNull();
 		LocalDateTime yesterday = TimeTools.getDateToday0();
 		yesterday.minusDays(1);
-		LocalDateTime[] newDates = new LocalDateTime[] { yesterday, yesterday };
+		LocalDateTime[] newDates = { yesterday, yesterday };
 		therapy.setDates(newDates);
 		assertThat(therapy.getDates()).isEqualTo(newDates);
 
@@ -455,7 +455,7 @@ public class Tests extends OHCoreTestCase {
 		medicalsIoOperationRepository.saveAndFlush(medical);
 		patientIoOperationRepository.saveAndFlush(patient);
 
-		LocalDateTime[] dates = new LocalDateTime[] { LocalDateTime.now(), LocalDateTime.now() };
+		LocalDateTime[] dates = { LocalDateTime.now(), LocalDateTime.now() };
 		Therapy therapy = new Therapy(1, patient.getCode(), dates, medical, 10.0, "", 1, "TestNote", true, true);
 		assertThat(therapy).hasToString("10.0 of TestDescription - 1 per day");
 	}


### PR DESCRIPTION
Array initializers can omit the type because it is already specified in the left side of the assignment.