### PR TITLE
Chore: add 's' to "If not, see <http://www.gnu.org/licenses/>" in header

### DIFF
--- a/.license-header/license-header.txt
+++ b/.license-header/license-header.txt
@@ -16,4 +16,4 @@ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with this program. If not, see <http://www.gnu.org/licenses/>.
+along with this program. If not, see <https://www.gnu.org/licenses/>.

--- a/src/main/java/org/isf/accounting/manager/BillBrowserManager.java
+++ b/src/main/java/org/isf/accounting/manager/BillBrowserManager.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.accounting.manager;
 

--- a/src/main/java/org/isf/accounting/model/Bill.java
+++ b/src/main/java/org/isf/accounting/model/Bill.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.accounting.model;
 

--- a/src/main/java/org/isf/accounting/model/BillItems.java
+++ b/src/main/java/org/isf/accounting/model/BillItems.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.accounting.model;
 

--- a/src/main/java/org/isf/accounting/model/BillPayments.java
+++ b/src/main/java/org/isf/accounting/model/BillPayments.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.accounting.model;
 

--- a/src/main/java/org/isf/accounting/service/AccountingBillIoOperationRepository.java
+++ b/src/main/java/org/isf/accounting/service/AccountingBillIoOperationRepository.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.accounting.service;
 

--- a/src/main/java/org/isf/accounting/service/AccountingBillItemsIoOperationRepository.java
+++ b/src/main/java/org/isf/accounting/service/AccountingBillItemsIoOperationRepository.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.accounting.service;
 

--- a/src/main/java/org/isf/accounting/service/AccountingBillPaymentIoOperationRepository.java
+++ b/src/main/java/org/isf/accounting/service/AccountingBillPaymentIoOperationRepository.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.accounting.service;
 

--- a/src/main/java/org/isf/accounting/service/AccountingIoOperations.java
+++ b/src/main/java/org/isf/accounting/service/AccountingIoOperations.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.accounting.service;
 

--- a/src/main/java/org/isf/accounting/service/AccountingPatientMergedEventListener.java
+++ b/src/main/java/org/isf/accounting/service/AccountingPatientMergedEventListener.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.accounting.service;
 

--- a/src/main/java/org/isf/admission/manager/AdmissionBrowserManager.java
+++ b/src/main/java/org/isf/admission/manager/AdmissionBrowserManager.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.admission.manager;
 

--- a/src/main/java/org/isf/admission/model/Admission.java
+++ b/src/main/java/org/isf/admission/model/Admission.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.admission.model;
 

--- a/src/main/java/org/isf/admission/model/AdmittedPatient.java
+++ b/src/main/java/org/isf/admission/model/AdmittedPatient.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.admission.model;
 

--- a/src/main/java/org/isf/admission/service/AdmissionIoOperationRepository.java
+++ b/src/main/java/org/isf/admission/service/AdmissionIoOperationRepository.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.admission.service;
 

--- a/src/main/java/org/isf/admission/service/AdmissionIoOperationRepositoryCustom.java
+++ b/src/main/java/org/isf/admission/service/AdmissionIoOperationRepositoryCustom.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.admission.service;
 

--- a/src/main/java/org/isf/admission/service/AdmissionIoOperationRepositoryImpl.java
+++ b/src/main/java/org/isf/admission/service/AdmissionIoOperationRepositoryImpl.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.admission.service;
 

--- a/src/main/java/org/isf/admission/service/AdmissionIoOperations.java
+++ b/src/main/java/org/isf/admission/service/AdmissionIoOperations.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.admission.service;
 

--- a/src/main/java/org/isf/admission/service/AdmissionPatientMergedEventListener.java
+++ b/src/main/java/org/isf/admission/service/AdmissionPatientMergedEventListener.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.admission.service;
 

--- a/src/main/java/org/isf/admtype/manager/AdmissionTypeBrowserManager.java
+++ b/src/main/java/org/isf/admtype/manager/AdmissionTypeBrowserManager.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.admtype.manager;
 

--- a/src/main/java/org/isf/admtype/model/AdmissionType.java
+++ b/src/main/java/org/isf/admtype/model/AdmissionType.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.admtype.model;
 

--- a/src/main/java/org/isf/admtype/service/AdmissionTypeIoOperation.java
+++ b/src/main/java/org/isf/admtype/service/AdmissionTypeIoOperation.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.admtype.service;
 

--- a/src/main/java/org/isf/admtype/service/AdmissionTypeIoOperationRepository.java
+++ b/src/main/java/org/isf/admtype/service/AdmissionTypeIoOperationRepository.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.admtype.service;
 

--- a/src/main/java/org/isf/agetype/manager/AgeTypeBrowserManager.java
+++ b/src/main/java/org/isf/agetype/manager/AgeTypeBrowserManager.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.agetype.manager;
 

--- a/src/main/java/org/isf/agetype/model/AgeType.java
+++ b/src/main/java/org/isf/agetype/model/AgeType.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.agetype.model;
 

--- a/src/main/java/org/isf/agetype/service/AgeTypeIoOperationRepository.java
+++ b/src/main/java/org/isf/agetype/service/AgeTypeIoOperationRepository.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.agetype.service;
 

--- a/src/main/java/org/isf/agetype/service/AgeTypeIoOperations.java
+++ b/src/main/java/org/isf/agetype/service/AgeTypeIoOperations.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.agetype.service;
 

--- a/src/main/java/org/isf/anamnesis/manager/PatientHistoryManager.java
+++ b/src/main/java/org/isf/anamnesis/manager/PatientHistoryManager.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.anamnesis.manager;
 

--- a/src/main/java/org/isf/anamnesis/model/PatientHistory.java
+++ b/src/main/java/org/isf/anamnesis/model/PatientHistory.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.anamnesis.model;
 

--- a/src/main/java/org/isf/anamnesis/model/PatientPatientHistory.java
+++ b/src/main/java/org/isf/anamnesis/model/PatientPatientHistory.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.anamnesis.model;
 

--- a/src/main/java/org/isf/anamnesis/service/PatientHistoryIoOperationRepository.java
+++ b/src/main/java/org/isf/anamnesis/service/PatientHistoryIoOperationRepository.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.anamnesis.service;
 

--- a/src/main/java/org/isf/anamnesis/service/PatientHistoryIoOperations.java
+++ b/src/main/java/org/isf/anamnesis/service/PatientHistoryIoOperations.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.anamnesis.service;
 

--- a/src/main/java/org/isf/dicom/manager/AbstractDicomLoader.java
+++ b/src/main/java/org/isf/dicom/manager/AbstractDicomLoader.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.dicom.manager;
 

--- a/src/main/java/org/isf/dicom/manager/AbstractThumbnailViewGui.java
+++ b/src/main/java/org/isf/dicom/manager/AbstractThumbnailViewGui.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.dicom.manager;
 

--- a/src/main/java/org/isf/dicom/manager/DicomManagerFactory.java
+++ b/src/main/java/org/isf/dicom/manager/DicomManagerFactory.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.dicom.manager;
 

--- a/src/main/java/org/isf/dicom/manager/DicomManagerInterface.java
+++ b/src/main/java/org/isf/dicom/manager/DicomManagerInterface.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.dicom.manager;
 

--- a/src/main/java/org/isf/dicom/manager/FileSystemDicomManager.java
+++ b/src/main/java/org/isf/dicom/manager/FileSystemDicomManager.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.dicom.manager;
 

--- a/src/main/java/org/isf/dicom/manager/SourceFiles.java
+++ b/src/main/java/org/isf/dicom/manager/SourceFiles.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.dicom.manager;
 

--- a/src/main/java/org/isf/dicom/manager/SqlDicomManager.java
+++ b/src/main/java/org/isf/dicom/manager/SqlDicomManager.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.dicom.manager;
 

--- a/src/main/java/org/isf/dicom/model/DicomData.java
+++ b/src/main/java/org/isf/dicom/model/DicomData.java
@@ -17,12 +17,13 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.dicom.model;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import java.io.File;
+import java.io.FileInputStream;
+import java.sql.Blob;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -35,9 +36,9 @@ import javax.persistence.Lob;
 import javax.persistence.OneToOne;
 import javax.persistence.Table;
 import javax.sql.rowset.serial.SerialBlob;
-import java.io.File;
-import java.io.FileInputStream;
-import java.sql.Blob;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * BLOB related to a {@link FileDicom}

--- a/src/main/java/org/isf/dicom/model/FileDicom.java
+++ b/src/main/java/org/isf/dicom/model/FileDicom.java
@@ -17,14 +17,13 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.dicom.model;
 
 import java.awt.image.BufferedImage;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
-import java.io.FileInputStream;
 import java.sql.Blob;
 import java.time.LocalDateTime;
 

--- a/src/main/java/org/isf/dicom/service/DicomIoOperationRepository.java
+++ b/src/main/java/org/isf/dicom/service/DicomIoOperationRepository.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.dicom.service;
 

--- a/src/main/java/org/isf/dicom/service/DicomIoOperations.java
+++ b/src/main/java/org/isf/dicom/service/DicomIoOperations.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.dicom.service;
 

--- a/src/main/java/org/isf/dicomtype/manager/DicomTypeBrowserManager.java
+++ b/src/main/java/org/isf/dicomtype/manager/DicomTypeBrowserManager.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.dicomtype.manager;
 

--- a/src/main/java/org/isf/dicomtype/model/DicomType.java
+++ b/src/main/java/org/isf/dicomtype/model/DicomType.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.dicomtype.model;
 

--- a/src/main/java/org/isf/dicomtype/service/DicomTypeIoOperation.java
+++ b/src/main/java/org/isf/dicomtype/service/DicomTypeIoOperation.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.dicomtype.service;
 

--- a/src/main/java/org/isf/dicomtype/service/DicomTypeIoOperationRepository.java
+++ b/src/main/java/org/isf/dicomtype/service/DicomTypeIoOperationRepository.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.dicomtype.service;
 

