### PR TITLE
OP-831 upgrade to java-mysql-connector 8.0.31

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -250,7 +250,7 @@
 		<dependency>
 			<groupId>mysql</groupId>
 			<artifactId>mysql-connector-java</artifactId>
-			<version>8.0.30</version>
+			<version>8.0.31</version>
 		</dependency>
 		<dependency>
 			<groupId>org.rxtx</groupId>


### PR DESCRIPTION
See OP-831

Tried to upgrade everything to the latest mariadb versions (connector, Hibernate dialect, etc.) but ran into problems.  This includes `org.isf.utils.db.DbSingleConn` which imports a class from the mysql jar: `import com.mysql.cj.jdbc.exceptions.CommunicationsException;`.   I think this can be removed by catching the `SQLException` and `IOException`, printing the message, and rethrowing them but I ran into issues about failing to connect to the DB.  I don't think it had to do with these changes.   

Given this class was written in 2005 I wonder if there are better alternatives for the DB connection code. :smirk: 