### PR TITLE
OP-319: embedded database support

### DIFF
--- a/mysql/create-sqlite-db.sh
+++ b/mysql/create-sqlite-db.sh
@@ -1,0 +1,2 @@
+mysqldump --no-tablespaces --compact --skip-extended-insert --protocol tcp -u isf -pisf123 -h localhost oh > dump_mysql.sql
+./mysql2sqlite dump_mysql.sql | sqlite3 mysqlite3.db

--- a/pom.xml
+++ b/pom.xml
@@ -515,12 +515,12 @@
 		<dependency>
 			<groupId>org.xerial</groupId>
 			<artifactId>sqlite-jdbc</artifactId>
-			<version>3.36.0.1</version>
+			<version>3.36.0.3</version>
 		</dependency>
 		<dependency>
 			<groupId>com.github.gwenn</groupId>
 			<artifactId>sqlite-dialect</artifactId>
-			<version>0.1.0</version>
+			<version>0.1.2</version>
 		</dependency>
 	</dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -512,6 +512,16 @@
 			<type>pom</type>
 			<scope>runtime</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.xerial</groupId>
+			<artifactId>sqlite-jdbc</artifactId>
+			<version>3.32.3.2</version>
+		</dependency>
+		<dependency>
+			<groupId>com.github.gwenn</groupId>
+			<artifactId>sqlite-dialect</artifactId>
+			<version>0.1.0</version>
+		</dependency>
 	</dependencies>
 
 	<repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -515,7 +515,7 @@
 		<dependency>
 			<groupId>org.xerial</groupId>
 			<artifactId>sqlite-jdbc</artifactId>
-			<version>3.32.3.2</version>
+			<version>3.36.0.1</version>
 		</dependency>
 		<dependency>
 			<groupId>com.github.gwenn</groupId>

--- a/src/main/java/org/isf/accounting/service/AccountingBillItemsIoOperationRepository.java
+++ b/src/main/java/org/isf/accounting/service/AccountingBillItemsIoOperationRepository.java
@@ -29,6 +29,7 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 @Repository
@@ -42,7 +43,7 @@ public interface AccountingBillItemsIoOperationRepository extends JpaRepository<
 	List<BillItems> findAllGroupByDescription();
 
 	@Modifying
-	@Transactional
+	@Transactional(propagation = Propagation.REQUIRES_NEW)
 	@Query(value = "delete from BillItems b where b.id = :billId")
 	void deleteWhereId(@Param("billId") Integer billId);
 

--- a/src/main/java/org/isf/disease/model/Disease.java
+++ b/src/main/java/org/isf/disease/model/Disease.java
@@ -22,6 +22,7 @@
 package org.isf.disease.model;
 
 import javax.persistence.AttributeOverride;
