### PR TITLE
OP-751 fix date conversions in reports

### DIFF
--- a/src/main/java/org/isf/stat/manager/JasperReportsManager.java
+++ b/src/main/java/org/isf/stat/manager/JasperReportsManager.java
@@ -826,8 +826,8 @@ public class JasperReportsManager {
 		LocalDateTime fromDateQuery = TimeTools.parseDate(fromDate, null, false);
 		LocalDateTime toDateQuery = TimeTools.parseDate(toDate, null, false);
 
-		parameters.put("fromdate", fromDateQuery); // real param
-		parameters.put("todate", toDateQuery); // real param
+		parameters.put("fromdate", convertToLegacyFormatForLibWithoutJavaTimeSupport(fromDateQuery)); // real param
+		parameters.put("todate", convertToLegacyFormatForLibWithoutJavaTimeSupport(toDateQuery)); // real param
 		parameters.put("user", aUser + ""); // real param
 		return parameters;
 	}
@@ -835,11 +835,11 @@ public class JasperReportsManager {
     private HashMap<String,Object> compileGenericReportFromDateToDateParameters(String fromDate, String toDate) throws OHServiceException {
         HashMap<String, Object> parameters = getHospitalParameters();
 
-	    LocalDateTime fromDateQuery = TimeTools.parseDate(fromDate, "dd/MM/yyyy", false);
-	    LocalDateTime toDateQuery = TimeTools.parseDate(toDate, "dd/MM/yyyy", false);
+	    LocalDateTime fromDateQuery = TimeTools.parseDate(fromDate, "dd/MM/yy", true);
+	    LocalDateTime toDateQuery = TimeTools.parseDate(toDate, "dd/MM/yy", true);
 
-        parameters.put("fromdate", fromDateQuery); // real param
-        parameters.put("todate", toDateQuery); // real param
+        parameters.put("fromdate", convertToLegacyFormatForLibWithoutJavaTimeSupport(fromDateQuery)); // real param
+        parameters.put("todate", convertToLegacyFormatForLibWithoutJavaTimeSupport(toDateQuery)); // real param
         return parameters;
     }
 

--- a/src/main/java/org/isf/stat/manager/JasperReportsManager.java
+++ b/src/main/java/org/isf/stat/manager/JasperReportsManager.java
@@ -835,8 +835,8 @@ public class JasperReportsManager {
     private HashMap<String,Object> compileGenericReportFromDateToDateParameters(String fromDate, String toDate) throws OHServiceException {
         HashMap<String, Object> parameters = getHospitalParameters();
 
-	    LocalDateTime fromDateQuery = TimeTools.parseDate(fromDate, "dd/MM/yy", true);
-	    LocalDateTime toDateQuery = TimeTools.parseDate(toDate, "dd/MM/yy", true);
+	    LocalDateTime fromDateQuery = TimeTools.parseDate(fromDate, "dd/MM/yyyy", true);
+	    LocalDateTime toDateQuery = TimeTools.parseDate(toDate, "dd/MM/yyyy", true);
 
         parameters.put("fromdate", convertToLegacyFormatForLibWithoutJavaTimeSupport(fromDateQuery)); // real param
         parameters.put("todate", convertToLegacyFormatForLibWithoutJavaTimeSupport(toDateQuery)); // real param

--- a/src/main/java/org/isf/utils/time/TimeTools.java
+++ b/src/main/java/org/isf/utils/time/TimeTools.java
@@ -209,12 +209,13 @@ public class TimeTools {
 	 *
 	 * @param string - a String object to be passed
 	 * @param pattern - the pattern. If <code>null</code> "yyyy-MM-dd HH:mm:ss" will be used
-	 * @param noTime - if <code>True</code> the time will be 00:00:00, actual time otherwise.
+	 * @param noTime - if <code>true</code> the time will be 00:00:00, actual time otherwise.
 	 * @return the String representation of the LocalDateTime
 	 */
 	public static LocalDateTime parseDate(String string, String pattern, boolean noTime) {
 		if (pattern == null) {
 			pattern = YYYY_MM_DD_HH_MM_SS;
+			noTime = false;
 		}
 		DateTimeFormatter format = DateTimeFormatter.ofPattern(pattern);
 		LocalDateTime dateTime;
@@ -223,7 +224,8 @@ public class TimeTools {
 			 * regarding to https://stackoverflow.com/questions/27454025/unable-to-obtain-localdatetime-from-temporalaccessor-when-parsing-localdatetime
 			 * Java does not accept a bare Date value as DateTime
 			 */
-			dateTime = LocalDate.parse(string, format).atStartOfDay();
+			LocalDate date = LocalDate.parse(string, format);
+			dateTime = date.atTime(LocalTime.MIN);
 		} else {
 			dateTime = LocalDateTime.parse(string, format);
 		}

--- a/src/test/java/org/isf/utils/time/TestTimeTools.java
+++ b/src/test/java/org/isf/utils/time/TestTimeTools.java
@@ -118,7 +118,7 @@ public class TestTimeTools {
 	public void testParseDate() throws Exception {
 		assertThat(TimeTools.parseDate("2021-11-03 23:59:59", "yyyy-MM-dd HH:mm:ss", false))
 				.isEqualTo(LocalDateTime.of(2021, 11, 3, 23, 59, 59));
-		assertThat(TimeTools.parseDate("2021-11-03 23:59:59", "yyyy-MM-dd HH:mm:ss", true))
+		assertThat(TimeTools.parseDate("2021-11-03", "yyyy-MM-dd", true))
 				.isEqualTo(LocalDateTime.of(2021, 11, 3, 0, 0, 0));
 	}
 }


### PR DESCRIPTION
See OP-751

- add missing `convertToLegacyFormatForLibWithoutJavaTimeSupport()` method calls
- fix date patterns
- change method parameter from `false` to `true` when there was no time component