--- a/src/main/java/org/isf/disctype/manager/DischargeTypeBrowserManager.java
+++ b/src/main/java/org/isf/disctype/manager/DischargeTypeBrowserManager.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.disctype.manager;
 

--- a/src/main/java/org/isf/disctype/model/DischargeType.java
+++ b/src/main/java/org/isf/disctype/model/DischargeType.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.disctype.model;
 

--- a/src/main/java/org/isf/disctype/service/DischargeTypeIoOperation.java
+++ b/src/main/java/org/isf/disctype/service/DischargeTypeIoOperation.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.disctype.service;
 

--- a/src/main/java/org/isf/disctype/service/DischargeTypeIoOperationRepository.java
+++ b/src/main/java/org/isf/disctype/service/DischargeTypeIoOperationRepository.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.disctype.service;
 

--- a/src/main/java/org/isf/disease/manager/DiseaseBrowserManager.java
+++ b/src/main/java/org/isf/disease/manager/DiseaseBrowserManager.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.disease.manager;
 

--- a/src/main/java/org/isf/disease/model/Disease.java
+++ b/src/main/java/org/isf/disease/model/Disease.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.disease.model;
 

--- a/src/main/java/org/isf/disease/service/DiseaseIoOperationRepository.java
+++ b/src/main/java/org/isf/disease/service/DiseaseIoOperationRepository.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.disease.service;
 

--- a/src/main/java/org/isf/disease/service/DiseaseIoOperations.java
+++ b/src/main/java/org/isf/disease/service/DiseaseIoOperations.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.disease.service;
 

--- a/src/main/java/org/isf/distype/manager/DiseaseTypeBrowserManager.java
+++ b/src/main/java/org/isf/distype/manager/DiseaseTypeBrowserManager.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.distype.manager;
 

--- a/src/main/java/org/isf/distype/model/DiseaseType.java
+++ b/src/main/java/org/isf/distype/model/DiseaseType.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.distype.model;
 

--- a/src/main/java/org/isf/distype/service/DiseaseTypeIoOperation.java
+++ b/src/main/java/org/isf/distype/service/DiseaseTypeIoOperation.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.distype.service;
 

--- a/src/main/java/org/isf/distype/service/DiseaseTypeIoOperationRepository.java
+++ b/src/main/java/org/isf/distype/service/DiseaseTypeIoOperationRepository.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.distype.service;
 

--- a/src/main/java/org/isf/dlvrrestype/manager/DeliveryResultTypeBrowserManager.java
+++ b/src/main/java/org/isf/dlvrrestype/manager/DeliveryResultTypeBrowserManager.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.dlvrrestype.manager;
 

--- a/src/main/java/org/isf/dlvrrestype/model/DeliveryResultType.java
+++ b/src/main/java/org/isf/dlvrrestype/model/DeliveryResultType.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.dlvrrestype.model;
 

--- a/src/main/java/org/isf/dlvrrestype/service/DeliveryResultIoOperationRepository.java
+++ b/src/main/java/org/isf/dlvrrestype/service/DeliveryResultIoOperationRepository.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.dlvrrestype.service;
 

--- a/src/main/java/org/isf/dlvrrestype/service/DeliveryResultTypeIoOperation.java
+++ b/src/main/java/org/isf/dlvrrestype/service/DeliveryResultTypeIoOperation.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.dlvrrestype.service;
 

--- a/src/main/java/org/isf/dlvrtype/manager/DeliveryTypeBrowserManager.java
+++ b/src/main/java/org/isf/dlvrtype/manager/DeliveryTypeBrowserManager.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.dlvrtype.manager;
 

--- a/src/main/java/org/isf/dlvrtype/model/DeliveryType.java
+++ b/src/main/java/org/isf/dlvrtype/model/DeliveryType.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.dlvrtype.model;
 

--- a/src/main/java/org/isf/dlvrtype/service/DeliveryTypeIoOperation.java
+++ b/src/main/java/org/isf/dlvrtype/service/DeliveryTypeIoOperation.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.dlvrtype.service;
 

--- a/src/main/java/org/isf/dlvrtype/service/DeliveryTypeIoOperationRepository.java
+++ b/src/main/java/org/isf/dlvrtype/service/DeliveryTypeIoOperationRepository.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.dlvrtype.service;
 

--- a/src/main/java/org/isf/exa/manager/ExamBrowsingManager.java
+++ b/src/main/java/org/isf/exa/manager/ExamBrowsingManager.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.exa.manager;
 

--- a/src/main/java/org/isf/exa/manager/ExamRowBrowsingManager.java
+++ b/src/main/java/org/isf/exa/manager/ExamRowBrowsingManager.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.exa.manager;
 

--- a/src/main/java/org/isf/exa/model/Exam.java
+++ b/src/main/java/org/isf/exa/model/Exam.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.exa.model;
 

--- a/src/main/java/org/isf/exa/model/ExamRow.java
+++ b/src/main/java/org/isf/exa/model/ExamRow.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.exa.model;
 

--- a/src/main/java/org/isf/exa/service/ExamIoOperationRepository.java
+++ b/src/main/java/org/isf/exa/service/ExamIoOperationRepository.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.exa.service;
 

--- a/src/main/java/org/isf/exa/service/ExamIoOperations.java
+++ b/src/main/java/org/isf/exa/service/ExamIoOperations.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.exa.service;
 

--- a/src/main/java/org/isf/exa/service/ExamRowIoOperationRepository.java
+++ b/src/main/java/org/isf/exa/service/ExamRowIoOperationRepository.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.exa.service;
 

--- a/src/main/java/org/isf/exa/service/ExamRowIoOperations.java
+++ b/src/main/java/org/isf/exa/service/ExamRowIoOperations.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.exa.service;
 

--- a/src/main/java/org/isf/examination/manager/ExaminationBrowserManager.java
+++ b/src/main/java/org/isf/examination/manager/ExaminationBrowserManager.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.examination.manager;
 

--- a/src/main/java/org/isf/examination/model/GenderPatientExamination.java
+++ b/src/main/java/org/isf/examination/model/GenderPatientExamination.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.examination.model;
 

--- a/src/main/java/org/isf/examination/model/PatientExamination.java
+++ b/src/main/java/org/isf/examination/model/PatientExamination.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.examination.model;
 

--- a/src/main/java/org/isf/examination/service/ExaminationIoOperationRepository.java
+++ b/src/main/java/org/isf/examination/service/ExaminationIoOperationRepository.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.examination.service;
 

--- a/src/main/java/org/isf/examination/service/ExaminationOperations.java
+++ b/src/main/java/org/isf/examination/service/ExaminationOperations.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.examination.service;
 

--- a/src/main/java/org/isf/examination/service/ExaminationPatientMergedEventListener.java
+++ b/src/main/java/org/isf/examination/service/ExaminationPatientMergedEventListener.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.examination.service;
 

--- a/src/main/java/org/isf/exatype/manager/ExamTypeBrowserManager.java
+++ b/src/main/java/org/isf/exatype/manager/ExamTypeBrowserManager.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.exatype.manager;
 

--- a/src/main/java/org/isf/exatype/model/ExamType.java
+++ b/src/main/java/org/isf/exatype/model/ExamType.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.exatype.model;
 

--- a/src/main/java/org/isf/exatype/service/ExamTypeIoOperation.java
+++ b/src/main/java/org/isf/exatype/service/ExamTypeIoOperation.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.exatype.service;
 

--- a/src/main/java/org/isf/exatype/service/ExamTypeIoOperationRepository.java
+++ b/src/main/java/org/isf/exatype/service/ExamTypeIoOperationRepository.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.exatype.service;
 

--- a/src/main/java/org/isf/generaldata/ConfigurationProperties.java
+++ b/src/main/java/org/isf/generaldata/ConfigurationProperties.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.generaldata;
 

--- a/src/main/java/org/isf/generaldata/ExaminationParameters.java
+++ b/src/main/java/org/isf/generaldata/ExaminationParameters.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.generaldata;
 

--- a/src/main/java/org/isf/generaldata/GeneralData.java
+++ b/src/main/java/org/isf/generaldata/GeneralData.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.generaldata;
 

--- a/src/main/java/org/isf/generaldata/MessageBundle.java
+++ b/src/main/java/org/isf/generaldata/MessageBundle.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.generaldata;
 

--- a/src/main/java/org/isf/generaldata/SmsParameters.java
+++ b/src/main/java/org/isf/generaldata/SmsParameters.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.generaldata;
 

--- a/src/main/java/org/isf/generaldata/TxtPrinter.java
+++ b/src/main/java/org/isf/generaldata/TxtPrinter.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.generaldata;
 

--- a/src/main/java/org/isf/generaldata/Version.java
+++ b/src/main/java/org/isf/generaldata/Version.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.generaldata;
 

--- a/src/main/java/org/isf/generaldata/XmppData.java
+++ b/src/main/java/org/isf/generaldata/XmppData.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.generaldata;
 

--- a/src/main/java/org/isf/hospital/manager/HospitalBrowsingManager.java
+++ b/src/main/java/org/isf/hospital/manager/HospitalBrowsingManager.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.hospital.manager;
 

--- a/src/main/java/org/isf/hospital/model/Hospital.java
+++ b/src/main/java/org/isf/hospital/model/Hospital.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.hospital.model;
 

--- a/src/main/java/org/isf/hospital/service/HospitalIoOperationRepository.java
+++ b/src/main/java/org/isf/hospital/service/HospitalIoOperationRepository.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.hospital.service;
 

--- a/src/main/java/org/isf/hospital/service/HospitalIoOperations.java
+++ b/src/main/java/org/isf/hospital/service/HospitalIoOperations.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.hospital.service;
 

--- a/src/main/java/org/isf/lab/manager/LabManager.java
+++ b/src/main/java/org/isf/lab/manager/LabManager.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.lab.manager;
 

--- a/src/main/java/org/isf/lab/manager/LabRowManager.java
+++ b/src/main/java/org/isf/lab/manager/LabRowManager.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.lab.manager;
 

--- a/src/main/java/org/isf/lab/model/Laboratory.java
+++ b/src/main/java/org/isf/lab/model/Laboratory.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.lab.model;
 

