### PR TITLE
Chore: mismatched number of placeholders in logger call

### DIFF
--- a/src/main/java/org/isf/sms/providers/gsm/GSMGatewayService.java
+++ b/src/main/java/org/isf/sms/providers/gsm/GSMGatewayService.java
@@ -128,7 +128,7 @@ public class GSMGatewayService implements SmsSenderInterface, SerialPortEventLis
 			} catch (PortInUseException e) {
 				LOGGER.error("Port in use: {}", portId.getCurrentOwner());
 			} catch (Exception e) {
-				LOGGER.error("Failed to open port {} {}", portId.getName(), e);
+				LOGGER.error("Failed to open port {}", portId.getName(), e);
 			}
 		} else {
 			LOGGER.error("COM PORT not found ({})!!!", port);


### PR DESCRIPTION
Exception tracebacks in logger call do not use a placeholder