### PR TITLE
OP-1087 Remove deprecated methods from org.isf.accounting.manager.BillBrowserManager

### DIFF
--- a/src/main/java/org/isf/accounting/manager/BillBrowserManager.java
+++ b/src/main/java/org/isf/accounting/manager/BillBrowserManager.java
@@ -90,18 +90,6 @@ public class BillBrowserManager {
 			throw new OHDataValidationException(errors);
 		}
 	}
-	
-	/**
-	 * Returns all the stored {@link BillItems}.
-	 * @return a list of {@link BillItems} or null if an error occurs.
-	 * @throws OHServiceException 
-	 * @deprecated this method should always be called with a parameter.
-	 * See {@link #getItems(int) getItems} method.
-	 */
-	@Deprecated
-	public List<BillItems> getItems() throws OHServiceException {
-		return ioOperations.getItems(0);
-	}
 
 	/**
 	 * Retrieves all the {@link BillItems} associated to the passed {@link Bill} id.
@@ -139,29 +127,14 @@ public class BillBrowserManager {
 	public List<BillPayments> getPayments(LocalDateTime dateFrom, LocalDateTime dateTo,Patient patient) throws OHServiceException {
 		return ioOperations.getPaymentsBetweenDatesWherePatient(dateFrom, dateTo, patient);
 	}
-	
-	/**
-	 * Retrieves all the stored {@link BillPayments}.
-	 * @return a list of bill payments or <code>null</code> if an error occurred.
-	 * @throws OHServiceException
-	 * @deprecated this method should always be called with a parameter.
-	 * See {@link #getPayments(int) getPayments} method.
-	 */
-	@Deprecated
-	public List<BillPayments> getPayments() throws OHServiceException {
-		return ioOperations.getPayments(0);
-	}
 
 	/**
 	 * Gets all the {@link BillPayments} for the specified {@link Bill}.
 	 * @param billID the bill id.
-	 * @return a list of {@link BillPayments} or <code>null</code> if an error occurred.
+	 * @return a list of {@link BillPayments}
 	 * @throws OHServiceException 
 	 */
 	public List<BillPayments> getPayments(int billID) throws OHServiceException {
-		if (billID == 0) {
-			return new ArrayList<>();
-		}
 		return ioOperations.getPayments(billID);
 	}
 	
@@ -265,17 +238,6 @@ public class BillBrowserManager {
 		return ioOperations.getPendingBills(patID);
 	}
 
-	/**
-	 * Get all the {@link Bill}s.
-	 * @return a list of bills or <code>null</code> if an error occurred.
-	 * @throws OHServiceException
-	 * @deprecated this method should not be called for its potentially huge resultset
-	 */
-	@Deprecated
-	public List<Bill> getBills() throws OHServiceException {
-		return ioOperations.getBills();
-	}
-	
 	/**
 	 * Get the {@link Bill} with specified billID
 	 * @param billID

--- a/src/test/java/org/isf/accounting/test/Tests.java
+++ b/src/test/java/org/isf/accounting/test/Tests.java
@@ -492,7 +492,7 @@ public class Tests extends OHCoreTestCase {
 		assertThat(billItems).isEmpty();
 		billItems = billBrowserManager.getItems(99999);
 		assertThat(billItems).isEmpty();
-		billItems = billBrowserManager.getItems();
+		billItems = billBrowserManager.getItems(id);
 		assertThat(billItems).hasSize(1);
 	}
 
@@ -511,17 +511,9 @@ public class Tests extends OHCoreTestCase {
 	public void mgrGetAllPayments() throws Exception {
 		int id = setupTestBillPayments(false);
 		BillPayments foundBillPayment = accountingBillPaymentIoOperationRepository.findById(id).get();
-		List<BillPayments> billItems = billBrowserManager.getPayments();
+		List<BillPayments> billItems = billBrowserManager.getPayments(0);  // get all
 		assertThat(billItems).isNotEmpty();
 		assertThat(billItems.get(0).getAmount()).isCloseTo(foundBillPayment.getAmount(), offset(0.1));
-	}
-
-	@Test
-	public void mgrGetAllPaymentsWithZero() throws Exception {
-		int id = setupTestBillPayments(false);
-		BillPayments foundBillPayment = accountingBillPaymentIoOperationRepository.findById(id).get();
-		List<BillPayments> billItems = billBrowserManager.getPayments(0);
-		assertThat(billItems).isEmpty();
 	}
 
 	@Test
@@ -716,9 +708,6 @@ public class Tests extends OHCoreTestCase {
 		foundBillItem = accountingBillItemsIoOperationRepository.findById(id).get();
 
 		bills = billBrowserManager.getBills(dateFrom, dateTo, foundBillItem);
-		assertThat(bills).contains(foundBill);
-
-		bills = billBrowserManager.getBills();
 		assertThat(bills).contains(foundBill);
 	}
 


### PR DESCRIPTION
Removed methods, rebuilt the jar, ran the unit tests.

Used new jar to rebuild GUI and API without errors. Ran all the API tests successfully.

Note:
Had to change the body to allow for the parameter zero to get all payments as that is what is supported at the IO level of the code:
`public List<BillPayments> getPayments(int billID) throws OHServiceException`