--- a/src/main/java/org/isf/lab/model/LaboratoryForPrint.java
+++ b/src/main/java/org/isf/lab/model/LaboratoryForPrint.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.lab.model;
 

--- a/src/main/java/org/isf/lab/model/LaboratoryRow.java
+++ b/src/main/java/org/isf/lab/model/LaboratoryRow.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.lab.model;
 

--- a/src/main/java/org/isf/lab/model/LaboratoryStatus.java
+++ b/src/main/java/org/isf/lab/model/LaboratoryStatus.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.lab.model;
 

--- a/src/main/java/org/isf/lab/service/LabIoOperationRepository.java
+++ b/src/main/java/org/isf/lab/service/LabIoOperationRepository.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.lab.service;
 

--- a/src/main/java/org/isf/lab/service/LabIoOperations.java
+++ b/src/main/java/org/isf/lab/service/LabIoOperations.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.lab.service;
 

--- a/src/main/java/org/isf/lab/service/LabPatientMergedEventListener.java
+++ b/src/main/java/org/isf/lab/service/LabPatientMergedEventListener.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.lab.service;
 

--- a/src/main/java/org/isf/lab/service/LabRowIoOperationRepository.java
+++ b/src/main/java/org/isf/lab/service/LabRowIoOperationRepository.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.lab.service;
 

--- a/src/main/java/org/isf/malnutrition/manager/MalnutritionManager.java
+++ b/src/main/java/org/isf/malnutrition/manager/MalnutritionManager.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.malnutrition.manager;
 

--- a/src/main/java/org/isf/malnutrition/model/Malnutrition.java
+++ b/src/main/java/org/isf/malnutrition/model/Malnutrition.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.malnutrition.model;
 

--- a/src/main/java/org/isf/malnutrition/service/MalnutritionIoOperation.java
+++ b/src/main/java/org/isf/malnutrition/service/MalnutritionIoOperation.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.malnutrition.service;
 

--- a/src/main/java/org/isf/malnutrition/service/MalnutritionIoOperationRepository.java
+++ b/src/main/java/org/isf/malnutrition/service/MalnutritionIoOperationRepository.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.malnutrition.service;
 

--- a/src/main/java/org/isf/medicals/manager/MedicalBrowsingManager.java
+++ b/src/main/java/org/isf/medicals/manager/MedicalBrowsingManager.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.medicals.manager;
 

--- a/src/main/java/org/isf/medicals/model/Medical.java
+++ b/src/main/java/org/isf/medicals/model/Medical.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.medicals.model;
 

--- a/src/main/java/org/isf/medicals/service/MedicalsIoOperationRepository.java
+++ b/src/main/java/org/isf/medicals/service/MedicalsIoOperationRepository.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.medicals.service;
 

--- a/src/main/java/org/isf/medicals/service/MedicalsIoOperations.java
+++ b/src/main/java/org/isf/medicals/service/MedicalsIoOperations.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.medicals.service;
 

--- a/src/main/java/org/isf/medicalstock/manager/MovBrowserManager.java
+++ b/src/main/java/org/isf/medicalstock/manager/MovBrowserManager.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.medicalstock.manager;
 

--- a/src/main/java/org/isf/medicalstock/manager/MovStockInsertingManager.java
+++ b/src/main/java/org/isf/medicalstock/manager/MovStockInsertingManager.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.medicalstock.manager;
 

--- a/src/main/java/org/isf/medicalstock/model/Lot.java
+++ b/src/main/java/org/isf/medicalstock/model/Lot.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.medicalstock.model;
 

--- a/src/main/java/org/isf/medicalstock/model/Movement.java
+++ b/src/main/java/org/isf/medicalstock/model/Movement.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.medicalstock.model;
 

--- a/src/main/java/org/isf/medicalstock/service/LotIoOperationRepository.java
+++ b/src/main/java/org/isf/medicalstock/service/LotIoOperationRepository.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.medicalstock.service;
 

--- a/src/main/java/org/isf/medicalstock/service/MedicalStockIoOperations.java
+++ b/src/main/java/org/isf/medicalstock/service/MedicalStockIoOperations.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.medicalstock.service;
 

--- a/src/main/java/org/isf/medicalstock/service/MovementIoOperationRepository.java
+++ b/src/main/java/org/isf/medicalstock/service/MovementIoOperationRepository.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.medicalstock.service;
 

--- a/src/main/java/org/isf/medicalstock/service/MovementIoOperationRepositoryCustom.java
+++ b/src/main/java/org/isf/medicalstock/service/MovementIoOperationRepositoryCustom.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.medicalstock.service;
 

--- a/src/main/java/org/isf/medicalstock/service/MovementIoOperationRepositoryImpl.java
+++ b/src/main/java/org/isf/medicalstock/service/MovementIoOperationRepositoryImpl.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.medicalstock.service;
 

--- a/src/main/java/org/isf/medicalstockward/manager/MovWardBrowserManager.java
+++ b/src/main/java/org/isf/medicalstockward/manager/MovWardBrowserManager.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.medicalstockward.manager;
 

--- a/src/main/java/org/isf/medicalstockward/model/MedicalWard.java
+++ b/src/main/java/org/isf/medicalstockward/model/MedicalWard.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.medicalstockward.model;
 

--- a/src/main/java/org/isf/medicalstockward/model/MedicalWardId.java
+++ b/src/main/java/org/isf/medicalstockward/model/MedicalWardId.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.medicalstockward.model;
 

--- a/src/main/java/org/isf/medicalstockward/model/MovementWard.java
+++ b/src/main/java/org/isf/medicalstockward/model/MovementWard.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.medicalstockward.model;
 

--- a/src/main/java/org/isf/medicalstockward/service/MedicalStockWardIoOperationRepository.java
+++ b/src/main/java/org/isf/medicalstockward/service/MedicalStockWardIoOperationRepository.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.medicalstockward.service;
 

--- a/src/main/java/org/isf/medicalstockward/service/MedicalStockWardIoOperationRepositoryCustom.java
+++ b/src/main/java/org/isf/medicalstockward/service/MedicalStockWardIoOperationRepositoryCustom.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.medicalstockward.service;
 

--- a/src/main/java/org/isf/medicalstockward/service/MedicalStockWardIoOperationRepositoryImpl.java
+++ b/src/main/java/org/isf/medicalstockward/service/MedicalStockWardIoOperationRepositoryImpl.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.medicalstockward.service;
 

--- a/src/main/java/org/isf/medicalstockward/service/MedicalStockWardIoOperations.java
+++ b/src/main/java/org/isf/medicalstockward/service/MedicalStockWardIoOperations.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.medicalstockward.service;
 

--- a/src/main/java/org/isf/medicalstockward/service/MovementWardIoOperationRepository.java
+++ b/src/main/java/org/isf/medicalstockward/service/MovementWardIoOperationRepository.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.medicalstockward.service;
 

--- a/src/main/java/org/isf/medicalstockward/service/MovementWardPatientMergedEventListener.java
+++ b/src/main/java/org/isf/medicalstockward/service/MovementWardPatientMergedEventListener.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.medicalstockward.service;
 

--- a/src/main/java/org/isf/medstockmovtype/manager/MedicaldsrstockmovTypeBrowserManager.java
+++ b/src/main/java/org/isf/medstockmovtype/manager/MedicaldsrstockmovTypeBrowserManager.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.medstockmovtype.manager;
 

--- a/src/main/java/org/isf/medstockmovtype/model/MovementType.java
+++ b/src/main/java/org/isf/medstockmovtype/model/MovementType.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.medstockmovtype.model;
 

--- a/src/main/java/org/isf/medstockmovtype/service/MedicalStockMovementTypeIoOperation.java
+++ b/src/main/java/org/isf/medstockmovtype/service/MedicalStockMovementTypeIoOperation.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.medstockmovtype.service;
 

--- a/src/main/java/org/isf/medstockmovtype/service/MedicalStockMovementTypeIoOperationRepository.java
+++ b/src/main/java/org/isf/medstockmovtype/service/MedicalStockMovementTypeIoOperationRepository.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.medstockmovtype.service;
 

--- a/src/main/java/org/isf/medtype/manager/MedicalTypeBrowserManager.java
+++ b/src/main/java/org/isf/medtype/manager/MedicalTypeBrowserManager.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.medtype.manager;
 

--- a/src/main/java/org/isf/medtype/model/MedicalType.java
+++ b/src/main/java/org/isf/medtype/model/MedicalType.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.medtype.model;
 

--- a/src/main/java/org/isf/medtype/service/MedicalTypeIoOperation.java
+++ b/src/main/java/org/isf/medtype/service/MedicalTypeIoOperation.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.medtype.service;
 

--- a/src/main/java/org/isf/medtype/service/MedicalTypeIoOperationRepository.java
+++ b/src/main/java/org/isf/medtype/service/MedicalTypeIoOperationRepository.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.medtype.service;
 

--- a/src/main/java/org/isf/menu/manager/Context.java
+++ b/src/main/java/org/isf/menu/manager/Context.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.menu.manager;
 

--- a/src/main/java/org/isf/menu/manager/UserBrowsingManager.java
+++ b/src/main/java/org/isf/menu/manager/UserBrowsingManager.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.menu.manager;
 

--- a/src/main/java/org/isf/menu/manager/UserGroupManager.java
+++ b/src/main/java/org/isf/menu/manager/UserGroupManager.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.menu.manager;
 

--- a/src/main/java/org/isf/menu/model/GroupMenu.java
+++ b/src/main/java/org/isf/menu/model/GroupMenu.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.menu.model;
 

--- a/src/main/java/org/isf/menu/model/User.java
+++ b/src/main/java/org/isf/menu/model/User.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.menu.model;
 

--- a/src/main/java/org/isf/menu/model/UserGroup.java
+++ b/src/main/java/org/isf/menu/model/UserGroup.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.menu.model;
 

--- a/src/main/java/org/isf/menu/model/UserMenuItem.java
+++ b/src/main/java/org/isf/menu/model/UserMenuItem.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.menu.model;
 

