### PR TITLE
Chore: combine recent dependabot updates into single PR for testing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,9 +19,9 @@
 		<oh.version>1.12.0-SNAPSHOT</oh.version>
 		<java.version>11</java.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<spring.framework.version>5.3.25</spring.framework.version>
+		<spring.framework.version>5.3.26</spring.framework.version>
 		<spring.boot.version>2.7.9</spring.boot.version>
-		<jasperreports.version>6.20.0</jasperreports.version>
+		<jasperreports.version>6.20.1</jasperreports.version>
 		<spring.cloud.starter.openfeign.version>3.1.6</spring.cloud.starter.openfeign.version>
 		<license.maven.plugin.version>4.1</license.maven.plugin.version>
 	</properties>
@@ -311,12 +311,12 @@
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-api</artifactId>
-			<version>2.0.6</version>
+			<version>2.0.7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-reload4j</artifactId>
-			<version>2.0.6</version>
+			<version>2.0.7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.igniterealtime.smack</groupId>
@@ -387,7 +387,7 @@
 		<dependency>
 			<groupId>org.springframework.data</groupId>
 			<artifactId>spring-data-jpa</artifactId>
-			<version>2.7.7</version>
+			<version>2.7.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
The Springframework  update fixes the following CVEs:

- [cve-2023-20860: Security Bypass With Un-Prefixed Double Wildcard Pattern](https://spring.io/security/cve-2023-20860)
- [cve-2023-20861: Spring Expression DoS Vulnerability](https://spring.io/security/cve-2023-20861)

All the tests ran successfully in the IDE and with `mvn clean test`