+import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.EntityListeners;
@@ -67,9 +68,9 @@ public class Disease extends Auditable<String> {
     private String description;
 
 	@NotNull
-	@ManyToOne
-	@NotFound(action = NotFoundAction.IGNORE)
-	@JoinColumn(name="DIS_DCL_ID_A")
+	@ManyToOne(cascade = {CascadeType.ALL})
+    @NotFound(action = NotFoundAction.IGNORE)
+    @JoinColumn(name="DIS_DCL_ID_A")
 	private DiseaseType diseaseType; 
 
 	@Version

--- a/src/main/java/org/isf/patient/model/PatientProfilePhoto.java
+++ b/src/main/java/org/isf/patient/model/PatientProfilePhoto.java
@@ -52,7 +52,7 @@ public class PatientProfilePhoto implements Serializable {
 	private Patient patient;
 
 	@Column(name="PAT_PHOTO")
-	@Lob
+	//@Lob https://github.com/xerial/sqlite-jdbc/issues/135#issuecomment-522299951
 	private byte[] photo;
 
 

--- a/src/main/resources/applicationContext.xml
+++ b/src/main/resources/applicationContext.xml
@@ -60,7 +60,7 @@
  		<!-- these are C3P0 properties -->
  		<property name="acquireIncrement" value="1" />
  		<property name="minPoolSize" value="0" />
- 		<property name="maxPoolSize" value="10" />
+ 		<property name="maxPoolSize" value="1" />
  		<property name="maxIdleTime" value="300" />
  		<property name="maxStatements" value="0" />
  		<property name="checkoutTimeout" value="5000" />

--- a/src/test/resources/database.properties
+++ b/src/test/resources/database.properties
@@ -10,7 +10,9 @@
 jdbc.url=jdbc:sqlite:mysqlite3.db
 jdbc.class=org.sqlite.JDBC
 hibernate.dialect=org.hibernate.dialect.SQLiteDialect
-hibernate.hbm2ddl.auto=none
+hibernate.hbm2ddl.auto=create
+hibernate.show_sql=true
+hibernate.connection.autocommit=true
 jdbc.username=root
 jdbc.password=root
 

--- a/src/test/resources/database.properties
+++ b/src/test/resources/database.properties
@@ -1,7 +1,15 @@
-jdbc.class=org.h2.Driver
-jdbc.url=jdbc:h2:mem:myDb;MODE=MySQL;IGNORECASE=TRUE;DB_CLOSE_DELAY=-1
+# jdbc.class=org.h2.Driver
+# jdbc.url=jdbc:h2:mem:myDb;MODE=MySQL;IGNORECASE=TRUE;DB_CLOSE_DELAY=-1
 
-hibernate.dialect=org.hibernate.dialect.H2Dialect
+# hibernate.dialect=org.hibernate.dialect.H2Dialect
+# hibernate.hbm2ddl.auto=update
+# jdbc.username=root
+# jdbc.password=root
+
+# Sqlite support:
+jdbc.url=jdbc:sqlite::memory:
+jdbc.class=org.sqlite.JDBC
+hibernate.dialect=org.hibernate.dialect.SQLiteDialect
 hibernate.hbm2ddl.auto=update
 jdbc.username=root
 jdbc.password=root

--- a/src/test/resources/database.properties
+++ b/src/test/resources/database.properties
@@ -10,7 +10,7 @@
 jdbc.url=jdbc:sqlite::memory:
 jdbc.class=org.sqlite.JDBC
 hibernate.dialect=org.hibernate.dialect.SQLiteDialect
-hibernate.hbm2ddl.auto=update
+hibernate.hbm2ddl.auto=none
 jdbc.username=root
 jdbc.password=root
 

--- a/src/test/resources/database.properties
+++ b/src/test/resources/database.properties
@@ -7,7 +7,7 @@
 # jdbc.password=root
 
 # Sqlite support:
-jdbc.url=jdbc:sqlite::memory:
+jdbc.url=jdbc:sqlite:mysqlite3.db
 jdbc.class=org.sqlite.JDBC
 hibernate.dialect=org.hibernate.dialect.SQLiteDialect
 hibernate.hbm2ddl.auto=none

--- a/src/test/resources/database.properties
+++ b/src/test/resources/database.properties
@@ -5,3 +5,11 @@ hibernate.dialect=org.hibernate.dialect.H2Dialect
 hibernate.hbm2ddl.auto=update
 jdbc.username=root
 jdbc.password=root
+
+# Uncomment the following lines to test against MySQL running locally
+# (e.g. using the Docker containter in the root folder)
+#jdbc.class=com.mysql.cj.jdbc.Driver
+#hibernate.dialect=org.hibernate.dialect.MySQLDialect
+#jdbc.url=jdbc:mysql://localhost:3306/oh
+#jdbc.username=isf
+#jdbc.password=isf123

--- a/src/test/resources/database.properties
+++ b/src/test/resources/database.properties
@@ -9,7 +9,7 @@
 # Sqlite support:
 jdbc.url=jdbc:sqlite:mysqlite3.db
 jdbc.class=org.sqlite.JDBC
-hibernate.dialect=org.hibernate.dialect.SQLiteDialect
+hibernate.dialect=org.sqlite.hibernate.dialect.SQLiteDialect
 hibernate.hbm2ddl.auto=create
 hibernate.show_sql=true
 hibernate.connection.autocommit=true


### PR DESCRIPTION
See [OP-319](https://openhospital.atlassian.net/browse/OP-319).

(best effort / very early draft PR)

it looks like using Sqlite requires a lot of effort (I'll list the details later), might consider using H2 instead, since we're using it for tests already and since it's fully java-based.

details documented here: https://openhospital.atlassian.net/browse/OP-166?focusedCommentId=12785

Tools to [port db from MySQL to Sqlite](https://stackoverflow.com/questions/3890518/convert-mysql-to-sqlite):
 - https://github.com/dumblob/mysql2sqlite
 - https://github.com/techouse/mysql-to-sqlite3

Java-based alternatives to Sqlite:
 - [hsqldb](http://hsqldb.org/) 
 - [derby](https://db.apache.org/derby/)
 - [H2](https://www.h2database.com/html/main.html) (we already use it for tests)