### PR TITLE
Chore: combine and fix recent buildabot updates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,8 +19,8 @@
 		<oh.version>1.11.3</oh.version>
 		<java.version>1.8</java.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<spring.framework.version>5.3.16</spring.framework.version>
-		<spring.boot.version>2.6.4</spring.boot.version>
+		<spring.framework.version>5.3.18</spring.framework.version>
+		<spring.boot.version>2.6.6</spring.boot.version>
 		<license.maven.plugin.version>4.1</license.maven.plugin.version>
 		<spring-cloud-starter-openfeign>3.1.1</spring-cloud-starter-openfeign>
 	</properties>
@@ -29,7 +29,7 @@
 		<plugins>
 			<plugin>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.10.0</version>
+				<version>3.10.1</version>
 				<configuration>
 					<source>${java.version}</source>
 					<target>${java.version}</target>
@@ -166,7 +166,7 @@
 		<dependency>
 			<groupId>com.drewnoakes</groupId>
 			<artifactId>metadata-extractor</artifactId>
-			<version>2.16.0</version>
+			<version>2.17.0</version>
 		</dependency>
 		<dependency>
 			<groupId>com.googlecode.gstreamer-java</groupId>
@@ -223,7 +223,7 @@
 		<dependency>
 			<groupId>com.h2database</groupId>
 			<artifactId>h2</artifactId>
-			<version>2.1.210</version>
+			<version>2.1.212</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
@@ -295,12 +295,12 @@
 		<dependency>
 			<groupId>org.apache.poi</groupId>
 			<artifactId>poi</artifactId>
-			<version>5.2.1</version>
+			<version>5.2.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.poi</groupId>
 			<artifactId>poi-ooxml</artifactId>
-			<version>5.2.1</version>
+			<version>5.2.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.slf4j</groupId>
@@ -381,7 +381,7 @@
 		<dependency>
 			<groupId>org.springframework.data</groupId>
 			<artifactId>spring-data-jpa</artifactId>
-			<version>2.6.2</version>
+			<version>2.6.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
Combine and test recent dependabot suggested upgrades as a single unit. This fixes a RCE CVE in Spring too.

Found that Hibernate has an issue; see https://github.com/informatici/openhospital-core/pull/627#issuecomment-1089072632

I will update all the individual PRs once this is committed.

This PR updates H2, Spring Framework, Spring Boot, Spring Data JPA, maven compiler plugin, metadata-extractor, poi, and poi-ooxml