### PR TITLE
OP-968 truncate DateTime values to seconds when storing in model and in service level

### DIFF
--- a/src/main/java/org/isf/accounting/model/Bill.java
+++ b/src/main/java/org/isf/accounting/model/Bill.java
@@ -134,8 +134,8 @@ public class Bill extends Auditable<String> implements Comparable<Bill> {
 			Patient billPatient, String patName, String status, Double amount, Double balance, String user) {
 		super();
 		this.id = id;
-		this.date = date;
-		this.update = update;
+		this.date = TimeTools.truncateToSeconds(date);
+		this.update = TimeTools.truncateToSeconds(update);
 		this.isList = isList;
 		this.list = list;
 		this.listName = listName;
@@ -159,13 +159,13 @@ public class Bill extends Auditable<String> implements Comparable<Bill> {
 		return date;
 	}
 	public void setDate(LocalDateTime date) {
-		this.date = date;
+		this.date = TimeTools.truncateToSeconds(date);
 	}
 	public LocalDateTime getUpdate() {
 		return update;
 	}
 	public void setUpdate(LocalDateTime update) {
-		this.update = update;
+		this.update = TimeTools.truncateToSeconds(update);
 	}
 	public boolean isList() {
 		return isList;

--- a/src/main/java/org/isf/accounting/model/BillPayments.java
+++ b/src/main/java/org/isf/accounting/model/BillPayments.java
@@ -37,6 +37,7 @@ import javax.persistence.Transient;
 import javax.validation.constraints.NotNull;
 
 import org.isf.utils.db.Auditable;
+import org.isf.utils.time.TimeTools;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 /**
@@ -91,7 +92,7 @@ public class BillPayments extends Auditable<String> implements Comparable<BillPa
 		super();
 		this.id = id;
 		this.bill = bill;
-		this.date = date;
+		this.date = TimeTools.truncateToSeconds(date);
 		this.amount = amount;
 		this.user = user;
 	}
@@ -117,7 +118,7 @@ public class BillPayments extends Auditable<String> implements Comparable<BillPa
 	}
 
 	public void setDate(LocalDateTime date) {
-		this.date = date;
+		this.date = TimeTools.truncateToSeconds(date);
 	}
 
 	public double getAmount() {

--- a/src/main/java/org/isf/accounting/service/AccountingIoOperations.java
+++ b/src/main/java/org/isf/accounting/service/AccountingIoOperations.java
@@ -210,7 +210,7 @@ public class AccountingIoOperations {
 	 */
 	@Deprecated
 	public List<Bill> getBills(LocalDateTime dateFrom, LocalDateTime dateTo) throws OHServiceException {
-		return getBillsBetweenDates(TimeTools.getBeginningOfDay(dateFrom), TimeTools.getBeginningOfNextDay(dateTo));
+		return getBillsBetweenDates(dateFrom, dateTo);
 	}
 
 	/**
@@ -260,7 +260,7 @@ public class AccountingIoOperations {
 	@Deprecated
 	public List<BillPayments> getPayments(LocalDateTime dateFrom, LocalDateTime dateTo, Patient patient)
 			throws OHServiceException {
-		return getPaymentsBetweenDatesWherePatient(TimeTools.getBeginningOfDay(dateFrom), TimeTools.getBeginningOfNextDay(dateTo), patient);
+		return getPaymentsBetweenDatesWherePatient(dateFrom, dateTo, patient);
 	}
 
 	/**
@@ -287,7 +287,7 @@ public class AccountingIoOperations {
 	 */
 	@Deprecated
 	public List<Bill> getBills(LocalDateTime dateFrom, LocalDateTime dateTo, Patient patient) throws OHServiceException {
-		return getBillsBetweenDatesWherePatient(TimeTools.getBeginningOfDay(dateFrom), TimeTools.getBeginningOfNextDay(dateTo), patient);
+		return getBillsBetweenDatesWherePatient(dateFrom, dateTo, patient);
 	}
 
 	/**
@@ -346,7 +346,7 @@ public class AccountingIoOperations {
 	 */
 	@Deprecated
 	public List<Bill> getBills(LocalDateTime dateFrom, LocalDateTime dateTo, BillItems billItem) throws OHServiceException {
-		return getBillsBetweenDatesWhereBillItem(TimeTools.getBeginningOfDay(dateFrom), TimeTools.getBeginningOfNextDay(dateTo), billItem);
+		return getBillsBetweenDatesWhereBillItem(dateFrom, dateTo, billItem);
 	}
 
 	/**

--- a/src/main/java/org/isf/accounting/service/AccountingIoOperations.java
+++ b/src/main/java/org/isf/accounting/service/AccountingIoOperations.java
@@ -210,7 +210,7 @@ public class AccountingIoOperations {
 	 */
 	@Deprecated
 	public List<Bill> getBills(LocalDateTime dateFrom, LocalDateTime dateTo) throws OHServiceException {
-		return getBillsBetweenDates(dateFrom, dateTo);
+		return getBillsBetweenDates(TimeTools.getBeginningOfDay(dateFrom), TimeTools.getBeginningOfNextDay(dateTo));
 	}
 
 	/**
@@ -260,7 +260,7 @@ public class AccountingIoOperations {
 	@Deprecated
 	public List<BillPayments> getPayments(LocalDateTime dateFrom, LocalDateTime dateTo, Patient patient)
 			throws OHServiceException {
-		return getPaymentsBetweenDatesWherePatient(dateFrom, dateTo, patient);
+		return getPaymentsBetweenDatesWherePatient(TimeTools.getBeginningOfDay(dateFrom), TimeTools.getBeginningOfNextDay(dateTo), patient);
 	}
 
 	/**
@@ -273,7 +273,7 @@ public class AccountingIoOperations {
 	 */
 	public List<BillPayments> getPaymentsBetweenDatesWherePatient(LocalDateTime dateFrom, LocalDateTime dateTo, Patient patient)
 			throws OHServiceException {
-		return billPaymentRepository.findByDateAndPatient(dateFrom, dateTo, patient.getCode());
+		return billPaymentRepository.findByDateAndPatient(TimeTools.getBeginningOfDay(dateFrom), TimeTools.getBeginningOfNextDay(dateTo), patient.getCode());
 	}
 
 	/**
@@ -287,7 +287,7 @@ public class AccountingIoOperations {
 	 */
 	@Deprecated
 	public List<Bill> getBills(LocalDateTime dateFrom, LocalDateTime dateTo, Patient patient) throws OHServiceException {
-		return getBillsBetweenDatesWherePatient(dateFrom, dateTo, patient);
+		return getBillsBetweenDatesWherePatient(TimeTools.getBeginningOfDay(dateFrom), TimeTools.getBeginningOfNextDay(dateTo), patient);
 	}
 
 	/**
@@ -299,7 +299,7 @@ public class AccountingIoOperations {
 	 * @throws OHServiceException
 	 */
 	public List<Bill> getBillsBetweenDatesWherePatient(LocalDateTime dateFrom, LocalDateTime dateTo, Patient patient) throws OHServiceException {
-		return billRepository.findByDateAndPatient(dateFrom, dateTo, patient.getCode());
+		return billRepository.findByDateAndPatient(TimeTools.getBeginningOfDay(dateFrom), TimeTools.getBeginningOfNextDay(dateTo), patient.getCode());
 	}
 
 	/**
@@ -346,7 +346,7 @@ public class AccountingIoOperations {
 	 */
 	@Deprecated
 	public List<Bill> getBills(LocalDateTime dateFrom, LocalDateTime dateTo, BillItems billItem) throws OHServiceException {
-		return getBillsBetweenDatesWhereBillItem(dateFrom, dateTo, billItem);
+		return getBillsBetweenDatesWhereBillItem(TimeTools.getBeginningOfDay(dateFrom), TimeTools.getBeginningOfNextDay(dateTo), billItem);
 	}
 
 	/**

--- a/src/main/java/org/isf/admission/model/Admission.java
+++ b/src/main/java/org/isf/admission/model/Admission.java
@@ -49,6 +49,7 @@ import org.isf.operation.model.Operation;
 import org.isf.patient.model.Patient;
 import org.isf.pregtreattype.model.PregnantTreatmentType;
 import org.isf.utils.db.Auditable;
+import org.isf.utils.time.TimeTools;
 import org.isf.ward.model.Ward;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
@@ -252,7 +253,7 @@ public class Admission extends Auditable<String> implements Comparable<Admission
 		this.ward = ward;
 		this.yProg = prog;
 		this.patient = patient;
-		this.admDate = admDate;
+		this.admDate = TimeTools.truncateToSeconds(admDate);
 		this.admissionType = admType;
 		this.fHU = fhu;
 		this.diseaseIn = diseaseIn;
@@ -261,20 +262,20 @@ public class Admission extends Auditable<String> implements Comparable<Admission
 		this.diseaseOut3 = diseaseOut3;
 		this.operation = operation;
 		this.opResult = opResult;
-		this.opDate = opDate;
-		this.disDate = disDate;
+		this.opDate = TimeTools.truncateToSeconds(opDate);
+		this.disDate = TimeTools.truncateToSeconds(disDate);
 		this.disType = disType;
 		this.note = note;
 		this.transUnit = transUnit;
-		this.visitDate = visitDate;
+		this.visitDate = TimeTools.truncateToSeconds(visitDate);
 		this.pregTreatmentType = pregTreatmentType;
-		this.deliveryDate = deliveryDate;
+		this.deliveryDate = TimeTools.truncateToSeconds(deliveryDate);
 		this.deliveryType = deliveryType;
 		this.deliveryResult = deliveryResult;
 		this.weight = weight;
-		this.ctrlDate1 = ctrlDate1;
-		this.ctrlDate2 = ctrlDate2;
-		this.abortDate = abortDate;
+		this.ctrlDate1 = TimeTools.truncateToSeconds(ctrlDate1);
+		this.ctrlDate2 = TimeTools.truncateToSeconds(ctrlDate2);
+		this.abortDate = TimeTools.truncateToSeconds(abortDate);
 		this.userID = userID;
 		this.deleted = deleted;
 	}
@@ -284,7 +285,7 @@ public class Admission extends Auditable<String> implements Comparable<Admission
 	}
 
 	public void setOpDate(LocalDateTime opDate) {
-		this.opDate = opDate;
+		this.opDate = TimeTools.truncateToSeconds(opDate);
 	}
 
 	public Float getTransUnit() {
@@ -308,7 +309,7 @@ public class Admission extends Auditable<String> implements Comparable<Admission
 	}
 
 	public void setAbortDate(LocalDateTime abortDate) {
-		this.abortDate = abortDate;
+		this.abortDate = TimeTools.truncateToSeconds(abortDate);
 	}
 
 	public LocalDateTime getAdmDate() {
@@ -316,7 +317,7 @@ public class Admission extends Auditable<String> implements Comparable<Admission
 	}
 
 	public void setAdmDate(LocalDateTime admDate) {
-		this.admDate = admDate;
+		this.admDate = TimeTools.truncateToSeconds(admDate);
 	}
 
 	public int getAdmitted() {
@@ -340,7 +341,7 @@ public class Admission extends Auditable<String> implements Comparable<Admission
 	}
 
 	public void setCtrlDate1(LocalDateTime ctrlDate1) {
-		this.ctrlDate1 = ctrlDate1;
+		this.ctrlDate1 = TimeTools.truncateToSeconds(ctrlDate1);
 	}
 
 	public LocalDateTime getCtrlDate2() {
@@ -348,7 +349,7 @@ public class Admission extends Auditable<String> implements Comparable<Admission
 	}
 
 	public void setCtrlDate2(LocalDateTime ctrlDate2) {
-		this.ctrlDate2 = ctrlDate2;
+		this.ctrlDate2 = TimeTools.truncateToSeconds(ctrlDate2);
 	}
 
 	public String getDeleted() {
@@ -364,7 +365,7 @@ public class Admission extends Auditable<String> implements Comparable<Admission
 	}
 
 	public void setDeliveryDate(LocalDateTime deliveryDate) {
-		this.deliveryDate = deliveryDate;
+		this.deliveryDate = TimeTools.truncateToSeconds(deliveryDate);
 	}
 
 	public DeliveryResultType getDeliveryResult() {
@@ -388,7 +389,7 @@ public class Admission extends Auditable<String> implements Comparable<Admission
 	}
 
 	public void setDisDate(LocalDateTime disDate) {
-		this.disDate = disDate;
+		this.disDate = TimeTools.truncateToSeconds(disDate);
 	}
 
 	public Disease getDiseaseIn() {
@@ -508,7 +509,7 @@ public class Admission extends Auditable<String> implements Comparable<Admission
 	}
 
 	public void setVisitDate(LocalDateTime visitDate) {
-		this.visitDate = visitDate;
+		this.visitDate = TimeTools.truncateToSeconds(visitDate);
 	}
 
 	public Ward getWard() {

--- a/src/main/java/org/isf/admission/service/AdmissionIoOperations.java
+++ b/src/main/java/org/isf/admission/service/AdmissionIoOperations.java
@@ -27,6 +27,7 @@ import static java.time.temporal.TemporalAdjusters.lastDayOfYear;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.Month;
+import java.time.temporal.ChronoUnit;
 import java.util.List;
 
 import org.hibernate.Hibernate;
@@ -228,15 +229,15 @@ public class AdmissionIoOperations {
 
 		if (wardId.equalsIgnoreCase("M") && GeneralData.MATERNITYRESTARTINJUNE) {
 			if (now.getMonthValue() < Month.JUNE.getValue()) {
-				first = now.minusYears(1).withMonth(Month.JULY.getValue()).withDayOfMonth(1).with(LocalTime.MIN);
-				last = now.withMonth(Month.JUNE.getValue()).withDayOfMonth(30).with(LocalTime.MAX);
+				first = now.minusYears(1).withMonth(Month.JULY.getValue()).withDayOfMonth(1).with(LocalTime.MIN).truncatedTo(ChronoUnit.SECONDS);
+				last = now.withMonth(Month.JUNE.getValue()).withDayOfMonth(30).with(LocalTime.MAX).truncatedTo(ChronoUnit.SECONDS);
 			} else {
-				first = now.withMonth(Month.JULY.getValue()).withDayOfMonth(1).with(LocalTime.MIN);
-				last = now.plusYears(1).withMonth(Month.JUNE.getValue()).withDayOfMonth(30).with(LocalTime.MAX);
+				first = now.withMonth(Month.JULY.getValue()).withDayOfMonth(1).with(LocalTime.MIN).truncatedTo(ChronoUnit.SECONDS);
+				last = now.plusYears(1).withMonth(Month.JUNE.getValue()).withDayOfMonth(30).with(LocalTime.MAX).truncatedTo(ChronoUnit.SECONDS);
 			}
 		} else {
-			first = now.with(firstDayOfYear()).with(LocalTime.MIN);
-			last = now.with(lastDayOfYear()).with(LocalTime.MAX);
+			first = now.with(firstDayOfYear()).with(LocalTime.MIN).truncatedTo(ChronoUnit.SECONDS);
+			last = now.with(lastDayOfYear()).with(LocalTime.MAX).truncatedTo(ChronoUnit.SECONDS);
 		}
 
 		List<Admission> admissions = repository.findAllWhereWardAndDates(wardId, first, last);

--- a/src/main/java/org/isf/dicom/model/FileDicom.java
+++ b/src/main/java/org/isf/dicom/model/FileDicom.java
@@ -46,6 +46,7 @@ import javax.validation.constraints.NotNull;
 
 import org.isf.dicomtype.model.DicomType;
 import org.isf.utils.db.Auditable;
+import org.isf.utils.time.TimeTools;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
@@ -221,13 +222,13 @@ public class FileDicom extends Auditable<String> {
 		this.dicomPatientSex = dicomPatientSex;
 		this.dicomPatientBirthDate = dicomPatientBirthDate;
 		this.dicomStudyId = dicomStudyId;
-		this.dicomStudyDate = dicomStudyDate;
+		this.dicomStudyDate = TimeTools.truncateToSeconds(dicomStudyDate);
 		this.dicomStudyDescription = dicomStudyDescription;
 		this.dicomSeriesUID = dicomSeriesUID;
 		this.dicomSeriesInstanceUID = dicomSeriesInstanceUID;
 		this.dicomSeriesNumber = dicomSeriesNumber;
 		this.dicomSeriesDescriptionCodeSequence = dicomSeriesDescriptionCodeSequence;
-		this.dicomSeriesDate = dicomSeriesDate;
+		this.dicomSeriesDate = TimeTools.truncateToSeconds(dicomSeriesDate);
 		this.dicomSeriesDescription = dicomSeriesDescription;
 		this.dicomInstanceUID = dicomInstanceUID;
 		this.modality = modality;
@@ -257,13 +258,13 @@ public class FileDicom extends Auditable<String> {
 		this.dicomPatientSex = dicomPatientSex;
 		this.dicomPatientBirthDate = dicomPatientBirthDate;
 		this.dicomStudyId = dicomStudyId;
-		this.dicomStudyDate = dicomStudyDate;
+		this.dicomStudyDate = TimeTools.truncateToSeconds(dicomStudyDate);
 		this.dicomStudyDescription = dicomStudyDescription;
 		this.dicomSeriesUID = dicomSeriesUID;
 		this.dicomSeriesInstanceUID = dicomSeriesInstanceUID;
 		this.dicomSeriesNumber = dicomSeriesNumber;
 		this.dicomSeriesDescriptionCodeSequence = dicomSeriesDescriptionCodeSequence;
-		this.dicomSeriesDate = dicomSeriesDate;
+		this.dicomSeriesDate = TimeTools.truncateToSeconds(dicomSeriesDate);
 		this.dicomSeriesDescription = dicomSeriesDescription;
 		this.dicomInstanceUID = dicomInstanceUID;
 		this.modality = modality;
@@ -464,7 +465,7 @@ public class FileDicom extends Auditable<String> {
 	 *            the dicomStudyDate to set
 	 */
 	public void setDicomStudyDate(LocalDateTime dicomStudyDate) {
-		this.dicomStudyDate = dicomStudyDate;
+		this.dicomStudyDate = TimeTools.truncateToSeconds(dicomStudyDate);
 	}
 
 	/**
@@ -554,7 +555,7 @@ public class FileDicom extends Auditable<String> {
 	 *            the dicomSeriesDate to set
 	 */
 	public void setDicomSeriesDate(LocalDateTime dicomSeriesDate) {
-		this.dicomSeriesDate = dicomSeriesDate;
+		this.dicomSeriesDate = TimeTools.truncateToSeconds(dicomSeriesDate);
 	}
 
 	/**

--- a/src/main/java/org/isf/examination/model/PatientExamination.java
+++ b/src/main/java/org/isf/examination/model/PatientExamination.java
@@ -38,6 +38,7 @@ import javax.persistence.Transient;
 import javax.validation.constraints.NotNull;
 
 import org.isf.patient.model.Patient;
+import org.isf.utils.time.TimeTools;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 /**
@@ -157,7 +158,7 @@ public class PatientExamination implements Serializable, Comparable<PatientExami
 			String pex_ausc,
 			String pex_note) {
 		super();
-		this.pex_date = pex_date;
+		this.pex_date = TimeTools.truncateToSeconds(pex_date);
 		this.patient = patient;
 		this.pex_height = pex_height;
 		this.pex_weight = pex_weight;
@@ -214,7 +215,7 @@ public class PatientExamination implements Serializable, Comparable<PatientExami
 	 * @param pex_date the pex_date to set
 	 */
 	public void setPex_date(LocalDateTime pex_date) {
-		this.pex_date = pex_date;
+		this.pex_date = TimeTools.truncateToSeconds(pex_date);
 	}
 
 	/**

--- a/src/main/java/org/isf/lab/model/Laboratory.java
+++ b/src/main/java/org/isf/lab/model/Laboratory.java
@@ -41,6 +41,7 @@ import javax.validation.constraints.NotNull;
 import org.isf.exa.model.Exam;
 import org.isf.patient.model.Patient;
 import org.isf.utils.db.Auditable;
+import org.isf.utils.time.TimeTools;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 /**
@@ -118,7 +119,7 @@ public class Laboratory extends Auditable<String> {
 
 	public Laboratory(Exam aExam, LocalDateTime aDate, String aResult, String aNote, Patient aPatId, String aPatName) {
 		exam = aExam;
-		labDate = aDate;
+		labDate = TimeTools.truncateToSeconds(aDate);
 		result = aResult;
 		note = aNote;
 		patient = aPatId;
@@ -128,7 +129,7 @@ public class Laboratory extends Auditable<String> {
 	public Laboratory(Integer aCode, Exam aExam, LocalDateTime aDate, String aResult, String aNote, Patient aPatId, String aPatName) {
 		code = aCode;
 		exam = aExam;
-		labDate = aDate;
+		labDate = TimeTools.truncateToSeconds(aDate);
 		result = aResult;
 		note = aNote;
 		patient = aPatId;
@@ -176,7 +177,7 @@ public class Laboratory extends Auditable<String> {
 		this.examDate = exDate;
 	}
 	public void setDate(LocalDateTime aDate) {
-		labDate = aDate;
+		labDate = TimeTools.truncateToSeconds(aDate);
 	}
 	public void setResult(String aResult) {
 		result = aResult;

--- a/src/main/java/org/isf/lab/service/LabIoOperations.java
+++ b/src/main/java/org/isf/lab/service/LabIoOperations.java
@@ -95,7 +95,9 @@ public class LabIoOperations {
 	 */
 	public List<Laboratory> getLaboratory(String exam, LocalDateTime dateFrom, LocalDateTime dateTo) throws OHServiceException {
 		return exam != null ?
-				repository.findByLabDateBetweenAndExam_DescriptionOrderByLabDateDesc(dateFrom, dateTo, exam) :
+				repository.findByLabDateBetweenAndExam_DescriptionOrderByLabDateDesc(TimeTools.truncateToSeconds(dateFrom),
+				                                                                     TimeTools.truncateToSeconds(dateTo),
+				                                                                     exam) :
 				repository.findByExamDateBetweenOrderByLabDateDesc(dateFrom.toLocalDate(), dateTo.toLocalDate());
 	}
 	
@@ -133,8 +135,11 @@ public class LabIoOperations {
 	public List<LaboratoryForPrint> getLaboratoryForPrint(String exam, LocalDateTime dateFrom, LocalDateTime dateTo) throws OHServiceException {
 		List<LaboratoryForPrint> pLaboratory = new ArrayList<>();
 		Iterable<Laboratory> laboritories = exam != null
-				? repository.findByLabDateBetweenAndExam_DescriptionContainingOrderByExam_Examtype_DescriptionDesc(dateFrom, dateTo, exam)
-				: repository.findByLabDateBetweenOrderByExam_Examtype_DescriptionDesc(dateFrom, dateTo);
+				? repository.findByLabDateBetweenAndExam_DescriptionContainingOrderByExam_Examtype_DescriptionDesc(TimeTools.truncateToSeconds(dateFrom),
+				                                                                                                   TimeTools.truncateToSeconds(dateTo),
+				                                                                                                   exam)
+				: repository.findByLabDateBetweenOrderByExam_Examtype_DescriptionDesc(TimeTools.truncateToSeconds(dateFrom),
+				                                                                      TimeTools.truncateToSeconds(dateTo));
 
 		for (Laboratory laboratory : laboritories) {
 			pLaboratory.add(new LaboratoryForPrint(

--- a/src/main/java/org/isf/malnutrition/model/Malnutrition.java
+++ b/src/main/java/org/isf/malnutrition/model/Malnutrition.java
@@ -40,6 +40,7 @@ import javax.validation.constraints.NotNull;
 import org.isf.admission.model.Admission;
 import org.isf.patient.model.Patient;
 import org.isf.utils.db.Auditable;
+import org.isf.utils.time.TimeTools;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 /**
@@ -102,8 +103,8 @@ public class Malnutrition extends Auditable<String> {
 
 	public Malnutrition(int aCode, LocalDateTime aDateSupp, LocalDateTime aDateConf, Admission anAdmission, float aHeight, float aWeight) {
 		code = aCode;
-		dateSupp = aDateSupp;
-		dateConf = aDateConf;
+		dateSupp = TimeTools.truncateToSeconds(aDateSupp);
+		dateConf = TimeTools.truncateToSeconds(aDateConf);
 		admission = anAdmission;
 		height = aHeight;
 		weight = aWeight;
@@ -111,8 +112,8 @@ public class Malnutrition extends Auditable<String> {
 
 	public Malnutrition(int aCode, LocalDateTime aDateSupp, LocalDateTime aDateConf, Admission anAdmission, Patient aPatient, float aHeight, float aWeight) {
 		code = aCode;
-		dateSupp = aDateSupp;
-		dateConf = aDateConf;
+		dateSupp = TimeTools.truncateToSeconds(aDateSupp);
+		dateConf = TimeTools.truncateToSeconds(aDateConf);
 		admission = anAdmission;
 		height = aHeight;
 		weight = aWeight;
@@ -143,11 +144,11 @@ public class Malnutrition extends Auditable<String> {
 	}
 
 	public void setDateSupp(LocalDateTime aDateSupp) {
-		dateSupp = aDateSupp;
+		dateSupp = TimeTools.truncateToSeconds(aDateSupp);
 	}
 
 	public void setDateConf(LocalDateTime aDateConf) {
-		dateConf = aDateConf;
+		dateConf = TimeTools.truncateToSeconds(aDateConf);
 	}
 	
 	public void setHeight(float aHeight) {

--- a/src/main/java/org/isf/medicalstock/model/Lot.java
+++ b/src/main/java/org/isf/medicalstock/model/Lot.java
@@ -40,6 +40,7 @@ import org.isf.generaldata.MessageBundle;
 import org.isf.medicals.model.Medical;
 import org.isf.medicalstockward.service.MedicalStockWardIoOperations;
 import org.isf.utils.db.Auditable;
+import org.isf.utils.time.TimeTools;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 /**
@@ -134,15 +135,15 @@ public class Lot extends Auditable<String> {
 
 	public Lot(String aCode, LocalDateTime aPreparationDate, LocalDateTime aDueDate) {
 		code = aCode;
-		preparationDate = aPreparationDate;
-		dueDate = aDueDate;
+		preparationDate = TimeTools.truncateToSeconds(aPreparationDate);
+		dueDate = TimeTools.truncateToSeconds(aDueDate);
 	}
 
 	public Lot(Medical aMedical, String aCode, LocalDateTime aPreparationDate, LocalDateTime aDueDate, BigDecimal aCost) {
 		medical = aMedical;
 		code = aCode;
-		preparationDate = aPreparationDate;
-		dueDate = aDueDate;
+		preparationDate = TimeTools.truncateToSeconds(aPreparationDate);
+		dueDate = TimeTools.truncateToSeconds(aDueDate);
 		cost = aCost;
 	}
 
@@ -191,7 +192,7 @@ public class Lot extends Auditable<String> {
 	}
 
 	public void setPreparationDate(LocalDateTime aPreparationDate) {
-		preparationDate = aPreparationDate;
+		preparationDate = TimeTools.truncateToSeconds(aPreparationDate);
 	}
 
 	public void setMedical(Medical aMedical) {
@@ -199,7 +200,7 @@ public class Lot extends Auditable<String> {
 	}
 
 	public void setDueDate(LocalDateTime aDueDate) {
-		dueDate = aDueDate;
+		dueDate = TimeTools.truncateToSeconds(aDueDate);
 	}
 
 	public void setCost(BigDecimal cost) {

--- a/src/main/java/org/isf/medicalstock/model/Movement.java
+++ b/src/main/java/org/isf/medicalstock/model/Movement.java
@@ -41,6 +41,7 @@ import org.isf.medicals.model.Medical;
 import org.isf.medstockmovtype.model.MovementType;
 import org.isf.supplier.model.Supplier;
 import org.isf.utils.db.Auditable;
+import org.isf.utils.time.TimeTools;
 import org.isf.ward.model.Ward;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
@@ -112,7 +113,7 @@ public class Movement extends Auditable<String> {
 		type = aType;
 		ward = aWard;
 		lot = aLot;
-		date = aDate;
+		date = TimeTools.truncateToSeconds(aDate);
 		quantity = aQuantity;
 		supplier = aSupplier;
 		refNo = aRefNo;
@@ -167,7 +168,7 @@ public class Movement extends Auditable<String> {
 	}
 
 	public void setDate(LocalDateTime date) {
-		this.date = date;
+		this.date = TimeTools.truncateToSeconds(date);
 	}
 
 	public void setSupplier(Supplier supplier) {

--- a/src/main/java/org/isf/medicalstock/service/MedicalStockIoOperations.java
+++ b/src/main/java/org/isf/medicalstock/service/MedicalStockIoOperations.java
@@ -36,6 +36,7 @@ import org.isf.medicalstockward.model.MedicalWard;
 import org.isf.medicalstockward.service.MedicalStockWardIoOperationRepository;
 import org.isf.utils.db.TranslateOHServiceException;
 import org.isf.utils.exception.OHServiceException;
+import org.isf.utils.time.TimeTools;
 import org.isf.ward.model.Ward;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -360,7 +361,8 @@ public class MedicalStockIoOperations {
 	public List<Movement> getMovements(String wardId, LocalDateTime dateFrom, LocalDateTime dateTo) throws OHServiceException {
 		List<Movement> pMovement = new ArrayList<>();
 
-		List<Integer> pMovementCode = movRepository.findMovementWhereDatesAndId(wardId, dateFrom, dateTo);
+		List<Integer> pMovementCode = movRepository.findMovementWhereDatesAndId(wardId, TimeTools.truncateToSeconds(dateFrom),
+		                                                                        TimeTools.truncateToSeconds(dateTo));
 		for (int i = 0; i < pMovementCode.size(); i++) {
 			Integer code = pMovementCode.get(i);
 			Movement movement = movRepository.findById(code).orElse(null);
@@ -397,8 +399,13 @@ public class MedicalStockIoOperations {
 			LocalDateTime lotDueTo) throws OHServiceException {
 		List<Movement> pMovement = new ArrayList<>();
 
-		List<Integer> pMovementCode = movRepository.findMovementWhereData(medicalCode, medicalType, wardId, movType, movFrom, movTo, lotPrepFrom, lotPrepTo, lotDueFrom,
-				lotDueTo);
+		List<Integer> pMovementCode = movRepository.findMovementWhereData(medicalCode, medicalType, wardId, movType,
+		                                                                  TimeTools.truncateToSeconds(movFrom),
+		                                                                  TimeTools.truncateToSeconds(movTo),
+		                                                                  TimeTools.truncateToSeconds(lotPrepFrom),
+		                                                                  TimeTools.truncateToSeconds(lotPrepTo),
+		                                                                  TimeTools.truncateToSeconds(lotDueFrom),
+		                                                                  TimeTools.truncateToSeconds(lotDueTo));
 		for (int i = 0; i < pMovementCode.size(); i++) {
 			Integer code = pMovementCode.get(i);
 			Movement movement = movRepository.findById(code).orElse(null);

--- a/src/main/java/org/isf/medicalstockward/model/MovementWard.java
+++ b/src/main/java/org/isf/medicalstockward/model/MovementWard.java
@@ -40,6 +40,7 @@ import org.isf.medicals.model.Medical;
 import org.isf.medicalstock.model.Lot;
 import org.isf.patient.model.Patient;
 import org.isf.utils.db.Auditable;
+import org.isf.utils.time.TimeTools;
 import org.isf.ward.model.Ward;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
@@ -140,7 +141,7 @@ public class MovementWard extends Auditable<String> {
 			Double quantity, String units) {
 		super();
 		this.ward = ward;
-		this.date = date;
+		this.date = TimeTools.truncateToSeconds(date);
 		this.isPatient = isPatient;
 		this.patient = patient;
 		this.age = age;
@@ -155,7 +156,7 @@ public class MovementWard extends Auditable<String> {
 			Double quantity, String units, Lot lot) {
 		super();
 		this.ward = ward;
-		this.date = date;
+		this.date = TimeTools.truncateToSeconds(date);
 		this.isPatient = isPatient;
 		this.patient = patient;
 		this.age = age;
@@ -186,7 +187,7 @@ public class MovementWard extends Auditable<String> {
 		    Double quantity, String units, Ward wardTo, Ward wardFrom, Lot lot) {
 	    super();
 	    this.ward = ward;
-	    this.date = date;
+	    this.date = TimeTools.truncateToSeconds(date);
 	    this.isPatient = isPatient;
 	    this.patient = patient;
 	    this.age = age;
@@ -291,7 +292,7 @@ public class MovementWard extends Auditable<String> {
 	}
 
 	public void setDate(LocalDateTime date) {
-		this.date = date;
+		this.date = TimeTools.truncateToSeconds(date);
 	}
 
 	public void setQuantity(Double quantity) {

--- a/src/main/java/org/isf/medicalstockward/service/MedicalStockWardIoOperations.java
+++ b/src/main/java/org/isf/medicalstockward/service/MedicalStockWardIoOperations.java
@@ -34,6 +34,7 @@ import org.isf.medicalstockward.model.MovementWard;
 import org.isf.patient.model.Patient;
 import org.isf.utils.db.TranslateOHServiceException;
 import org.isf.utils.exception.OHServiceException;
+import org.isf.utils.time.TimeTools;
 import org.isf.ward.model.Ward;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -66,7 +67,8 @@ public class MedicalStockWardIoOperations
 	public List<MovementWard> getWardMovements(String wardId, LocalDateTime dateFrom, LocalDateTime dateTo) throws OHServiceException {
 		List<MovementWard> pMovementWard = new ArrayList<>();
 
-		List<Integer> pMovementWardCode = new ArrayList<>(repository.findAllWardMovement(wardId, dateFrom, dateTo));
+		List<Integer> pMovementWardCode = new ArrayList<>(repository.findAllWardMovement(wardId, TimeTools.truncateToSeconds(dateFrom),
+		                                                                                 TimeTools.truncateToSeconds(dateTo)));
 		for (Integer code : pMovementWardCode) {
 			MovementWard movementWard = movementRepository.findById(code).orElse(null);
 			pMovementWard.add(movementWard);
@@ -83,7 +85,7 @@ public class MedicalStockWardIoOperations
 	 * @throws OHServiceException if an error occurs retrieving the movements.
 	 */
     public List<MovementWard> getWardMovementsToWard(String idwardTo, LocalDateTime dateFrom, LocalDateTime dateTo) throws OHServiceException {
-	    return movementRepository.findWardMovements(idwardTo, dateFrom, dateTo);
+	    return movementRepository.findWardMovements(idwardTo, TimeTools.truncateToSeconds(dateFrom), TimeTools.truncateToSeconds(dateTo));
     }
 
 	/**

--- a/src/main/java/org/isf/opd/model/Opd.java
+++ b/src/main/java/org/isf/opd/model/Opd.java
@@ -40,6 +40,7 @@ import javax.validation.constraints.NotNull;
 import org.isf.disease.model.Disease;
 import org.isf.patient.model.Patient;
 import org.isf.utils.db.Auditable;
+import org.isf.utils.time.TimeTools;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 /**
@@ -258,7 +259,7 @@ public class Opd extends Auditable<String> {
 		return date;
 	}
 	public void setDate(LocalDateTime date) {
-		this.date = date;
+		this.date = TimeTools.truncateToSeconds(date);
 	}
 
 	public char getSex() {
@@ -290,7 +291,7 @@ public class Opd extends Auditable<String> {
 	}
 
 	public void setNextVisitDate(LocalDateTime nextVisitDate) {
-		this.nextVisitDate = nextVisitDate;
+		this.nextVisitDate = TimeTools.truncateToSeconds(nextVisitDate);
 	}
 
 	public boolean isPersisted() {

--- a/src/main/java/org/isf/operation/model/OperationRow.java
+++ b/src/main/java/org/isf/operation/model/OperationRow.java
@@ -37,6 +37,7 @@ import javax.validation.constraints.NotNull;
 import org.isf.accounting.model.Bill;
 import org.isf.admission.model.Admission;
 import org.isf.opd.model.Opd;
+import org.isf.utils.time.TimeTools;
 
 /**
  * @author xavier
@@ -108,7 +109,7 @@ public class OperationRow {
         this.operation = operation;
         this.prescriber = prescriber;
         this.opResult = opResult;
-        this.opDate = opDate;
+        this.opDate = TimeTools.truncateToSeconds(opDate);
         this.remarks = remarks;
         this.admission = admission;
         this.opd = opd;
@@ -168,7 +169,7 @@ public class OperationRow {
     }
 
     public void setOpDate(LocalDateTime opDate) {
-        this.opDate = opDate;
+        this.opDate = TimeTools.truncateToSeconds(opDate);
     }
 
     public String getRemarks() {

--- a/src/main/java/org/isf/patvac/model/PatientVaccine.java
+++ b/src/main/java/org/isf/patvac/model/PatientVaccine.java
@@ -38,6 +38,7 @@ import javax.validation.constraints.NotNull;
 
 import org.isf.patient.model.Patient;
 import org.isf.utils.db.Auditable;
+import org.isf.utils.time.TimeTools;
 import org.isf.vaccine.model.Vaccine;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
@@ -97,7 +98,7 @@ public class PatientVaccine extends Auditable<String> {
 	public PatientVaccine(int codeIn, int progIn, LocalDateTime vacDateIn, Patient patient, Vaccine vacIn, int lockIn) {
 		this.code = codeIn;
 		this.progr = progIn;
-		this.vaccineDate = vacDateIn;
+		this.vaccineDate = TimeTools.truncateToSeconds(vacDateIn);
 		this.patient = patient;
 		this.vaccine = vacIn;
 		this.lock = lockIn;
@@ -124,7 +125,7 @@ public class PatientVaccine extends Auditable<String> {
 	}
 
 	public void setVaccineDate(LocalDateTime vaccineDate) {
-		this.vaccineDate = vaccineDate;
+		this.vaccineDate = TimeTools.truncateToSeconds(vaccineDate);
 	}
 
 	public Patient getPatient() {

--- a/src/main/java/org/isf/patvac/service/PatVacIoOperationRepositoryImpl.java
+++ b/src/main/java/org/isf/patvac/service/PatVacIoOperationRepositoryImpl.java
@@ -33,6 +33,7 @@ import javax.persistence.criteria.Predicate;
 import javax.persistence.criteria.Root;
 
 import org.isf.patvac.model.PatientVaccine;
+import org.isf.utils.time.TimeTools;
 import org.springframework.transaction.annotation.Transactional;
 
 @Transactional
@@ -53,7 +54,8 @@ public class PatVacIoOperationRepositoryImpl implements PatVacIoOperationReposit
 			int ageFrom,
 			int ageTo) {
 		return this.entityManager.
-				createQuery(getPatientVaccineQuery(vaccineTypeCode, vaccineCode, dateFrom, dateTo, sex, ageFrom, ageTo)).getResultList();
+				createQuery(getPatientVaccineQuery(vaccineTypeCode, vaccineCode, TimeTools.truncateToSeconds(dateFrom),
+				                                   TimeTools.truncateToSeconds(dateTo), sex, ageFrom, ageTo)).getResultList();
 	}	
 
 	private CriteriaQuery<PatientVaccine> getPatientVaccineQuery(
@@ -72,12 +74,12 @@ public class PatVacIoOperationRepositoryImpl implements PatVacIoOperationReposit
 		query.select(pvRoot);
 		if (dateFrom != null) {
 			predicates.add(
-					cb.greaterThanOrEqualTo(pvRoot.<LocalDateTime> get("vaccineDate"), dateFrom)
+					cb.greaterThanOrEqualTo(pvRoot.<LocalDateTime> get("vaccineDate"), TimeTools.truncateToSeconds(dateFrom))
 			);
 		}
 		if (dateTo != null) {
 			predicates.add(
-					cb.lessThanOrEqualTo(pvRoot.<LocalDateTime> get("vaccineDate"), dateTo)
+					cb.lessThanOrEqualTo(pvRoot.<LocalDateTime> get("vaccineDate"), TimeTools.truncateToSeconds(dateTo))
 			);
 		}
 		if (vaccineTypeCode != null) {

--- a/src/main/java/org/isf/patvac/service/PatVacIoOperations.java
+++ b/src/main/java/org/isf/patvac/service/PatVacIoOperations.java
@@ -22,9 +22,7 @@
 package org.isf.patvac.service;
 
 import java.time.LocalDateTime;
-import java.time.LocalTime;
 import java.time.Month;
-import java.time.temporal.ChronoUnit;
 import java.util.List;
 
 import org.isf.patvac.model.PatientVaccine;
@@ -62,8 +60,8 @@ public class PatVacIoOperations {
 	 */
 	public List<PatientVaccine> getPatientVaccine(boolean minusOneWeek) throws OHServiceException {
 		LocalDateTime now = TimeTools.getNow();
-		LocalDateTime timeTo = now.with(LocalTime.MAX).truncatedTo(ChronoUnit.SECONDS);
-		LocalDateTime timeFrom = now.with(LocalTime.MIN).truncatedTo(ChronoUnit.SECONDS);
+		LocalDateTime timeTo = TimeTools.getDateToday24();
+		LocalDateTime timeFrom = TimeTools.getDateToday0();
 
 		if (minusOneWeek) {
 			timeFrom = timeFrom.minusWeeks(1);
@@ -94,7 +92,8 @@ public class PatVacIoOperations {
 			char sex,
 			int ageFrom,
 			int ageTo) throws OHServiceException {
-		return repository.findAllByCodesAndDatesAndSexAndAges(vaccineTypeCode, vaccineCode, dateFrom, dateTo, sex, ageFrom, ageTo);
+		return repository.findAllByCodesAndDatesAndSexAndAges(vaccineTypeCode, vaccineCode, TimeTools.truncateToSeconds(dateFrom),
+		                                                      TimeTools.truncateToSeconds(dateTo), sex, ageFrom, ageTo);
 	}
 
 	public List<PatientVaccine> findForPatient(int patientCode) {

--- a/src/main/java/org/isf/sms/manager/SmsManager.java
+++ b/src/main/java/org/isf/sms/manager/SmsManager.java
@@ -33,6 +33,7 @@ import org.isf.utils.exception.OHDataValidationException;
 import org.isf.utils.exception.OHServiceException;
 import org.isf.utils.exception.model.OHExceptionMessage;
 import org.isf.utils.exception.model.OHSeverityLevel;
+import org.isf.utils.time.TimeTools;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -75,7 +76,7 @@ public class SmsManager {
 	}
 
 	public List<Sms> getAll(LocalDateTime from, LocalDateTime to) throws OHServiceException {
-		return smsOperations.getAll(from, to);
+		return smsOperations.getAll(TimeTools.truncateToSeconds(from), TimeTools.truncateToSeconds(to));
 	}
 
 	/**

--- a/src/main/java/org/isf/sms/model/Sms.java
+++ b/src/main/java/org/isf/sms/model/Sms.java
@@ -32,6 +32,8 @@ import javax.persistence.Table;
 import javax.persistence.Transient;
 import javax.validation.constraints.NotNull;
 
+import org.isf.utils.time.TimeTools;
+
 /**
  * @author Mwithi
  */
@@ -81,7 +83,7 @@ public class Sms {
 	}
 
 	public Sms(LocalDateTime smsDateSched, String smsNumber, String smsText, String smsUser) {
-		this.smsDateSched = smsDateSched;
+		this.smsDateSched = TimeTools.truncateToSeconds(smsDateSched);
 		this.smsNumber = smsNumber;
 		this.smsText = smsText;
 		this.smsUser = smsUser;
@@ -90,11 +92,11 @@ public class Sms {
 	public Sms(int smsId, LocalDateTime smsDate, LocalDateTime smsDateSched, String smsNumber, String smsText, LocalDateTime smsDateSent, String smsUser,
 			String module, String moduleID) {
 		this.smsId = smsId;
-		this.smsDate = smsDate;
-		this.smsDateSched = smsDateSched;
+		this.smsDate = TimeTools.truncateToSeconds(smsDate);
+		this.smsDateSched = TimeTools.truncateToSeconds(smsDateSched);
 		this.smsNumber = smsNumber;
 		this.smsText = smsText;
-		this.smsDateSent = smsDateSent;
+		this.smsDateSent = TimeTools.truncateToSeconds(smsDateSent);
 		this.smsUser = smsUser;
 		this.module = module;
 		this.moduleID = moduleID;
@@ -113,7 +115,7 @@ public class Sms {
 	}
 
 	public void setSmsDate(LocalDateTime smsDate) {
-		this.smsDate = smsDate;
+		this.smsDate = TimeTools.truncateToSeconds(smsDate);
 	}
 
 	public LocalDateTime getSmsDateSched() {
@@ -121,7 +123,7 @@ public class Sms {
 	}
 
 	public void setSmsDateSched(LocalDateTime smsDateSched) {
-		this.smsDateSched = smsDateSched;
+		this.smsDateSched = TimeTools.truncateToSeconds(smsDateSched);
 	}
 
 	public String getSmsNumber() {
@@ -145,7 +147,7 @@ public class Sms {
 	}
 
 	public void setSmsDateSent(LocalDateTime smsDateSent) {
-		this.smsDateSent = smsDateSent;
+		this.smsDateSent = TimeTools.truncateToSeconds(smsDateSent);
 	}
 
 	public String getSmsUser() {

--- a/src/main/java/org/isf/sms/service/SmsOperations.java
+++ b/src/main/java/org/isf/sms/service/SmsOperations.java
@@ -27,6 +27,7 @@ import java.util.List;
 import org.isf.sms.model.Sms;
 import org.isf.utils.db.TranslateOHServiceException;
 import org.isf.utils.exception.OHServiceException;
+import org.isf.utils.time.TimeTools;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -83,7 +84,7 @@ public class SmsOperations {
 	 * @throws OHServiceException 
 	 */
 	public List<Sms> getAll(LocalDateTime dateFrom, LocalDateTime dateTo) throws OHServiceException {
-		return repository.findBySmsDateSchedBetweenOrderBySmsDateSchedAsc(dateFrom, dateTo);
+		return repository.findBySmsDateSchedBetweenOrderBySmsDateSchedAsc(TimeTools.truncateToSeconds(dateFrom), TimeTools.truncateToSeconds(dateTo));
 	}
 	
 	/**
@@ -92,7 +93,8 @@ public class SmsOperations {
 	 * @throws OHServiceException 
 	 */
 	public List<Sms> getList(LocalDateTime dateFrom, LocalDateTime dateTo) throws OHServiceException {
-		return repository.findBySmsDateSchedBetweenAndSmsDateSentIsNullOrderBySmsDateSchedAsc(dateFrom, dateTo);
+		return repository.findBySmsDateSchedBetweenAndSmsDateSentIsNullOrderBySmsDateSchedAsc(TimeTools.truncateToSeconds(dateFrom),
+		                                                                                      TimeTools.truncateToSeconds(dateTo));
 	}
 	
 	/**

--- a/src/main/java/org/isf/therapy/manager/TherapyManager.java
+++ b/src/main/java/org/isf/therapy/manager/TherapyManager.java
@@ -97,8 +97,10 @@ public class TherapyManager {
 
 		List<LocalDateTime> datesArray = new ArrayList<>();
 
-		LocalDateTime stepDate = startDate;
-		datesArray.add(startDate);
+		LocalDateTime stepDate = TimeTools.truncateToSeconds(startDate);
+		datesArray.add(stepDate);
+
+		endDate = TimeTools.truncateToSeconds(endDate);
 
 		while (stepDate.isBefore(endDate)) {
 			LocalDateTime newDate = stepDate.plusDays(freqInPeriod);

--- a/src/main/java/org/isf/therapy/model/TherapyRow.java
+++ b/src/main/java/org/isf/therapy/model/TherapyRow.java
@@ -39,6 +39,7 @@ import javax.validation.constraints.NotNull;
 import org.isf.medicals.model.Medical;
 import org.isf.patient.model.Patient;
 import org.isf.utils.db.Auditable;
+import org.isf.utils.time.TimeTools;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 /**
@@ -138,8 +139,8 @@ public class TherapyRow extends Auditable<String> {
 		super();
 		this.therapyID = therapyID;
 		this.patient = patient;
-		this.startDate = startDate;
-		this.endDate = endDate;
+		this.startDate = TimeTools.truncateToSeconds(startDate);
+		this.endDate = TimeTools.truncateToSeconds(endDate);
 		this.medicalId = medical.getCode();
 		this.qty = qty;
 		this.unitID = unitID;
@@ -171,7 +172,7 @@ public class TherapyRow extends Auditable<String> {
 	}
 
 	public void setStartDate(LocalDateTime startDate) {
-		this.startDate = startDate;
+		this.startDate = TimeTools.truncateToSeconds(startDate);
 	}
 
 	public LocalDateTime getEndDate() {
@@ -179,7 +180,7 @@ public class TherapyRow extends Auditable<String> {
 	}
 
 	public void setEndDate(LocalDateTime endDate) {
-		this.endDate = endDate;
+		this.endDate = TimeTools.truncateToSeconds(endDate);
 	}
 
 	public Integer getMedical() {

--- a/src/main/java/org/isf/utils/time/RememberDates.java
+++ b/src/main/java/org/isf/utils/time/RememberDates.java
@@ -52,7 +52,7 @@ public class RememberDates {
 	}
 
 	public static void setLastOpdVisitDate(LocalDateTime visitDate) {
-		lastOpdVisitDate = visitDate;
+		lastOpdVisitDate = TimeTools.truncateToSeconds(visitDate);
 	}
 
 	//------------  laboratory exam -----------------------
@@ -61,7 +61,7 @@ public class RememberDates {
 	}
 
 	public static void setLastLabExamDate(LocalDateTime labDate) {
-		lastLabExamDate = labDate;
+		lastLabExamDate = TimeTools.truncateToSeconds(labDate);
 	}
 
 	//------------  admission date -----------------------
@@ -70,7 +70,7 @@ public class RememberDates {
 	}
 
 	public static void setLastAdmInDate(LocalDateTime inDate) {
-		lastAdmInDate = inDate;
+		lastAdmInDate = TimeTools.truncateToSeconds(inDate);
 	}
 	
 	//------------ bill date -----------------------
@@ -79,7 +79,7 @@ public class RememberDates {
 	}
 
 	public static void setLastBillDate(LocalDateTime billDate) {
-		lastBillDate = billDate;
+		lastBillDate = TimeTools.truncateToSeconds(billDate);
 	}
 	
 	//------------  patient vaccine-----------------------
@@ -87,8 +87,8 @@ public class RememberDates {
 		return lastPatientVaccineDate;
 	}
 
-	public static void setLastPatineVaccineDate(LocalDateTime labDate) {
-		lastPatientVaccineDate = labDate;
+	public static void setLastPatineVaccineDate(LocalDateTime vaccineDate) {
+		lastPatientVaccineDate = TimeTools.truncateToSeconds(vaccineDate);
 	}
 
 }

--- a/src/main/java/org/isf/utils/time/TimeTools.java
+++ b/src/main/java/org/isf/utils/time/TimeTools.java
@@ -186,6 +186,15 @@ public class TimeTools {
 	}
 
 	/**
+	 * Truncate date time to SECONDS only if value is non-null
+	 * @param dateTime
+	 * @return LocaleDateTime turncated to seconds
+	 */
+	public static LocalDateTime truncateToSeconds(LocalDateTime dateTime) {
+		return dateTime == null ? null : dateTime.truncatedTo(ChronoUnit.SECONDS);
+	}
+
+	/**
 	 * Return the current date time
 	 *
 	 * @return LocalDateTime without nanoseconds
@@ -233,7 +242,7 @@ public class TimeTools {
 			 * Java does not accept a bare Date value as DateTime
 			 */
 			LocalDate date = LocalDate.parse(string, format);
-			dateTime = date.atTime(LocalTime.MIN);
+			dateTime = date.atTime(LocalTime.MIN).truncatedTo(ChronoUnit.SECONDS);
 		} else {
 			dateTime = LocalDateTime.parse(string, format);
 		}
@@ -241,11 +250,11 @@ public class TimeTools {
 	}
 
 	public static LocalDateTime getBeginningOfDay(LocalDateTime date) {
-		return date.with(LocalTime.MIN);
+		return date.with(LocalTime.MIN).truncatedTo(ChronoUnit.SECONDS);
 	}
 
 	public static LocalDateTime getBeginningOfNextDay(LocalDateTime date) {
-		return date.plusDays(1).with(LocalTime.MIN);
+		return date.plusDays(1).with(LocalTime.MIN).truncatedTo(ChronoUnit.SECONDS);
 	}
 
 	/**

--- a/src/main/java/org/isf/visits/model/Visit.java
+++ b/src/main/java/org/isf/visits/model/Visit.java
@@ -40,6 +40,7 @@ import javax.validation.constraints.NotNull;
 import org.isf.generaldata.MessageBundle;
 import org.isf.patient.model.Patient;
 import org.isf.utils.db.Auditable;
+import org.isf.utils.time.TimeTools;
 import org.isf.ward.model.Ward;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
@@ -106,7 +107,7 @@ public class Visit extends Auditable<String> {
 	public Visit(int visitID, LocalDateTime date, Patient patient, String note, boolean sms, Ward ward, Integer duration, String service) {
 		super();
 		this.visitID = visitID;
-		this.date = date;
+		this.date = TimeTools.truncateToSeconds(date);
 		this.patient = patient;
 		this.note = note;
 		this.sms = sms;		
@@ -120,7 +121,7 @@ public class Visit extends Auditable<String> {
 	}
 
 	public void setDate(LocalDateTime date) {
-		this.date = date;
+		this.date = TimeTools.truncateToSeconds(date);
 	}
 
 	public int getVisitID() {


### PR DESCRIPTION
See OP-968

Some might consider these changes excessive and unneeded but given the many sources of where the values are coming from these changes ensure everything is consistent.

Added a new method `TimeTools.truncateToSeconds()` that does what the method name implies but also checks for null values.