### PR TITLE
OP-727 remove NON_KEYWORDS from db url once all tables have prefix

### DIFF
--- a/src/test/resources/database.properties
+++ b/src/test/resources/database.properties
@@ -1,5 +1,5 @@
 jdbc.class=org.h2.Driver
-jdbc.url=jdbc:h2:mem:myDb;MODE=MySQL;IGNORECASE=TRUE;DB_CLOSE_DELAY=-1;NON_KEYWORDS=USER
+jdbc.url=jdbc:h2:mem:myDb;MODE=MySQL;IGNORECASE=TRUE;DB_CLOSE_DELAY=-1
 
 hibernate.dialect=org.hibernate.dialect.H2Dialect
 hibernate.hbm2ddl.auto=update


### PR DESCRIPTION
This can be merged after https://github.com/informatici/openhospital-core/pull/557 is merged into develop; the CI checks will fail until this is done.