--- a/src/main/java/org/isf/menu/service/GroupMenuIoOperationRepository.java
+++ b/src/main/java/org/isf/menu/service/GroupMenuIoOperationRepository.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.menu.service;
 

--- a/src/main/java/org/isf/menu/service/MenuIoOperations.java
+++ b/src/main/java/org/isf/menu/service/MenuIoOperations.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.menu.service;
 

--- a/src/main/java/org/isf/menu/service/UserGroupIoOperationRepository.java
+++ b/src/main/java/org/isf/menu/service/UserGroupIoOperationRepository.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.menu.service;
 

--- a/src/main/java/org/isf/menu/service/UserIoOperationRepository.java
+++ b/src/main/java/org/isf/menu/service/UserIoOperationRepository.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.menu.service;
 

--- a/src/main/java/org/isf/menu/service/UserMenuItemIoOperationRepository.java
+++ b/src/main/java/org/isf/menu/service/UserMenuItemIoOperationRepository.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.menu.service;
 

--- a/src/main/java/org/isf/opd/manager/OpdBrowserManager.java
+++ b/src/main/java/org/isf/opd/manager/OpdBrowserManager.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.opd.manager;
 

--- a/src/main/java/org/isf/opd/model/Opd.java
+++ b/src/main/java/org/isf/opd/model/Opd.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.opd.model;
 

--- a/src/main/java/org/isf/opd/service/OpdIoOperationRepository.java
+++ b/src/main/java/org/isf/opd/service/OpdIoOperationRepository.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.opd.service;
 

--- a/src/main/java/org/isf/opd/service/OpdIoOperationRepositoryCustom.java
+++ b/src/main/java/org/isf/opd/service/OpdIoOperationRepositoryCustom.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.opd.service;
 

--- a/src/main/java/org/isf/opd/service/OpdIoOperationRepositoryImpl.java
+++ b/src/main/java/org/isf/opd/service/OpdIoOperationRepositoryImpl.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.opd.service;
 

--- a/src/main/java/org/isf/opd/service/OpdIoOperations.java
+++ b/src/main/java/org/isf/opd/service/OpdIoOperations.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.opd.service;
 

--- a/src/main/java/org/isf/opd/service/OpdPatientMergedEventListener.java
+++ b/src/main/java/org/isf/opd/service/OpdPatientMergedEventListener.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.opd.service;
 

--- a/src/main/java/org/isf/operation/manager/OperationBrowserManager.java
+++ b/src/main/java/org/isf/operation/manager/OperationBrowserManager.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.operation.manager;
 

--- a/src/main/java/org/isf/operation/manager/OperationRowBrowserManager.java
+++ b/src/main/java/org/isf/operation/manager/OperationRowBrowserManager.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.operation.manager;
 

--- a/src/main/java/org/isf/operation/model/Operation.java
+++ b/src/main/java/org/isf/operation/model/Operation.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.operation.model;
 

--- a/src/main/java/org/isf/operation/model/OperationRow.java
+++ b/src/main/java/org/isf/operation/model/OperationRow.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.operation.model;
 

--- a/src/main/java/org/isf/operation/service/OperationIoOperationRepository.java
+++ b/src/main/java/org/isf/operation/service/OperationIoOperationRepository.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.operation.service;
 

--- a/src/main/java/org/isf/operation/service/OperationIoOperations.java
+++ b/src/main/java/org/isf/operation/service/OperationIoOperations.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.operation.service;
 

--- a/src/main/java/org/isf/operation/service/OperationRowIoOperationRepository.java
+++ b/src/main/java/org/isf/operation/service/OperationRowIoOperationRepository.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.operation.service;
 

--- a/src/main/java/org/isf/operation/service/OperationRowIoOperations.java
+++ b/src/main/java/org/isf/operation/service/OperationRowIoOperations.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.operation.service;
 

--- a/src/main/java/org/isf/opetype/manager/OperationTypeBrowserManager.java
+++ b/src/main/java/org/isf/opetype/manager/OperationTypeBrowserManager.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.opetype.manager;
 

--- a/src/main/java/org/isf/opetype/model/OperationType.java
+++ b/src/main/java/org/isf/opetype/model/OperationType.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.opetype.model;
 

--- a/src/main/java/org/isf/opetype/service/OperationTypeIoOperation.java
+++ b/src/main/java/org/isf/opetype/service/OperationTypeIoOperation.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.opetype.service;
 

--- a/src/main/java/org/isf/opetype/service/OperationTypeIoOperationRepository.java
+++ b/src/main/java/org/isf/opetype/service/OperationTypeIoOperationRepository.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.opetype.service;
 

--- a/src/main/java/org/isf/patient/manager/PatientBrowserManager.java
+++ b/src/main/java/org/isf/patient/manager/PatientBrowserManager.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.patient.manager;
 

--- a/src/main/java/org/isf/patient/model/Patient.java
+++ b/src/main/java/org/isf/patient/model/Patient.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.patient.model;
 

--- a/src/main/java/org/isf/patient/model/PatientMergedEvent.java
+++ b/src/main/java/org/isf/patient/model/PatientMergedEvent.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.patient.model;
 

--- a/src/main/java/org/isf/patient/model/PatientProfilePhoto.java
+++ b/src/main/java/org/isf/patient/model/PatientProfilePhoto.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.patient.model;
 

--- a/src/main/java/org/isf/patient/service/FileSystemPatientPhotoRepository.java
+++ b/src/main/java/org/isf/patient/service/FileSystemPatientPhotoRepository.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.patient.service;
 

--- a/src/main/java/org/isf/patient/service/PatientIoOperationRepository.java
+++ b/src/main/java/org/isf/patient/service/PatientIoOperationRepository.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.patient.service;
 

--- a/src/main/java/org/isf/patient/service/PatientIoOperationRepositoryCustom.java
+++ b/src/main/java/org/isf/patient/service/PatientIoOperationRepositoryCustom.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.patient.service;
 

--- a/src/main/java/org/isf/patient/service/PatientIoOperationRepositoryImpl.java
+++ b/src/main/java/org/isf/patient/service/PatientIoOperationRepositoryImpl.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.patient.service;
 

--- a/src/main/java/org/isf/patient/service/PatientIoOperations.java
+++ b/src/main/java/org/isf/patient/service/PatientIoOperations.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.patient.service;
 

--- a/src/main/java/org/isf/patvac/manager/PatVacManager.java
+++ b/src/main/java/org/isf/patvac/manager/PatVacManager.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.patvac.manager;
 

--- a/src/main/java/org/isf/patvac/model/PatientVaccine.java
+++ b/src/main/java/org/isf/patvac/model/PatientVaccine.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.patvac.model;
 

--- a/src/main/java/org/isf/patvac/service/PatVacIoOperationRepository.java
+++ b/src/main/java/org/isf/patvac/service/PatVacIoOperationRepository.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.patvac.service;
 

--- a/src/main/java/org/isf/patvac/service/PatVacIoOperationRepositoryCustom.java
+++ b/src/main/java/org/isf/patvac/service/PatVacIoOperationRepositoryCustom.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.patvac.service;
 

--- a/src/main/java/org/isf/patvac/service/PatVacIoOperationRepositoryImpl.java
+++ b/src/main/java/org/isf/patvac/service/PatVacIoOperationRepositoryImpl.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.patvac.service;
 

--- a/src/main/java/org/isf/patvac/service/PatVacIoOperations.java
+++ b/src/main/java/org/isf/patvac/service/PatVacIoOperations.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.patvac.service;
 

--- a/src/main/java/org/isf/patvac/service/VaccinePatientMergedEventListener.java
+++ b/src/main/java/org/isf/patvac/service/VaccinePatientMergedEventListener.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.patvac.service;
 

--- a/src/main/java/org/isf/permissions/manager/GroupPermissionManager.java
+++ b/src/main/java/org/isf/permissions/manager/GroupPermissionManager.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.permissions.manager;
 

--- a/src/main/java/org/isf/permissions/manager/PermissionManager.java
+++ b/src/main/java/org/isf/permissions/manager/PermissionManager.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.permissions.manager;
 

--- a/src/main/java/org/isf/permissions/model/GroupPermission.java
+++ b/src/main/java/org/isf/permissions/model/GroupPermission.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.permissions.model;
 

--- a/src/main/java/org/isf/permissions/model/Permission.java
+++ b/src/main/java/org/isf/permissions/model/Permission.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.permissions.model;
 

--- a/src/main/java/org/isf/permissions/service/GroupPermissionIoOperationRepository.java
+++ b/src/main/java/org/isf/permissions/service/GroupPermissionIoOperationRepository.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.permissions.service;
 

--- a/src/main/java/org/isf/permissions/service/GroupPermissionIoOperations.java
+++ b/src/main/java/org/isf/permissions/service/GroupPermissionIoOperations.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.permissions.service;
 

--- a/src/main/java/org/isf/permissions/service/PermissionIoOperationRepository.java
+++ b/src/main/java/org/isf/permissions/service/PermissionIoOperationRepository.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.permissions.service;
 

--- a/src/main/java/org/isf/permissions/service/PermissionIoOperations.java
+++ b/src/main/java/org/isf/permissions/service/PermissionIoOperations.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.permissions.service;
 

--- a/src/main/java/org/isf/pregtreattype/manager/PregnantTreatmentTypeBrowserManager.java
+++ b/src/main/java/org/isf/pregtreattype/manager/PregnantTreatmentTypeBrowserManager.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.pregtreattype.manager;
 

--- a/src/main/java/org/isf/pregtreattype/model/PregnantTreatmentType.java
+++ b/src/main/java/org/isf/pregtreattype/model/PregnantTreatmentType.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.pregtreattype.model;
 

--- a/src/main/java/org/isf/pregtreattype/service/PregnantTreatmentTypeIoOperation.java
+++ b/src/main/java/org/isf/pregtreattype/service/PregnantTreatmentTypeIoOperation.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.pregtreattype.service;
 

