### PR TITLE
OP-831 use the new maven dependency format for the jar

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -248,8 +248,8 @@
 			<version>1.1.3</version>
 		</dependency>
 		<dependency>
-			<groupId>mysql</groupId>
-			<artifactId>mysql-connector-java</artifactId>
+			<groupId>com.mysql</groupId>
+			<artifactId>mysql-connector-j</artifactId>
 			<version>8.0.31</version>
 		</dependency>
 		<dependency>


### PR DESCRIPTION
See OP-831

Tried to upgrade everything to the latest mariadb versions (connector, Hibernate dialect, etc.) but ran into problems.  This includes `org.isf.utils.db.DbSingleConn` which imports a class from the mysql jar: `import com.mysql.cj.jdbc.exceptions.CommunicationsException;`.   I think this can be removed by catching the `SQLException` and `IOException`, printing the message, and rethrowing them but I ran into issues about failing to connect to the DB.  I don't think it had to do with these changes.   

Given this class was written in 2005 I wonder if there are better alternatives for the DB connection code. :smirk: 