### PR TITLE
Chore: update to Spring 5.3.27

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 		<oh.version>1.12.1-SNAPSHOT</oh.version>
 		<java.version>11</java.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<spring.framework.version>5.3.26</spring.framework.version>
+		<spring.framework.version>5.3.27</spring.framework.version>
 		<spring.boot.version>2.7.10</spring.boot.version>
 		<jasperreports.version>6.20.1</jasperreports.version>
 		<spring.cloud.starter.openfeign.version>3.1.6</spring.cloud.starter.openfeign.version>


### PR DESCRIPTION
Release Notes:  https://github.com/spring-projects/spring-framework/releases/tag/v5.3.27

This update fixes the following CVE:

[cve-2023-20863: Spring Expression DoS Vulnerability](https://spring.io/security/cve-2023-20863)