### PR TITLE
OP-1088 Remove deprecated methods from org.isf.accounting.service.AccountingIoOperation

### DIFF
--- a/src/main/java/org/isf/accounting/service/AccountingIoOperations.java
+++ b/src/main/java/org/isf/accounting/service/AccountingIoOperations.java
@@ -202,19 +202,6 @@ public class AccountingIoOperations {
 
 	/**
 	 * Retrieves all the {@link Bill}s for the specified date range.
-	 * @param dateFrom the low date range endpoint, inclusive. 
-	 * @param dateTo the high date range endpoint, inclusive.
-	 * @return a list of retrieved {@link Bill}s.
-	 * @throws OHServiceException if an error occurs retrieving the bill list.
-	 * @deprecated use {@link #getBillsBetweenDates(LocalDateTime, LocalDateTime)}
-	 */
-	@Deprecated
-	public List<Bill> getBills(LocalDateTime dateFrom, LocalDateTime dateTo) throws OHServiceException {
-		return getBillsBetweenDates(dateFrom, dateTo);
-	}
-
-	/**
-	 * Retrieves all the {@link Bill}s for the specified date range.
 	 * @param dateFrom the low date range endpoint, inclusive.
 	 * @param dateTo the high date range endpoint, inclusive.
 	 * @return a list of retrieved {@link Bill}s.
@@ -247,21 +234,6 @@ public class AccountingIoOperations {
 	public List<BillPayments> getPayments(List<Bill> bills) throws OHServiceException {
 		return billPaymentRepository.findAllByBillIn(bills);
 	}
-	
-	/**
-	 * Retrieves all billPayments for a given patient in the period dateFrom -> dateTo
-	 * @param dateFrom
-	 * @param dateTo
-	 * @param patient
-	 * @return
-	 * @throws OHServiceException
-	 * @deprecated use {@link #getPaymentsBetweenDatesWherePatient(LocalDateTime, LocalDateTime, Patient)}
-	 */
-	@Deprecated
-	public List<BillPayments> getPayments(LocalDateTime dateFrom, LocalDateTime dateTo, Patient patient)
-			throws OHServiceException {
-		return getPaymentsBetweenDatesWherePatient(dateFrom, dateTo, patient);
-	}
 
 	/**
 	 * Retrieves all billPayments for a given patient in the period dateFrom -> dateTo
@@ -274,20 +246,6 @@ public class AccountingIoOperations {
 	public List<BillPayments> getPaymentsBetweenDatesWherePatient(LocalDateTime dateFrom, LocalDateTime dateTo, Patient patient)
 			throws OHServiceException {
 		return billPaymentRepository.findByDateAndPatient(TimeTools.getBeginningOfDay(dateFrom), TimeTools.getBeginningOfNextDay(dateTo), patient.getCode());
-	}
-
-	/**
-	 * Retrieves all the bills for a given patient in the period dateFrom -> dateTo
-	 * @param dateFrom
-	 * @param dateTo
-	 * @param patient
-	 * @return the bill list
-	 * @throws OHServiceException
-	 * @deprecated use {@link #getBillsBetweenDatesWherePatient(LocalDateTime, LocalDateTime, Patient)}
-	 */
-	@Deprecated
-	public List<Bill> getBills(LocalDateTime dateFrom, LocalDateTime dateTo, Patient patient) throws OHServiceException {
-		return getBillsBetweenDatesWherePatient(dateFrom, dateTo, patient);
 	}
 
 	/**
@@ -330,23 +288,6 @@ public class AccountingIoOperations {
 	 */
 	public List<BillItems> getDistictsBillItems() throws OHServiceException {
 		return billItemsRepository.findAllGroupByDescription();
-	}
-	
-	/**
-	 * Return the bill list which date between dateFrom and dateTo and containing given billItem
-	 * <p>
-	 * added by u2g
-	 *
-	 * @param dateFrom
-	 * @param dateTo
-	 * @param billItem
-	 * @return the bill list
-	 * @throws OHServiceException
-	 * @deprecated use {@link #getBillsBetweenDatesWhereBillItem(LocalDateTime, LocalDateTime, BillItems)}
-	 */
-	@Deprecated
-	public List<Bill> getBills(LocalDateTime dateFrom, LocalDateTime dateTo, BillItems billItem) throws OHServiceException {
-		return getBillsBetweenDatesWhereBillItem(dateFrom, dateTo, billItem);
 	}
 
 	/**

--- a/src/test/java/org/isf/accounting/test/Tests.java
+++ b/src/test/java/org/isf/accounting/test/Tests.java
@@ -254,7 +254,7 @@ public class Tests extends OHCoreTestCase {
 		Bill foundBill = accountingBillIoOperationRepository.findById(id).get();
 		LocalDateTime dateFrom = foundBill.getDate().minusYears(1);
 		LocalDateTime dateTo = TimeTools.getNow();
-		List<Bill> billItems = accountingIoOperation.getBills(dateFrom, dateTo, foundBill.getBillPatient());
+		List<Bill> billItems = accountingIoOperation.getBillsBetweenDatesWherePatient(dateFrom, dateTo, foundBill.getBillPatient());
 		assertThat(billItems).isNotEmpty();
 		assertThat(billItems.get(0).getAmount()).isCloseTo(foundBill.getAmount(), offset(0.1));
 	}
@@ -340,7 +340,7 @@ public class Tests extends OHCoreTestCase {
 		Bill foundBill = accountingBillIoOperationRepository.findById(id).get();
 		LocalDateTime dateFrom = foundBill.getDate().minusYears(1);
 		LocalDateTime dateTo = TimeTools.getNow();
-		List<Bill> bills = accountingIoOperation.getBills(dateFrom, dateTo);
+		List<Bill> bills = accountingIoOperation.getBillsBetweenDates(dateFrom, dateTo);
 
 		assertThat(bills).contains(foundBill);
 	}
@@ -353,29 +353,29 @@ public class Tests extends OHCoreTestCase {
 		int id = setupTestBill(false);
 		Bill foundBill = accountingBillIoOperationRepository.findById(id).get();
 
-		List<Bill> bills = accountingIoOperation.getBills(dateFrom, dateTo);
+		List<Bill> bills = accountingIoOperation.getBillsBetweenDates(dateFrom, dateTo);
 		assertThat(bills).contains(foundBill);
 
-		bills = accountingIoOperation.getBills(LocalDateTime.of(10, 1, 1, 0, 0, 0), dateFrom);
+		bills = accountingIoOperation.getBillsBetweenDates(LocalDateTime.of(10, 1, 1, 0, 0, 0), dateFrom);
 		assertThat(bills).doesNotContain(foundBill);
 
-		bills = accountingIoOperation.getBills(dateTo, LocalDateTime.of(11, 1, 1, 0, 0, 0));
+		bills = accountingIoOperation.getBillsBetweenDates(dateTo, LocalDateTime.of(11, 1, 1, 0, 0, 0));
 		assertThat(bills).doesNotContain(foundBill);
 
 		id = setupTestBillItems(false);
 		BillItems foundBillItem = accountingBillItemsIoOperationRepository.findById(id).get();
 		foundBill = accountingBillIoOperationRepository.findById(foundBillItem.getBill().getId()).get();
 
-		bills = accountingIoOperation.getBills(dateFrom, dateTo, foundBillItem);
+		bills = accountingIoOperation.getBillsBetweenDatesWhereBillItem(dateFrom, dateTo, foundBillItem);
 		assertThat(bills).contains(foundBill);
 
-		bills = accountingIoOperation.getBills(dateFrom, dateTo, (BillItems) null);
+		bills = accountingIoOperation.getBillsBetweenDatesWhereBillItem(dateFrom, dateTo, (BillItems) null);
 		assertThat(bills).contains(foundBill);
 
 		id = setupTestBillItems(true);
 		foundBillItem = accountingBillItemsIoOperationRepository.findById(id).get();
 
-		bills = accountingIoOperation.getBills(dateFrom, dateTo, foundBillItem);
+		bills = accountingIoOperation.getBillsBetweenDatesWhereBillItem(dateFrom, dateTo, foundBillItem);
 		assertThat(bills).contains(foundBill);
 	}
 
@@ -480,7 +480,7 @@ public class Tests extends OHCoreTestCase {
 		BillPayments foundBillPayment = accountingBillPaymentIoOperationRepository.findById(id).get();
 		LocalDateTime dateFrom = LocalDateTime.of(1, 3, 2, 0, 0, 0, 0);
 		LocalDateTime dateTo = TimeTools.getNow();
-		List<BillPayments> billItems = accountingIoOperation.getPayments(dateFrom, dateTo, foundBillPayment.getBill().getBillPatient());
+		List<BillPayments> billItems = accountingIoOperation.getPaymentsBetweenDatesWherePatient(dateFrom, dateTo, foundBillPayment.getBill().getBillPatient());
 		assertThat(billItems).isNotEmpty();
 		assertThat(billItems.get(0).getAmount()).isCloseTo(foundBillPayment.getAmount(), offset(0.1));
 	}


### PR DESCRIPTION
See OP-1088

Removed methods, rebuilt the jar, ran the unit tests successfully.

Used new jar to rebuild GUI and API without errors. Ran all the API tests successfully.