--- a/src/main/java/org/isf/pregtreattype/service/PregnantTreatmentTypeIoOperationRepository.java
+++ b/src/main/java/org/isf/pregtreattype/service/PregnantTreatmentTypeIoOperationRepository.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.pregtreattype.service;
 

--- a/src/main/java/org/isf/priceslist/manager/PriceListManager.java
+++ b/src/main/java/org/isf/priceslist/manager/PriceListManager.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.priceslist.manager;
 

--- a/src/main/java/org/isf/priceslist/model/Price.java
+++ b/src/main/java/org/isf/priceslist/model/Price.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.priceslist.model;
 

--- a/src/main/java/org/isf/priceslist/model/PriceList.java
+++ b/src/main/java/org/isf/priceslist/model/PriceList.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.priceslist.model;
 

--- a/src/main/java/org/isf/priceslist/service/PriceIoOperationRepository.java
+++ b/src/main/java/org/isf/priceslist/service/PriceIoOperationRepository.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.priceslist.service;
 

--- a/src/main/java/org/isf/priceslist/service/PricesListIoOperationRepository.java
+++ b/src/main/java/org/isf/priceslist/service/PricesListIoOperationRepository.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.priceslist.service;
 

--- a/src/main/java/org/isf/priceslist/service/PricesListIoOperations.java
+++ b/src/main/java/org/isf/priceslist/service/PricesListIoOperations.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.priceslist.service;
 

--- a/src/main/java/org/isf/pricesothers/manager/PricesOthersManager.java
+++ b/src/main/java/org/isf/pricesothers/manager/PricesOthersManager.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.pricesothers.manager;
 

--- a/src/main/java/org/isf/pricesothers/model/PricesOthers.java
+++ b/src/main/java/org/isf/pricesothers/model/PricesOthers.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.pricesothers.model;
 

--- a/src/main/java/org/isf/pricesothers/service/PriceOthersIoOperationRepository.java
+++ b/src/main/java/org/isf/pricesothers/service/PriceOthersIoOperationRepository.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.pricesothers.service;
 

--- a/src/main/java/org/isf/pricesothers/service/PriceOthersIoOperations.java
+++ b/src/main/java/org/isf/pricesothers/service/PriceOthersIoOperations.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.pricesothers.service;
 

--- a/src/main/java/org/isf/serviceprinting/manager/PrintLabels.java
+++ b/src/main/java/org/isf/serviceprinting/manager/PrintLabels.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.serviceprinting.manager;
 

--- a/src/main/java/org/isf/serviceprinting/manager/PrintManager.java
+++ b/src/main/java/org/isf/serviceprinting/manager/PrintManager.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.serviceprinting.manager;
 

--- a/src/main/java/org/isf/serviceprinting/manager/PrintReceipt.java
+++ b/src/main/java/org/isf/serviceprinting/manager/PrintReceipt.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.serviceprinting.manager;
 

--- a/src/main/java/org/isf/serviceprinting/print/Medical4Print.java
+++ b/src/main/java/org/isf/serviceprinting/print/Medical4Print.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.serviceprinting.print;
 

--- a/src/main/java/org/isf/serviceprinting/print/MedicalWardForPrint.java
+++ b/src/main/java/org/isf/serviceprinting/print/MedicalWardForPrint.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.serviceprinting.print;
 

--- a/src/main/java/org/isf/serviceprinting/print/Movement4Print.java
+++ b/src/main/java/org/isf/serviceprinting/print/Movement4Print.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.serviceprinting.print;
 

--- a/src/main/java/org/isf/serviceprinting/print/MovementForPrint.java
+++ b/src/main/java/org/isf/serviceprinting/print/MovementForPrint.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.serviceprinting.print;
 

--- a/src/main/java/org/isf/serviceprinting/print/MovementWardForPrint.java
+++ b/src/main/java/org/isf/serviceprinting/print/MovementWardForPrint.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.serviceprinting.print;
 

--- a/src/main/java/org/isf/serviceprinting/print/PriceForPrint.java
+++ b/src/main/java/org/isf/serviceprinting/print/PriceForPrint.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.serviceprinting.print;
 

--- a/src/main/java/org/isf/sessionaudit/manager/SessionAuditManager.java
+++ b/src/main/java/org/isf/sessionaudit/manager/SessionAuditManager.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.sessionaudit.manager;
 

--- a/src/main/java/org/isf/sessionaudit/model/SessionAudit.java
+++ b/src/main/java/org/isf/sessionaudit/model/SessionAudit.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.sessionaudit.model;
 

--- a/src/main/java/org/isf/sessionaudit/service/SessionAuditIoOperation.java
+++ b/src/main/java/org/isf/sessionaudit/service/SessionAuditIoOperation.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.sessionaudit.service;
 

--- a/src/main/java/org/isf/sessionaudit/service/SessionAuditIoOperationRepository.java
+++ b/src/main/java/org/isf/sessionaudit/service/SessionAuditIoOperationRepository.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.sessionaudit.service;
 

--- a/src/main/java/org/isf/sms/manager/SmsManager.java
+++ b/src/main/java/org/isf/sms/manager/SmsManager.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.sms.manager;
 

--- a/src/main/java/org/isf/sms/model/Sms.java
+++ b/src/main/java/org/isf/sms/model/Sms.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.sms.model;
 

--- a/src/main/java/org/isf/sms/providers/SmsSenderInterface.java
+++ b/src/main/java/org/isf/sms/providers/SmsSenderInterface.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.sms.providers;
 

--- a/src/main/java/org/isf/sms/providers/common/CustomCommonDecoder.java
+++ b/src/main/java/org/isf/sms/providers/common/CustomCommonDecoder.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.sms.providers.common;
 

--- a/src/main/java/org/isf/sms/providers/common/CustomCommonEncoder.java
+++ b/src/main/java/org/isf/sms/providers/common/CustomCommonEncoder.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.sms.providers.common;
 

--- a/src/main/java/org/isf/sms/providers/gsm/GSMGatewayService.java
+++ b/src/main/java/org/isf/sms/providers/gsm/GSMGatewayService.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.sms.providers.gsm;
 

--- a/src/main/java/org/isf/sms/providers/gsm/GSMParameters.java
+++ b/src/main/java/org/isf/sms/providers/gsm/GSMParameters.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.sms.providers.gsm;
 

--- a/src/main/java/org/isf/sms/providers/skebby/SkebbyGatewayConverter.java
+++ b/src/main/java/org/isf/sms/providers/skebby/SkebbyGatewayConverter.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.sms.providers.skebby;
 

--- a/src/main/java/org/isf/sms/providers/skebby/SkebbyGatewayService.java
+++ b/src/main/java/org/isf/sms/providers/skebby/SkebbyGatewayService.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.sms.providers.skebby;
 

--- a/src/main/java/org/isf/sms/providers/skebby/SkebbyGatewayUtil.java
+++ b/src/main/java/org/isf/sms/providers/skebby/SkebbyGatewayUtil.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.sms.providers.skebby;
 

--- a/src/main/java/org/isf/sms/providers/skebby/model/MessageType.java
+++ b/src/main/java/org/isf/sms/providers/skebby/model/MessageType.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.sms.providers.skebby.model;
 

--- a/src/main/java/org/isf/sms/providers/skebby/model/SckebbySmsRequest.java
+++ b/src/main/java/org/isf/sms/providers/skebby/model/SckebbySmsRequest.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.sms.providers.skebby.model;
 

--- a/src/main/java/org/isf/sms/providers/skebby/model/SckebbySmsResponse.java
+++ b/src/main/java/org/isf/sms/providers/skebby/model/SckebbySmsResponse.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.sms.providers.skebby.model;
 

--- a/src/main/java/org/isf/sms/providers/skebby/remote/SkebbyGatewayRemoteService.java
+++ b/src/main/java/org/isf/sms/providers/skebby/remote/SkebbyGatewayRemoteService.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.sms.providers.skebby.remote;
 

--- a/src/main/java/org/isf/sms/providers/textbelt/TextbeltGatewayConverter.java
+++ b/src/main/java/org/isf/sms/providers/textbelt/TextbeltGatewayConverter.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.sms.providers.textbelt;
 

--- a/src/main/java/org/isf/sms/providers/textbelt/TextbeltGatewayService.java
+++ b/src/main/java/org/isf/sms/providers/textbelt/TextbeltGatewayService.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.sms.providers.textbelt;
 

--- a/src/main/java/org/isf/sms/providers/textbelt/model/TextbeltSmsRequest.java
+++ b/src/main/java/org/isf/sms/providers/textbelt/model/TextbeltSmsRequest.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.sms.providers.textbelt.model;
 

--- a/src/main/java/org/isf/sms/providers/textbelt/model/TextbeltSmsResponse.java
+++ b/src/main/java/org/isf/sms/providers/textbelt/model/TextbeltSmsResponse.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.sms.providers.textbelt.model;
 

--- a/src/main/java/org/isf/sms/providers/textbelt/remote/TextbeltGatewayRemoteService.java
+++ b/src/main/java/org/isf/sms/providers/textbelt/remote/TextbeltGatewayRemoteService.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.sms.providers.textbelt.remote;
 

--- a/src/main/java/org/isf/sms/service/SmsIoOperationRepository.java
+++ b/src/main/java/org/isf/sms/service/SmsIoOperationRepository.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.sms.service;
 

--- a/src/main/java/org/isf/sms/service/SmsOperations.java
+++ b/src/main/java/org/isf/sms/service/SmsOperations.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.sms.service;
 

--- a/src/main/java/org/isf/sms/service/SmsSender.java
+++ b/src/main/java/org/isf/sms/service/SmsSender.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.sms.service;
 

--- a/src/main/java/org/isf/sms/service/SmsSenderOperations.java
+++ b/src/main/java/org/isf/sms/service/SmsSenderOperations.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.sms.service;
 

--- a/src/main/java/org/isf/stat/dto/JasperReportResultDto.java
+++ b/src/main/java/org/isf/stat/dto/JasperReportResultDto.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.stat.dto;
 

