### PR TITLE
OP-1067 OHExceptionMessage: Description should come from the argument and not be hardcoded

### DIFF
--- a/src/main/java/org/isf/utils/exception/model/OHExceptionMessage.java
+++ b/src/main/java/org/isf/utils/exception/model/OHExceptionMessage.java
@@ -50,7 +50,7 @@ public class OHExceptionMessage implements Serializable{
 	public OHExceptionMessage(String title, ErrorDescription description, String message, OHSeverityLevel level) {
 		super();
 		this.title = title;
-		this.description = ErrorDescription.PASSWORD_TOO_SHORT;
+		this.description = description;
 		this.message = message;
 		this.level = level;
 	}


### PR DESCRIPTION
It was probably a typo when the new constructor was created as the only place where it is being used is where ErrorDescription.PASSWORD_TOO_SHORT is passed as description.

I verfified that constructor is not used anywhere else in openhospital-core, openhospital-api or openhospital-gui, so no other code is affected.