### PR TITLE
Chore Starting with Spring 5.3.0, isEmpty() was deprecated.

### DIFF
--- a/src/main/java/org/isf/medicalstockward/service/MedicalStockWardIoOperationRepositoryImpl.java
+++ b/src/main/java/org/isf/medicalstockward/service/MedicalStockWardIoOperationRepositoryImpl.java
@@ -58,7 +58,7 @@ public class MedicalStockWardIoOperationRepositoryImpl implements MedicalStockWa
 		query.select(root.<Integer>get(CODE));
 		List<Predicate> predicates = new ArrayList<>();
 
-		if (!StringUtils.isEmpty(wardId)) {
+		if (StringUtils.isNotEmpty(wardId)) {
 			predicates.add(builder.equal(root.<Ward>get(WARD).<String>get(CODE), wardId));
 		}
 		if ((dateFrom != null) && (dateTo != null)) {

--- a/src/main/java/org/isf/patient/manager/PatientBrowserManager.java
+++ b/src/main/java/org/isf/patient/manager/PatientBrowserManager.java
@@ -27,6 +27,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.commons.lang3.StringUtils;
 import org.isf.accounting.manager.BillBrowserManager;
 import org.isf.accounting.model.Bill;
 import org.isf.admission.manager.AdmissionBrowserManager;
@@ -40,7 +41,6 @@ import org.isf.utils.exception.model.OHSeverityLevel;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Component;
-import org.springframework.util.StringUtils;
 
 @Component
 public class PatientBrowserManager {
@@ -324,7 +324,7 @@ public class PatientBrowserManager {
 				mergedPatient.setAge(age2);
 				mergedPatient.setBirthDate(bdate2);
 			}
-			if (bdate2 != null && !StringUtils.isEmpty(ageType2)) {
+			if (bdate2 != null && StringUtils.isNotEmpty(ageType2)) {
 				//patient2 has AgeType
 				mergedPatient.setAge(age2);
 				mergedPatient.setAgetype(ageType2);

--- a/src/main/java/org/isf/patvac/manager/PatVacManager.java
+++ b/src/main/java/org/isf/patvac/manager/PatVacManager.java
@@ -25,6 +25,7 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.apache.commons.lang3.StringUtils;
 import org.isf.generaldata.MessageBundle;
 import org.isf.patvac.model.PatientVaccine;
 import org.isf.patvac.service.PatVacIoOperations;
@@ -34,7 +35,6 @@ import org.isf.utils.exception.model.OHExceptionMessage;
 import org.isf.utils.exception.model.OHSeverityLevel;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
-import org.springframework.util.StringUtils;
 
 /**
  * ------------------------------------------

--- a/src/main/java/org/isf/pregtreattype/manager/PregnantTreatmentTypeBrowserManager.java
+++ b/src/main/java/org/isf/pregtreattype/manager/PregnantTreatmentTypeBrowserManager.java
@@ -24,6 +24,7 @@ package org.isf.pregtreattype.manager;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.apache.commons.lang3.StringUtils;
 import org.isf.generaldata.MessageBundle;
 import org.isf.pregtreattype.model.PregnantTreatmentType;
 import org.isf.pregtreattype.service.PregnantTreatmentTypeIoOperation;
@@ -33,7 +34,6 @@ import org.isf.utils.exception.model.OHExceptionMessage;
 import org.isf.utils.exception.model.OHSeverityLevel;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
-import org.springframework.util.StringUtils;
 
 @Component
 public class PregnantTreatmentTypeBrowserManager {

--- a/src/main/java/org/isf/priceslist/manager/PriceListManager.java
+++ b/src/main/java/org/isf/priceslist/manager/PriceListManager.java
@@ -25,6 +25,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import org.apache.commons.lang3.StringUtils;
 import org.isf.generaldata.MessageBundle;
 import org.isf.priceslist.model.Price;
 import org.isf.priceslist.model.PriceList;
@@ -36,7 +37,6 @@ import org.isf.utils.exception.model.OHExceptionMessage;
 import org.isf.utils.exception.model.OHSeverityLevel;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
-import org.springframework.util.StringUtils;
 
 @Component
 public class PriceListManager {

--- a/src/main/java/org/isf/pricesothers/manager/PricesOthersManager.java
+++ b/src/main/java/org/isf/pricesothers/manager/PricesOthersManager.java
@@ -24,6 +24,7 @@ package org.isf.pricesothers.manager;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.apache.commons.lang3.StringUtils;
 import org.isf.generaldata.MessageBundle;
 import org.isf.pricesothers.model.PricesOthers;
 import org.isf.pricesothers.service.PriceOthersIoOperations;
@@ -33,7 +34,6 @@ import org.isf.utils.exception.model.OHExceptionMessage;
 import org.isf.utils.exception.model.OHSeverityLevel;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
-import org.springframework.util.StringUtils;
 
 @Component
 public class PricesOthersManager {


### PR DESCRIPTION
The easiest change is to use `isEmpty()` from `org.apache.commons.lang3` which is already included in the project and used in some of the code.

Also changed a few `!isEmpty()` to `isNotEmpty()`.