--- a/src/main/java/org/isf/stat/manager/JasperReportsManager.java
+++ b/src/main/java/org/isf/stat/manager/JasperReportsManager.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.stat.manager;
 

--- a/src/main/java/org/isf/supplier/manager/SupplierBrowserManager.java
+++ b/src/main/java/org/isf/supplier/manager/SupplierBrowserManager.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.supplier.manager;
 

--- a/src/main/java/org/isf/supplier/model/Supplier.java
+++ b/src/main/java/org/isf/supplier/model/Supplier.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.supplier.model;
 

--- a/src/main/java/org/isf/supplier/service/SupplierIoOperationRepository.java
+++ b/src/main/java/org/isf/supplier/service/SupplierIoOperationRepository.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.supplier.service;
 

--- a/src/main/java/org/isf/supplier/service/SupplierOperations.java
+++ b/src/main/java/org/isf/supplier/service/SupplierOperations.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.supplier.service;
 

--- a/src/main/java/org/isf/therapy/manager/TherapyManager.java
+++ b/src/main/java/org/isf/therapy/manager/TherapyManager.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.therapy.manager;
 

--- a/src/main/java/org/isf/therapy/model/Therapy.java
+++ b/src/main/java/org/isf/therapy/model/Therapy.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.therapy.model;
 

--- a/src/main/java/org/isf/therapy/model/TherapyRow.java
+++ b/src/main/java/org/isf/therapy/model/TherapyRow.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.therapy.model;
 

--- a/src/main/java/org/isf/therapy/service/TherapyIoOperationRepository.java
+++ b/src/main/java/org/isf/therapy/service/TherapyIoOperationRepository.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.therapy.service;
 

--- a/src/main/java/org/isf/therapy/service/TherapyIoOperations.java
+++ b/src/main/java/org/isf/therapy/service/TherapyIoOperations.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.therapy.service;
 

--- a/src/main/java/org/isf/therapy/service/TherapyPatientMergedEventListener.java
+++ b/src/main/java/org/isf/therapy/service/TherapyPatientMergedEventListener.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.therapy.service;
 

--- a/src/main/java/org/isf/utils/db/Auditable.java
+++ b/src/main/java/org/isf/utils/db/Auditable.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.utils.db;
 

--- a/src/main/java/org/isf/utils/db/AuditorAwareImpl.java
+++ b/src/main/java/org/isf/utils/db/AuditorAwareImpl.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.utils.db;
 

--- a/src/main/java/org/isf/utils/db/BCrypt.java
+++ b/src/main/java/org/isf/utils/db/BCrypt.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.utils.db;
 

--- a/src/main/java/org/isf/utils/db/DbJpaUtil.java
+++ b/src/main/java/org/isf/utils/db/DbJpaUtil.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.utils.db;
 

--- a/src/main/java/org/isf/utils/db/DbQueryLogger.java
+++ b/src/main/java/org/isf/utils/db/DbQueryLogger.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.utils.db;
 

--- a/src/main/java/org/isf/utils/db/DbSingleJpaConn.java
+++ b/src/main/java/org/isf/utils/db/DbSingleJpaConn.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.utils.db;
 

--- a/src/main/java/org/isf/utils/db/JpaConfig.java
+++ b/src/main/java/org/isf/utils/db/JpaConfig.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.utils.db;
 

--- a/src/main/java/org/isf/utils/db/NormalizeString.java
+++ b/src/main/java/org/isf/utils/db/NormalizeString.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.utils.db;
 

--- a/src/main/java/org/isf/utils/db/OHServiceExceptionTranslator.java
+++ b/src/main/java/org/isf/utils/db/OHServiceExceptionTranslator.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.utils.db;
 

--- a/src/main/java/org/isf/utils/db/RememberData.java
+++ b/src/main/java/org/isf/utils/db/RememberData.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.utils.db;
 

--- a/src/main/java/org/isf/utils/db/TranslateOHServiceException.java
+++ b/src/main/java/org/isf/utils/db/TranslateOHServiceException.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.utils.db;
 

--- a/src/main/java/org/isf/utils/db/UTF8Control.java
+++ b/src/main/java/org/isf/utils/db/UTF8Control.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.utils.db;
 

--- a/src/main/java/org/isf/utils/excel/ExcelExporter.java
+++ b/src/main/java/org/isf/utils/excel/ExcelExporter.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.utils.excel;
 

--- a/src/main/java/org/isf/utils/exception/OHDBConnectionException.java
+++ b/src/main/java/org/isf/utils/exception/OHDBConnectionException.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.utils.exception;
 

--- a/src/main/java/org/isf/utils/exception/OHDataIntegrityViolationException.java
+++ b/src/main/java/org/isf/utils/exception/OHDataIntegrityViolationException.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.utils.exception;
 

--- a/src/main/java/org/isf/utils/exception/OHDataLockFailureException.java
+++ b/src/main/java/org/isf/utils/exception/OHDataLockFailureException.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.utils.exception;
 

--- a/src/main/java/org/isf/utils/exception/OHDataValidationException.java
+++ b/src/main/java/org/isf/utils/exception/OHDataValidationException.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.utils.exception;
 

--- a/src/main/java/org/isf/utils/exception/OHDicomException.java
+++ b/src/main/java/org/isf/utils/exception/OHDicomException.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.utils.exception;
 

--- a/src/main/java/org/isf/utils/exception/OHException.java
+++ b/src/main/java/org/isf/utils/exception/OHException.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.utils.exception;
 

--- a/src/main/java/org/isf/utils/exception/OHInvalidSQLException.java
+++ b/src/main/java/org/isf/utils/exception/OHInvalidSQLException.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.utils.exception;
 

--- a/src/main/java/org/isf/utils/exception/OHOperationNotAllowedException.java
+++ b/src/main/java/org/isf/utils/exception/OHOperationNotAllowedException.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.utils.exception;
 

--- a/src/main/java/org/isf/utils/exception/OHReportException.java
+++ b/src/main/java/org/isf/utils/exception/OHReportException.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.utils.exception;
 

--- a/src/main/java/org/isf/utils/exception/OHServiceException.java
+++ b/src/main/java/org/isf/utils/exception/OHServiceException.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.utils.exception;
 

--- a/src/main/java/org/isf/utils/exception/model/ErrorDescription.java
+++ b/src/main/java/org/isf/utils/exception/model/ErrorDescription.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.utils.exception.model;
 

--- a/src/main/java/org/isf/utils/exception/model/OHExceptionMessage.java
+++ b/src/main/java/org/isf/utils/exception/model/OHExceptionMessage.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.utils.exception.model;
 

--- a/src/main/java/org/isf/utils/exception/model/OHSeverityLevel.java
+++ b/src/main/java/org/isf/utils/exception/model/OHSeverityLevel.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.utils.exception.model;
 

--- a/src/main/java/org/isf/utils/file/FileTools.java
+++ b/src/main/java/org/isf/utils/file/FileTools.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.utils.file;
 

--- a/src/main/java/org/isf/utils/sms/SetupGSM.java
+++ b/src/main/java/org/isf/utils/sms/SetupGSM.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.utils.sms;
 

--- a/src/main/java/org/isf/utils/table/TableMap.java
+++ b/src/main/java/org/isf/utils/table/TableMap.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.utils.table;
 

--- a/src/main/java/org/isf/utils/table/TableSorter.java
+++ b/src/main/java/org/isf/utils/table/TableSorter.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.utils.table;
 

--- a/src/main/java/org/isf/utils/time/RememberDates.java
+++ b/src/main/java/org/isf/utils/time/RememberDates.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.utils.time;
 

--- a/src/main/java/org/isf/utils/time/TimeTools.java
+++ b/src/main/java/org/isf/utils/time/TimeTools.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.utils.time;
 

--- a/src/main/java/org/isf/utils/treetable/AbstractCellEditor.java
+++ b/src/main/java/org/isf/utils/treetable/AbstractCellEditor.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.utils.treetable;
 

--- a/src/main/java/org/isf/utils/treetable/AbstractTreeTableModel.java
+++ b/src/main/java/org/isf/utils/treetable/AbstractTreeTableModel.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.utils.treetable;
 

--- a/src/main/java/org/isf/utils/treetable/JTreeTable.java
+++ b/src/main/java/org/isf/utils/treetable/JTreeTable.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.utils.treetable;
 

--- a/src/main/java/org/isf/utils/treetable/TreeTableCellRenderer.java
+++ b/src/main/java/org/isf/utils/treetable/TreeTableCellRenderer.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.utils.treetable;
 

--- a/src/main/java/org/isf/utils/treetable/TreeTableModel.java
+++ b/src/main/java/org/isf/utils/treetable/TreeTableModel.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.utils.treetable;
 

--- a/src/main/java/org/isf/utils/treetable/TreeTableModelAdapter.java
+++ b/src/main/java/org/isf/utils/treetable/TreeTableModelAdapter.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.utils.treetable;
 

--- a/src/main/java/org/isf/utils/validator/DefaultSorter.java
+++ b/src/main/java/org/isf/utils/validator/DefaultSorter.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.utils.validator;
 

--- a/src/main/java/org/isf/utils/validator/EmailValidator.java
+++ b/src/main/java/org/isf/utils/validator/EmailValidator.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.utils.validator;
 

--- a/src/main/java/org/isf/vaccine/manager/VaccineBrowserManager.java
+++ b/src/main/java/org/isf/vaccine/manager/VaccineBrowserManager.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.vaccine.manager;
 

--- a/src/main/java/org/isf/vaccine/model/Vaccine.java
+++ b/src/main/java/org/isf/vaccine/model/Vaccine.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.vaccine.model;
 

--- a/src/main/java/org/isf/vaccine/service/VaccineIoOperationRepository.java
+++ b/src/main/java/org/isf/vaccine/service/VaccineIoOperationRepository.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.vaccine.service;
 

--- a/src/main/java/org/isf/vaccine/service/VaccineIoOperations.java
+++ b/src/main/java/org/isf/vaccine/service/VaccineIoOperations.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.vaccine.service;
 

