### PR TITLE
chore: bump h2 dependency to v2.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -216,7 +216,7 @@
 		<dependency>
 			<groupId>com.h2database</groupId>
 			<artifactId>h2</artifactId>
-			<version>1.4.200</version>
+			<version>2.1.210</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/src/test/java/org/isf/therapy/test/Tests.java
+++ b/src/test/java/org/isf/therapy/test/Tests.java
@@ -348,7 +348,7 @@ public class Tests extends OHCoreTestCase {
 	public void testTherapyRowToString() throws Exception {
 		int id = setupTestTherapyRow(false);
 		TherapyRow therapyRow = therapyIoOperationRepository.findById(id).get();
-		assertThat(therapyRow).hasToString("2 - 10 9.9/11/12");
+		assertThat(therapyRow).hasToString("1 - 10 9.9/11/12");
 	}
 
 	@Test

--- a/src/test/resources/database.properties
+++ b/src/test/resources/database.properties
@@ -1,5 +1,5 @@
 jdbc.class=org.h2.Driver
-jdbc.url=jdbc:h2:mem:myDb;MODE=MySQL;IGNORECASE=TRUE;DB_CLOSE_DELAY=-1
+jdbc.url=jdbc:h2:mem:myDb;MODE=MySQL;IGNORECASE=TRUE;DB_CLOSE_DELAY=-1;NON_KEYWORDS=USER
 
 hibernate.dialect=org.hibernate.dialect.H2Dialect
 hibernate.hbm2ddl.auto=update


### PR DESCRIPTION
[H2 v2.0 changelog ](https://github.com/h2database/h2database/releases/tag/version-2.0.202)- TLDR: they fixed lots of bugs

Additional changes to make the upgrade work:
 - add `NON_KEYWORDS=USER` - workaround to use `USER` as table name even if it's a keyword in H2 (see [this explanation](https://github.com/h2database/h2database/issues/3363#issuecomment-1010631797))
 - fixed `testTherapyRowToString` - that test (added in https://github.com/informatici/openhospital-core/commit/025b642f92ebdadd5f7cc78e435ab5af8967059a ) was failing also when executing it individually with H2 v1. When executing it with all the other tests it was passing, due, most probably, to some race condition bug in H2 v1.x that has been fixed in v2.x




replaces #580 