### PR TITLE
OP-947 do not export the button object to Excel file (old format)

### DIFF
--- a/src/main/java/org/isf/utils/excel/ExcelExporter.java
+++ b/src/main/java/org/isf/utils/excel/ExcelExporter.java
@@ -533,9 +533,14 @@ public class ExcelExporter {
 	 *
 	 * @param jtable
 	 * @param file
+	 * @param columnCount (optional) if not specified or -1 then get the column count from the table model; if specified use that number for the column count
 	 * @throws IOException
 	 */
 	public void exportTableToExcelOLD(JTable jtable, File file) throws IOException {
+		exportTableToExcelOLD(jtable, file, -1);
+	}
+
+	public void exportTableToExcelOLD(JTable jtable, File file, int columnCount) throws IOException {
 		TableModel model = jtable.getModel();
 		FileOutputStream fileStream = new FileOutputStream(file);
 
@@ -544,7 +549,12 @@ public class ExcelExporter {
 		initStyles();
 
 		HSSFRow headers = worksheet.createRow((short) 0);
-		int colCount = model.getColumnCount();
+		int colCount;
+		if (columnCount == -1) {
+			colCount = model.getColumnCount();
+		} else {
+			colCount = columnCount;
+		}
 		for (int i = 0; i < colCount; i++) {
 			HSSFCell cell = headers.createCell((short) i);
 			HSSFRichTextString value = new HSSFRichTextString(model.getColumnName(i));


### PR DESCRIPTION
See OP-947

While working on OP-943 I realized that the OLD format needed the same column count parameter.  Originally I had deleted all the OLD methods until I noticed OP-943.   I forgot to go back and make the column change.