--- a/src/main/java/org/isf/vactype/manager/VaccineTypeBrowserManager.java
+++ b/src/main/java/org/isf/vactype/manager/VaccineTypeBrowserManager.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.vactype.manager;
 

--- a/src/main/java/org/isf/vactype/model/VaccineType.java
+++ b/src/main/java/org/isf/vactype/model/VaccineType.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.vactype.model;
 

--- a/src/main/java/org/isf/vactype/service/VacTypeIoOperation.java
+++ b/src/main/java/org/isf/vactype/service/VacTypeIoOperation.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.vactype.service;
 

--- a/src/main/java/org/isf/vactype/service/VaccineTypeIoOperationRepository.java
+++ b/src/main/java/org/isf/vactype/service/VaccineTypeIoOperationRepository.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.vactype.service;
 

--- a/src/main/java/org/isf/visits/manager/VisitManager.java
+++ b/src/main/java/org/isf/visits/manager/VisitManager.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.visits.manager;
 

--- a/src/main/java/org/isf/visits/model/Visit.java
+++ b/src/main/java/org/isf/visits/model/Visit.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.visits.model;
 

--- a/src/main/java/org/isf/visits/service/VisitsIoOperationRepository.java
+++ b/src/main/java/org/isf/visits/service/VisitsIoOperationRepository.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.visits.service;
 

--- a/src/main/java/org/isf/visits/service/VisitsIoOperations.java
+++ b/src/main/java/org/isf/visits/service/VisitsIoOperations.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.visits.service;
 

--- a/src/main/java/org/isf/visits/service/VisitsPatientMergedEventListener.java
+++ b/src/main/java/org/isf/visits/service/VisitsPatientMergedEventListener.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.visits.service;
 

--- a/src/main/java/org/isf/ward/manager/WardBrowserManager.java
+++ b/src/main/java/org/isf/ward/manager/WardBrowserManager.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.ward.manager;
 

--- a/src/main/java/org/isf/ward/model/Ward.java
+++ b/src/main/java/org/isf/ward/model/Ward.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.ward.model;
 

--- a/src/main/java/org/isf/ward/service/WardIoOperationRepository.java
+++ b/src/main/java/org/isf/ward/service/WardIoOperationRepository.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.ward.service;
 

--- a/src/main/java/org/isf/ward/service/WardIoOperations.java
+++ b/src/main/java/org/isf/ward/service/WardIoOperations.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.ward.service;
 

--- a/src/main/java/org/isf/xmpp/manager/AbstractCommunicationFrame.java
+++ b/src/main/java/org/isf/xmpp/manager/AbstractCommunicationFrame.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.xmpp.manager;
 

--- a/src/main/java/org/isf/xmpp/manager/ComplexCellRender.java
+++ b/src/main/java/org/isf/xmpp/manager/ComplexCellRender.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.xmpp.manager;
 

--- a/src/main/java/org/isf/xmpp/manager/Interaction.java
+++ b/src/main/java/org/isf/xmpp/manager/Interaction.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.xmpp.manager;
 

--- a/src/main/java/org/isf/xmpp/service/Server.java
+++ b/src/main/java/org/isf/xmpp/service/Server.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.xmpp.service;
 

--- a/src/test/java/org/isf/OHCoreTestCase.java
+++ b/src/test/java/org/isf/OHCoreTestCase.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf;
 

--- a/src/test/java/org/isf/accounting/test/TestBill.java
+++ b/src/test/java/org/isf/accounting/test/TestBill.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.accounting.test;
 

--- a/src/test/java/org/isf/accounting/test/TestBillItems.java
+++ b/src/test/java/org/isf/accounting/test/TestBillItems.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.accounting.test;
 

--- a/src/test/java/org/isf/accounting/test/TestBillPayments.java
+++ b/src/test/java/org/isf/accounting/test/TestBillPayments.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.accounting.test;
 

--- a/src/test/java/org/isf/accounting/test/Tests.java
+++ b/src/test/java/org/isf/accounting/test/Tests.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.accounting.test;
 

--- a/src/test/java/org/isf/admission/test/TestAdmission.java
+++ b/src/test/java/org/isf/admission/test/TestAdmission.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.admission.test;
 

--- a/src/test/java/org/isf/admission/test/Tests.java
+++ b/src/test/java/org/isf/admission/test/Tests.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.admission.test;
 

--- a/src/test/java/org/isf/admtype/test/TestAdmissionType.java
+++ b/src/test/java/org/isf/admtype/test/TestAdmissionType.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.admtype.test;
 

--- a/src/test/java/org/isf/admtype/test/Tests.java
+++ b/src/test/java/org/isf/admtype/test/Tests.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.admtype.test;
 

--- a/src/test/java/org/isf/agetype/test/TestAgeType.java
+++ b/src/test/java/org/isf/agetype/test/TestAgeType.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.agetype.test;
 

--- a/src/test/java/org/isf/agetype/test/Tests.java
+++ b/src/test/java/org/isf/agetype/test/Tests.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.agetype.test;
 

--- a/src/test/java/org/isf/dicom/test/TestDicom.java
+++ b/src/test/java/org/isf/dicom/test/TestDicom.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.dicom.test;
 

--- a/src/test/java/org/isf/dicom/test/TestFileSystemDicomManager.java
+++ b/src/test/java/org/isf/dicom/test/TestFileSystemDicomManager.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.dicom.test;
 

--- a/src/test/java/org/isf/dicom/test/TestSqlDicomManager.java
+++ b/src/test/java/org/isf/dicom/test/TestSqlDicomManager.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.dicom.test;
 

--- a/src/test/java/org/isf/dicom/test/Tests.java
+++ b/src/test/java/org/isf/dicom/test/Tests.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.dicom.test;
 

--- a/src/test/java/org/isf/dicomtype/test/TestDicomType.java
+++ b/src/test/java/org/isf/dicomtype/test/TestDicomType.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.dicomtype.test;
 

--- a/src/test/java/org/isf/dicomtype/test/Tests.java
+++ b/src/test/java/org/isf/dicomtype/test/Tests.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.dicomtype.test;
 

--- a/src/test/java/org/isf/disctype/test/TestDischargeType.java
+++ b/src/test/java/org/isf/disctype/test/TestDischargeType.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.disctype.test;
 

--- a/src/test/java/org/isf/disctype/test/Tests.java
+++ b/src/test/java/org/isf/disctype/test/Tests.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.disctype.test;
 

--- a/src/test/java/org/isf/disease/test/TestDisease.java
+++ b/src/test/java/org/isf/disease/test/TestDisease.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.disease.test;
 

--- a/src/test/java/org/isf/disease/test/Tests.java
+++ b/src/test/java/org/isf/disease/test/Tests.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.disease.test;
 

--- a/src/test/java/org/isf/distype/test/TestDiseaseType.java
+++ b/src/test/java/org/isf/distype/test/TestDiseaseType.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.distype.test;
 

--- a/src/test/java/org/isf/distype/test/Tests.java
+++ b/src/test/java/org/isf/distype/test/Tests.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.distype.test;
 

--- a/src/test/java/org/isf/dlvrrestype/test/TestDeliveryResultType.java
+++ b/src/test/java/org/isf/dlvrrestype/test/TestDeliveryResultType.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.dlvrrestype.test;
 

--- a/src/test/java/org/isf/dlvrrestype/test/Tests.java
+++ b/src/test/java/org/isf/dlvrrestype/test/Tests.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.dlvrrestype.test;
 

--- a/src/test/java/org/isf/dlvrtype/test/TestDeliveryType.java
+++ b/src/test/java/org/isf/dlvrtype/test/TestDeliveryType.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.dlvrtype.test;
 

--- a/src/test/java/org/isf/dlvrtype/test/Tests.java
+++ b/src/test/java/org/isf/dlvrtype/test/Tests.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.dlvrtype.test;
 

--- a/src/test/java/org/isf/exa/test/TestExam.java
+++ b/src/test/java/org/isf/exa/test/TestExam.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.exa.test;
 

--- a/src/test/java/org/isf/exa/test/TestExamRow.java
+++ b/src/test/java/org/isf/exa/test/TestExamRow.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.exa.test;
 

--- a/src/test/java/org/isf/exa/test/Tests.java
+++ b/src/test/java/org/isf/exa/test/Tests.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.exa.test;
 

--- a/src/test/java/org/isf/examination/test/TestPatientExamination.java
+++ b/src/test/java/org/isf/examination/test/TestPatientExamination.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.examination.test;
 

--- a/src/test/java/org/isf/examination/test/Tests.java
+++ b/src/test/java/org/isf/examination/test/Tests.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.examination.test;
 

--- a/src/test/java/org/isf/exatype/test/TestExamType.java
+++ b/src/test/java/org/isf/exatype/test/TestExamType.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.exatype.test;
 

--- a/src/test/java/org/isf/exatype/test/Tests.java
+++ b/src/test/java/org/isf/exatype/test/Tests.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.exatype.test;
 

--- a/src/test/java/org/isf/generaldata/GeneralDataTest.java
+++ b/src/test/java/org/isf/generaldata/GeneralDataTest.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.generaldata;
 

--- a/src/test/java/org/isf/hospital/test/TestHospital.java
+++ b/src/test/java/org/isf/hospital/test/TestHospital.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.hospital.test;
 

--- a/src/test/java/org/isf/hospital/test/Tests.java
+++ b/src/test/java/org/isf/hospital/test/Tests.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.hospital.test;
 

--- a/src/test/java/org/isf/lab/test/TestLaboratory.java
+++ b/src/test/java/org/isf/lab/test/TestLaboratory.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.lab.test;
 

--- a/src/test/java/org/isf/lab/test/TestLaboratoryRow.java
+++ b/src/test/java/org/isf/lab/test/TestLaboratoryRow.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.lab.test;
 

--- a/src/test/java/org/isf/lab/test/Tests.java
+++ b/src/test/java/org/isf/lab/test/Tests.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.lab.test;
 

--- a/src/test/java/org/isf/malnutrition/test/TestMalnutrition.java
+++ b/src/test/java/org/isf/malnutrition/test/TestMalnutrition.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.malnutrition.test;
 

