### PR TITLE
OP-1083: remove deprecated method from org.isf.patient.manager.PatientBrowserManager

### DIFF
--- a/src/main/java/org/isf/patient/manager/PatientBrowserManager.java
+++ b/src/main/java/org/isf/patient/manager/PatientBrowserManager.java
@@ -92,19 +92,6 @@ public class PatientBrowserManager {
 	}
 
 	/**
-	 * Method that gets a Patient by his/her name
-	 *
-	 * @param name
-	 * @return the Patient that match specified name (could be null)
-	 * @throws OHServiceException
-	 * @deprecated use getPatient(Integer code) for one patient or getPatientsByOneOfFieldsLike(String regex) for a list
-	 */
-	@Deprecated
-	public Patient getPatientByName(String name) throws OHServiceException {
-		return ioOperations.getPatient(name);
-	}
-
-	/**
 	 * Method that get a Patient list by his/her name
 	 *
 	 * @param params

--- a/src/test/java/org/isf/patient/test/Tests.java
+++ b/src/test/java/org/isf/patient/test/Tests.java
@@ -376,19 +376,6 @@ public class Tests extends OHCoreTestCase {
 	}
 
 	@Test
-	public void testMgrGetPatientByName() throws Exception {
-		Integer code = setupTestPatient(false);
-		Patient foundPatient = patientIoOperation.getPatient(code);
-		Patient patient = patientBrowserManager.getPatientByName(foundPatient.getName());
-		assertThat(patient.getName()).isEqualTo(foundPatient.getName());
-	}
-
-	@Test
-	public void testMgrGetPatientByNameDoesNotExist() throws Exception {
-		assertThat(patientBrowserManager.getPatientByName("someUnusualNameThatWillNotBeFound")).isNull();
-	}
-
-	@Test
 	public void testMgrGetPatientById() throws Exception {
 		Integer code = setupTestPatient(false);
 		Patient foundPatient = patientIoOperation.getPatient(code);


### PR DESCRIPTION
See OP-1083

Rebuilt Core and then successfully rebuilt GUI.    There are corresponding changes required in API repo that in addition fix some "FIXME" comments