### PR TITLE
Chore: combine and fix recent buildbot updates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -191,7 +191,7 @@
 		<dependency>
 			<groupId>net.sf.jasperreports</groupId>
 			<artifactId>jasperreports</artifactId>
-			<version>6.18.1</version>
+			<version>6.19.0</version>
 			<exclusions>
 				<exclusion>
 					<groupId>com.lowagie</groupId>
@@ -202,12 +202,17 @@
 		<dependency>
 			<groupId>net.sf.jasperreports</groupId>
 			<artifactId>jasperreports-fonts</artifactId>
-			<version>6.18.1</version>
+			<version>6.19.0</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-lang3</artifactId>
+			<version>3.12.0</version>
 		</dependency>
 		<dependency>
 			<groupId>com.github.librepdf</groupId>
 			<artifactId>openpdf</artifactId>
-			<version>1.3.26</version>
+			<version>1.3.27</version>
 		</dependency>
 		<dependency>
 			<groupId>junit</groupId>
@@ -290,12 +295,12 @@
 		<dependency>
 			<groupId>org.apache.poi</groupId>
 			<artifactId>poi</artifactId>
-			<version>5.2.0</version>
+			<version>5.2.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.poi</groupId>
 			<artifactId>poi-ooxml</artifactId>
-			<version>5.2.0</version>
+			<version>5.2.1</version>
 		</dependency>
 		<dependency>
  			<groupId>org.slf4j</groupId>
@@ -304,7 +309,7 @@
 		</dependency>
 		<dependency>
 			<groupId>org.slf4j</groupId>
-			<artifactId>slf4j-log4j12</artifactId>
+			<artifactId>slf4j-reload4j</artifactId>
 			<version>1.7.36</version>
 		</dependency>
 		<dependency>
@@ -453,6 +458,11 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
+			<groupId>org.springframework</groupId>
+			<artifactId>spring-webmvc</artifactId>
+			<version>${spring.framework.version}</version>
+		</dependency>
+		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-starter-openfeign</artifactId>
 			<version>${spring-cloud-starter-openfeign}</version>
@@ -493,11 +503,6 @@
 			<version>11.8</version>
 		</dependency>
 		<dependency>
-			<groupId>org.springframework</groupId>
-			<artifactId>spring-webmvc</artifactId>
-			<version>${spring.framework.version}</version>
-		</dependency>
-		<dependency>
 			<groupId>javax.annotation</groupId>
 			<artifactId>javax.annotation-api</artifactId>
 			<version>1.3.2</version>
@@ -505,12 +510,12 @@
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-annotations</artifactId>
-			<version>2.13.1</version>
+			<version>2.13.2</version>
 		</dependency>
 		<dependency>
 			<groupId>com.fasterxml.jackson.module</groupId>
 			<artifactId>jackson-modules-java8</artifactId>
-			<version>2.13.1</version>
+			<version>2.13.2</version>
 			<type>pom</type>
 			<scope>runtime</scope>
 		</dependency>


### PR DESCRIPTION
Combined all the recent buildbot updates and tested them together

- Had to add `commons-lang3` dependency because jasperreports 6.19.0 removed it 
- Reorder some dependencies so the latest version of common jars where used and not excluded
- Change `slf4j-log4j12` to `slf4j-reload4j` which is the new name; see `Reload4j 1.2.18 as a replacement for log4j 1.2.17` at https://www.slf4j.org/log4shell.html

I will rebase/close the buildbot entries when this is committed.