--- a/src/test/java/org/isf/malnutrition/test/Tests.java
+++ b/src/test/java/org/isf/malnutrition/test/Tests.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.malnutrition.test;
 

--- a/src/test/java/org/isf/medicals/test/TestMedical.java
+++ b/src/test/java/org/isf/medicals/test/TestMedical.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.medicals.test;
 

--- a/src/test/java/org/isf/medicals/test/Tests.java
+++ b/src/test/java/org/isf/medicals/test/Tests.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.medicals.test;
 

--- a/src/test/java/org/isf/medicalstock/test/TestLot.java
+++ b/src/test/java/org/isf/medicalstock/test/TestLot.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.medicalstock.test;
 

--- a/src/test/java/org/isf/medicalstock/test/TestMovement.java
+++ b/src/test/java/org/isf/medicalstock/test/TestMovement.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.medicalstock.test;
 

--- a/src/test/java/org/isf/medicalstock/test/Tests.java
+++ b/src/test/java/org/isf/medicalstock/test/Tests.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.medicalstock.test;
 

--- a/src/test/java/org/isf/medicalstockward/test/TestMedicalWard.java
+++ b/src/test/java/org/isf/medicalstockward/test/TestMedicalWard.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.medicalstockward.test;
 

--- a/src/test/java/org/isf/medicalstockward/test/TestMovementWard.java
+++ b/src/test/java/org/isf/medicalstockward/test/TestMovementWard.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.medicalstockward.test;
 

--- a/src/test/java/org/isf/medicalstockward/test/Tests.java
+++ b/src/test/java/org/isf/medicalstockward/test/Tests.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.medicalstockward.test;
 

--- a/src/test/java/org/isf/medstockmovtype/test/TestMovementType.java
+++ b/src/test/java/org/isf/medstockmovtype/test/TestMovementType.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.medstockmovtype.test;
 

--- a/src/test/java/org/isf/medstockmovtype/test/Tests.java
+++ b/src/test/java/org/isf/medstockmovtype/test/Tests.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.medstockmovtype.test;
 

--- a/src/test/java/org/isf/medtype/test/TestMedicalType.java
+++ b/src/test/java/org/isf/medtype/test/TestMedicalType.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.medtype.test;
 

--- a/src/test/java/org/isf/medtype/test/Tests.java
+++ b/src/test/java/org/isf/medtype/test/Tests.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.medtype.test;
 

--- a/src/test/java/org/isf/menu/test/TestGroupMenu.java
+++ b/src/test/java/org/isf/menu/test/TestGroupMenu.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.menu.test;
 

--- a/src/test/java/org/isf/menu/test/TestUser.java
+++ b/src/test/java/org/isf/menu/test/TestUser.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.menu.test;
 

--- a/src/test/java/org/isf/menu/test/TestUserGroup.java
+++ b/src/test/java/org/isf/menu/test/TestUserGroup.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.menu.test;
 

--- a/src/test/java/org/isf/menu/test/TestUserMenu.java
+++ b/src/test/java/org/isf/menu/test/TestUserMenu.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.menu.test;
 

--- a/src/test/java/org/isf/menu/test/Tests.java
+++ b/src/test/java/org/isf/menu/test/Tests.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.menu.test;
 

--- a/src/test/java/org/isf/menu/test/UserBrowsingManagerTest.java
+++ b/src/test/java/org/isf/menu/test/UserBrowsingManagerTest.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.menu.test;
 

--- a/src/test/java/org/isf/opd/test/TestOpd.java
+++ b/src/test/java/org/isf/opd/test/TestOpd.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.opd.test;
 

--- a/src/test/java/org/isf/opd/test/Tests.java
+++ b/src/test/java/org/isf/opd/test/Tests.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.opd.test;
 

--- a/src/test/java/org/isf/operation/test/TestOperation.java
+++ b/src/test/java/org/isf/operation/test/TestOperation.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.operation.test;
 

--- a/src/test/java/org/isf/operation/test/TestOperationRow.java
+++ b/src/test/java/org/isf/operation/test/TestOperationRow.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.operation.test;
 

--- a/src/test/java/org/isf/operation/test/Tests.java
+++ b/src/test/java/org/isf/operation/test/Tests.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.operation.test;
 

--- a/src/test/java/org/isf/opetype/test/TestOperationType.java
+++ b/src/test/java/org/isf/opetype/test/TestOperationType.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.opetype.test;
 

--- a/src/test/java/org/isf/opetype/test/Tests.java
+++ b/src/test/java/org/isf/opetype/test/Tests.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.opetype.test;
 

--- a/src/test/java/org/isf/patient/TestMergePatient.java
+++ b/src/test/java/org/isf/patient/TestMergePatient.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.patient;
 

--- a/src/test/java/org/isf/patient/TestPatientMergedEventListener.java
+++ b/src/test/java/org/isf/patient/TestPatientMergedEventListener.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.patient;
 

--- a/src/test/java/org/isf/patient/test/TestPatient.java
+++ b/src/test/java/org/isf/patient/test/TestPatient.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.patient.test;
 

--- a/src/test/java/org/isf/patient/test/Tests.java
+++ b/src/test/java/org/isf/patient/test/Tests.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.patient.test;
 

--- a/src/test/java/org/isf/patvac/test/TestPatientVaccine.java
+++ b/src/test/java/org/isf/patvac/test/TestPatientVaccine.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.patvac.test;
 

--- a/src/test/java/org/isf/patvac/test/Tests.java
+++ b/src/test/java/org/isf/patvac/test/Tests.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.patvac.test;
 

--- a/src/test/java/org/isf/pregtreattype/test/TestPregnantTreatmentType.java
+++ b/src/test/java/org/isf/pregtreattype/test/TestPregnantTreatmentType.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.pregtreattype.test;
 

--- a/src/test/java/org/isf/pregtreattype/test/Tests.java
+++ b/src/test/java/org/isf/pregtreattype/test/Tests.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.pregtreattype.test;
 

--- a/src/test/java/org/isf/priceslist/test/TestPrice.java
+++ b/src/test/java/org/isf/priceslist/test/TestPrice.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.priceslist.test;
 

--- a/src/test/java/org/isf/priceslist/test/TestPriceList.java
+++ b/src/test/java/org/isf/priceslist/test/TestPriceList.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.priceslist.test;
 

--- a/src/test/java/org/isf/priceslist/test/Tests.java
+++ b/src/test/java/org/isf/priceslist/test/Tests.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.priceslist.test;
 

--- a/src/test/java/org/isf/pricesothers/test/TestPricesOthers.java
+++ b/src/test/java/org/isf/pricesothers/test/TestPricesOthers.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.pricesothers.test;
 

--- a/src/test/java/org/isf/pricesothers/test/Tests.java
+++ b/src/test/java/org/isf/pricesothers/test/Tests.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.pricesothers.test;
 

--- a/src/test/java/org/isf/sms/test/TestSms.java
+++ b/src/test/java/org/isf/sms/test/TestSms.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.sms.test;
 

--- a/src/test/java/org/isf/sms/test/Tests.java
+++ b/src/test/java/org/isf/sms/test/Tests.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.sms.test;
 

--- a/src/test/java/org/isf/supplier/test/TestSupplier.java
+++ b/src/test/java/org/isf/supplier/test/TestSupplier.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.supplier.test;
 

--- a/src/test/java/org/isf/supplier/test/Tests.java
+++ b/src/test/java/org/isf/supplier/test/Tests.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.supplier.test;
 

--- a/src/test/java/org/isf/therapy/test/TestTherapy.java
+++ b/src/test/java/org/isf/therapy/test/TestTherapy.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.therapy.test;
 

--- a/src/test/java/org/isf/therapy/test/Tests.java
+++ b/src/test/java/org/isf/therapy/test/Tests.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.therapy.test;
 

--- a/src/test/java/org/isf/utils/db/TestBCrypt.java
+++ b/src/test/java/org/isf/utils/db/TestBCrypt.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.utils.db;
 

--- a/src/test/java/org/isf/utils/file/TestFileTools.java
+++ b/src/test/java/org/isf/utils/file/TestFileTools.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.utils.file;
 

--- a/src/test/java/org/isf/utils/time/TestTimeTools.java
+++ b/src/test/java/org/isf/utils/time/TestTimeTools.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.utils.time;
 

--- a/src/test/java/org/isf/utils/validator/TestEmailValidator.java
+++ b/src/test/java/org/isf/utils/validator/TestEmailValidator.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.utils.validator;
 

--- a/src/test/java/org/isf/vaccine/test/TestVaccine.java
+++ b/src/test/java/org/isf/vaccine/test/TestVaccine.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.vaccine.test;
 

--- a/src/test/java/org/isf/vaccine/test/Tests.java
+++ b/src/test/java/org/isf/vaccine/test/Tests.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.vaccine.test;
 

--- a/src/test/java/org/isf/vactype/test/TestVaccineType.java
+++ b/src/test/java/org/isf/vactype/test/TestVaccineType.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.vactype.test;
 

--- a/src/test/java/org/isf/vactype/test/Tests.java
+++ b/src/test/java/org/isf/vactype/test/Tests.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.vactype.test;
 

--- a/src/test/java/org/isf/visits/test/TestVisit.java
+++ b/src/test/java/org/isf/visits/test/TestVisit.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.visits.test;
 

--- a/src/test/java/org/isf/visits/test/Tests.java
+++ b/src/test/java/org/isf/visits/test/Tests.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.visits.test;
 

--- a/src/test/java/org/isf/ward/test/TestWard.java
+++ b/src/test/java/org/isf/ward/test/TestWard.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.ward.test;
 

--- a/src/test/java/org/isf/ward/test/Tests.java
+++ b/src/test/java/org/isf/ward/test/Tests.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.ward.test;
 


### PR DESCRIPTION
Change: `If not, see <http://www.gnu.org/licenses/>`
To: `If not, see <https://www.gnu.org/licenses/>`

Also corrected the import ordering of one file