### PR TITLE
OP-946 Fix IllegalArgumentException in Pharmaceutical Stock

### DIFF
--- a/src/main/java/org/isf/medicalstock/service/MovementIoOperationRepositoryImpl.java
+++ b/src/main/java/org/isf/medicalstock/service/MovementIoOperationRepositoryImpl.java
@@ -146,7 +146,7 @@ public class MovementIoOperationRepositoryImpl implements MovementIoOperationRep
 			predicates.add(builder.between(root.<Lot>get(LOT).<LocalDateTime>get("preparationDate"), lotPrepFrom, lotPrepTo));
 		}
 		if ((lotDueFrom != null) && (lotDueTo != null)) {
-			predicates.add(builder.between(root.<Lot>get(LOT).<LocalDateTime>get("dueDate"), lotPrepFrom, lotPrepTo));
+			predicates.add(builder.between(root.<Lot>get(LOT).<LocalDateTime>get("dueDate"), lotDueFrom, lotDueTo));
 		}
 		if (movType != null) {
 			predicates.add(builder.equal(root.<MedicalType>get(TYPE).<String>get(CODE), movType));


### PR DESCRIPTION
See OP-946

Corrects a cut-n-paste error as the fields tested are not the ones used in the query.