### PR TITLE
OP-1090 Remove deprecated methods from org.isf.medicalstockward.manager.MovWardBrowserManager

### DIFF
--- a/src/main/java/org/isf/medicalstockward/manager/MovWardBrowserManager.java
+++ b/src/main/java/org/isf/medicalstockward/manager/MovWardBrowserManager.java
@@ -75,19 +75,6 @@ public class MovWardBrowserManager {
 	}
 
 	/**
-	 * Gets all the {@link MovementWard}s.
-	 * If an error occurs a message error is shown and the <code>null</code> value is returned.
-	 *
-	 * @return all the retrieved movements ward.
-	 * @throws OHServiceException
-	 * @deprecated
-	 */
-	@Deprecated
-	public List<MovementWard> getMovementWard() throws OHServiceException {
-		return ioOperations.getWardMovements(null, null, null);
-	}
-
-	/**
 	 * Gets all the {@link MedicalWard}s associated to the specified ward.
 	 *
 	 * @param wardId the ward id.

--- a/src/test/java/org/isf/medicalstockward/test/Tests.java
+++ b/src/test/java/org/isf/medicalstockward/test/Tests.java
@@ -484,15 +484,6 @@ public class Tests extends OHCoreTestCase {
 	}
 
 	@Test
-	public void testMgrGetMovementWard() throws Exception {
-		int code = setupTestMovementWard(false);
-		MovementWard foundMovement = movementWardIoOperationRepository.findById(code).get();
-		List<MovementWard> movements = movWardBrowserManager.getMovementWard();
-		assertThat(movements).hasSize(1);
-		assertThat(movements.get(0).getCode()).isEqualTo(foundMovement.getCode());
-	}
-
-	@Test
 	public void testMgrGetMedicalsWard() throws Exception {
 		MedicalWardId code = setupTestMedicalWard(false);
 		MedicalWard foundMedicalWard = medicalStockWardIoOperationRepository.findOneWhereCodeAndMedical(code.getWard().getCode(), code.getMedical().getCode());


### PR DESCRIPTION
See OP-1090

Removed methods, rebuilt the jar, ran the unit tests.

Used new jar and rebuilt GUI and there were no issues.

Used new jar and rebuilt API and there were errors.   I commented out three methods that were causing problems.   I checked the UI code base and it appears that these "/medicalstockward" endpoints are not being used but only defined.   I left them in the API code for easier updating of the API and UI code bases but those more familiar with the UI.

See https://github.com/informatici/openhospital-api/pull/271
