### PR TITLE
OP-1085: remove deprecated method from org.isf.visits.service.VisitsI…

### DIFF
--- a/src/main/java/org/isf/visits/service/VisitsIoOperations.java
+++ b/src/main/java/org/isf/visits/service/VisitsIoOperations.java
@@ -110,20 +110,6 @@ public class VisitsIoOperations {
 	public Visit updateVisit(Visit visit) throws OHServiceException {
 		return repository.save(visit);
 	}
-	
-	/**
-	 * Deletes all {@link Visit}s related to a patID
-	 * 
-	 * @param patID - the {@link Patient} ID
-	 * @return <code>true</code> if the list has been deleted, <code>false</code> otherwise
-	 * @throws OHServiceException
-	 * @deprecated OP-713 raised the need of a strong link with OPDs so deletions like this one could be done safely.
-	 * 				Before that it is not possible to use this method safely.
-	 */
-	public boolean deleteAllVisits(int patID) throws OHServiceException {
-		repository.deleteByPatient_Code(patID);
-        return true;
-	}
 
 	/**
 	 * Checks if the code is already in use

--- a/src/test/java/org/isf/visits/test/Tests.java
+++ b/src/test/java/org/isf/visits/test/Tests.java
@@ -152,17 +152,6 @@ public class Tests extends OHCoreTestCase {
 	}
 
 	@Test
-	public void testIoDeleteVisit() throws Exception {
-		int id = setupTestVisit(false);
-		Visit foundVisit = visitsIoOperation.findVisit(id);
-		boolean result = visitsIoOperation.deleteAllVisits(foundVisit.getPatient().getCode());
-
-		assertThat(result).isTrue();
-		result = visitsIoOperation.isCodePresent(id);
-		assertThat(result).isFalse();
-	}
-
-	@Test
 	public void testIoFindVisit() throws Exception {
 		int id = setupTestVisit(false);
 		Visit result = visitsIoOperation.findVisit(id);


### PR DESCRIPTION
See OP-1085

Rebuilt Core and ran all tests. Then successfully rebuilt GUI and ran tests (after making class name changes that are pending).    Then rebuilt API repo and ran all tests (again after making class name changes that are pending).