### PR TITLE
Chore: Upgrade to Spring Boot 2.7.11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 		<java.version>11</java.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<spring.framework.version>5.3.27</spring.framework.version>
-		<spring.boot.version>2.7.10</spring.boot.version>
+		<spring.boot.version>2.7.11</spring.boot.version>
 		<jasperreports.version>6.20.1</jasperreports.version>
 		<spring.cloud.starter.openfeign.version>3.1.6</spring.cloud.starter.openfeign.version>
 		<license.maven.plugin.version>4.2</license.maven.plugin.version>
@@ -251,7 +251,7 @@
 		<dependency>
 			<groupId>com.mysql</groupId>
 			<artifactId>mysql-connector-j</artifactId>
-			<version>8.0.32</version>
+			<version>8.0.33</version>
 		</dependency>
 		<dependency>
 			<groupId>org.rxtx</groupId>


### PR DESCRIPTION
Release Notes: https://github.com/spring-projects/spring-boot/releases/tag/v2.7.11
Updated one dependency that is in Core project (mysql)

This release includes a fix for [CVE-2023-20873: Security Bypass With Wildcard Pattern Matching on Cloud Foundry](http://spring.io/security/cve-2023-20873).