### PR TITLE
Chore: combine recent dependabot updates together for testing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<spring.framework.version>5.3.27</spring.framework.version>
 		<spring.boot.version>2.7.11</spring.boot.version>
-		<jasperreports.version>6.20.1</jasperreports.version>
+		<jasperreports.version>6.20.3</jasperreports.version>
 		<spring.cloud.starter.openfeign.version>3.1.6</spring.cloud.starter.openfeign.version>
 		<license.maven.plugin.version>4.2</license.maven.plugin.version>
 	</properties>
@@ -387,7 +387,7 @@
 		<dependency>
 			<groupId>org.springframework.data</groupId>
 			<artifactId>spring-data-jpa</artifactId>
-			<version>2.7.10</version>
+			<version>2.7.11</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -516,12 +516,12 @@
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-annotations</artifactId>
-			<version>2.14.2</version>
+			<version>2.15.0</version>
 		</dependency>
 		<dependency>
 			<groupId>com.fasterxml.jackson.module</groupId>
 			<artifactId>jackson-modules-java8</artifactId>
-			<version>2.14.2</version>
+			<version>2.15.0</version>
 			<type>pom</type>
 			<scope>runtime</scope>
 		</dependency>


### PR DESCRIPTION
Combine updates for jackson-annotations, jackson-modules-java8, jasperreports, and spring-data-jpa together for testing.

`mvn clean test` was successful. 