### PR TITLE
 OP-939 add additional validation logic for visit

### DIFF
--- a/src/main/java/org/isf/visits/manager/VisitManager.java
+++ b/src/main/java/org/isf/visits/manager/VisitManager.java
@@ -41,6 +41,7 @@ import org.isf.utils.exception.model.OHSeverityLevel;
 import org.isf.utils.time.TimeTools;
 import org.isf.visits.model.Visit;
 import org.isf.visits.service.VisitsIoOperations;
+import org.isf.ward.model.Ward;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
 import org.springframework.stereotype.Component;
@@ -88,10 +89,24 @@ public class VisitManager {
 //							OHSeverityLevel.ERROR));
 //
 //		}
+		if (visit.getWard().getBeds() <= 0) {
+			errors.add(new OHExceptionMessage(MessageBundle.getMessage("angal.common.error.title"),
+					MessageBundle.getMessage("angal.visit.thewardhasnobedsavailable.msgg"),
+					OHSeverityLevel.ERROR));
+		}
 		if (patient == null) {
 			errors.add(new OHExceptionMessage(MessageBundle.getMessage("angal.common.error.title"),
 							MessageBundle.getMessage("angal.visit.pleasechooseapatient.msg"),
 							OHSeverityLevel.ERROR));
+		} else {
+			String sex = String.valueOf(patient.getSex());
+			Ward ward = visit.getWard();
+			if ((sex.equalsIgnoreCase("F") && !ward.isFemale())
+				|| (sex.equalsIgnoreCase("M") && !ward.isMale())) {
+				errors.add(new OHExceptionMessage(MessageBundle.getMessage("angal.common.error.title"),
+						MessageBundle.getMessage("angal.visit.thepatientssexandwarddonotagree.msg"),
+						OHSeverityLevel.ERROR));
+			}
 		}
 		if (!errors.isEmpty()) {
 			throw new OHDataValidationException(errors);

--- a/src/main/java/org/isf/visits/manager/VisitManager.java
+++ b/src/main/java/org/isf/visits/manager/VisitManager.java
@@ -89,11 +89,6 @@ public class VisitManager {
 //							OHSeverityLevel.ERROR));
 //
 //		}
-		if (visit.getWard().getBeds() <= 0) {
-			errors.add(new OHExceptionMessage(MessageBundle.getMessage("angal.common.error.title"),
-					MessageBundle.getMessage("angal.visit.thewardhasnobedsavailable.msgg"),
-					OHSeverityLevel.ERROR));
-		}
 		if (patient == null) {
 			errors.add(new OHExceptionMessage(MessageBundle.getMessage("angal.common.error.title"),
 							MessageBundle.getMessage("angal.visit.pleasechooseapatient.msg"),

--- a/src/test/java/org/isf/ward/test/TestWard.java
+++ b/src/test/java/org/isf/ward/test/TestWard.java
@@ -38,8 +38,8 @@ public class TestWard {
 	private Integer nurs = 101;
 	private Integer docs = 102;
 	private boolean isPharmacy = true;
-	private boolean isFemale = false;
-	private boolean isMale = true;
+	private boolean isFemale = true;
+	private boolean isMale = false;
 	private int visitDuration = 30;
 
 	public Ward setup(boolean usingSet) throws OHException {

--- a/src/test/java/org/isf/ward/test/Tests.java
+++ b/src/test/java/org/isf/ward/test/Tests.java
@@ -542,7 +542,7 @@ public class Tests extends OHCoreTestCase {
 	public void testWardDebug() throws Exception {
 		Ward ward = testWard.setup(true);
 		assertThat(ward.debug()).isEqualTo(
-				"Ward [code=Z, description=TestDescription, telephone=TestTelephone, fax=TestFac, email=TestEmail@gmail.com, beds=100, nurs=101, docs=102, isPharmacy=true, isMale=true, isFemale=false, lock=null, hashCode=0]");
+				"Ward [code=Z, description=TestDescription, telephone=TestTelephone, fax=TestFac, email=TestEmail@gmail.com, beds=100, nurs=101, docs=102, isPharmacy=true, isMale=false, isFemale=true, lock=null, hashCode=0]");
 	}
 
 	@Test


### PR DESCRIPTION
See OP-939

Added validation for ward with no beds and for mismatch between patient's sex and ward type.

There is a corresponding GUI PR that implements the visual changes.