### PR TITLE
Chore: remove deprecated method usage

### DIFF
--- a/src/test/java/org/isf/admission/test/Tests.java
+++ b/src/test/java/org/isf/admission/test/Tests.java
@@ -558,7 +558,7 @@ public class Tests extends OHCoreTestCase {
 		foundAdmission.setPatient(null);
 		assertThat(foundAdmission.getPatient()).isNull();
 		foundAdmission.setPatient(foundPatient);
-		assertThat(foundAdmission.getPatient()).isEqualToComparingFieldByField(foundPatient);
+		assertThat(foundAdmission.getPatient()).usingRecursiveComparison().isEqualTo(foundPatient);
 		int lock = foundAdmission.getLock();
 		foundAdmission.setLock(-1);
 		assertThat(foundAdmission.getLock()).isEqualTo(-1);
@@ -583,12 +583,12 @@ public class Tests extends OHCoreTestCase {
 		admittedPatient.setPatient(null);
 		assertThat(admittedPatient.getPatient()).isNull();
 		admittedPatient.setPatient(patient);
-		assertThat(admittedPatient.getPatient()).isEqualToComparingFieldByField(patient);
+		assertThat(admittedPatient.getPatient()).usingRecursiveComparison().isEqualTo(patient);
 		Admission admission = admittedPatient.getAdmission();
 		admittedPatient.setAdmission(null);
 		assertThat(admittedPatient.getAdmission()).isNull();
 		admittedPatient.setAdmission(admission);
-		assertThat(admittedPatient.getAdmission()).isEqualToComparingFieldByField(admission);
+		assertThat(admittedPatient.getAdmission()).usingRecursiveComparison().isEqualTo(admission);
 	}
 
 	@Test

--- a/src/test/java/org/isf/dicom/test/TestFileSystemDicomManager.java
+++ b/src/test/java/org/isf/dicom/test/TestFileSystemDicomManager.java
@@ -193,18 +193,18 @@ public class TestFileSystemDicomManager extends OHCoreTestCase {
 
 	@Test
 	public void testLoadDetailsLongObject() throws Exception {
-		FileDicom fileDicom = fileSystemDicomManager.loadDetails(new Long(2), 1, "TestSeriesNumber");
+		FileDicom fileDicom = fileSystemDicomManager.loadDetails(Long.valueOf(2), 1, "TestSeriesNumber");
 		testFileDicom.check(fileDicom);
 	}
 
 	@Test
 	public void testLoadDetailsLongObjectSeriesNumberNull() throws Exception {
-		assertThat(fileSystemDicomManager.loadDetails(new Long(2), 1, null)).isNull();
+		assertThat(fileSystemDicomManager.loadDetails(Long.valueOf(2), 1, null)).isNull();
 	}
 
 	@Test
 	public void testLoadDetailsLongObjectSeriesNumberZeroLength() throws Exception {
-		assertThat(fileSystemDicomManager.loadDetails(new Long(2), 1, "     ")).isNull();
+		assertThat(fileSystemDicomManager.loadDetails(Long.valueOf(2), 1, "     ")).isNull();
 	}
 
 	@Test
@@ -214,7 +214,7 @@ public class TestFileSystemDicomManager extends OHCoreTestCase {
 
 	@Test
 	public void testLoadDetailsLongObjectSeriesNumberNullString() throws Exception {
-		assertThat(fileSystemDicomManager.loadDetails(new Long(2), 1, "NuLl")).isNull();
+		assertThat(fileSystemDicomManager.loadDetails(Long.valueOf(2), 1, "NuLl")).isNull();
 	}
 
 	@Test

--- a/src/test/java/org/isf/dicom/test/TestSqlDicomManager.java
+++ b/src/test/java/org/isf/dicom/test/TestSqlDicomManager.java
@@ -97,7 +97,7 @@ public class TestSqlDicomManager extends OHCoreTestCase {
 	@Test
 	public void testLoadDetailsLongObject() throws Exception {
 		long id = setupTestFileDicom(true);
-		FileDicom fileDicom = sqlDicomManager.loadDetails(new Long(id), 0, "TestSeriesNumber");
+		FileDicom fileDicom = sqlDicomManager.loadDetails(Long.valueOf(id), 0, "TestSeriesNumber");
 		testFileDicom.check(fileDicom);
 	}
 

--- a/src/test/java/org/isf/dicom/test/Tests.java
+++ b/src/test/java/org/isf/dicom/test/Tests.java
@@ -126,7 +126,7 @@ public class Tests extends OHCoreTestCase {
 		long code = setupTestFileDicom(false);
 		FileDicom foundFileDicom = dicomIoOperationRepository.findById(code).get();
 		FileDicom dicom = dicomIoOperation.loadDetails(foundFileDicom.getIdFile(), foundFileDicom.getPatId(), foundFileDicom.getDicomSeriesNumber());
-		FileDicom dicom2 = dicomIoOperation.loadDetails(new Long(foundFileDicom.getIdFile()), foundFileDicom.getPatId(), foundFileDicom.getDicomSeriesNumber());
+		FileDicom dicom2 = dicomIoOperation.loadDetails(Long.valueOf(foundFileDicom.getIdFile()), foundFileDicom.getPatId(), foundFileDicom.getDicomSeriesNumber());
 		assertThat(dicom2.getDicomInstanceUID()).isEqualTo(dicom.getDicomInstanceUID());
 		assertThat(dicom.getDicomSeriesDescription()).isEqualTo(foundFileDicom.getDicomSeriesDescription());
 	}

--- a/src/test/java/org/isf/disease/test/Tests.java
+++ b/src/test/java/org/isf/disease/test/Tests.java
@@ -395,7 +395,7 @@ public class Tests extends OHCoreTestCase {
 	}
 
 	private void checkDiseaseIntoDb(String code) throws Exception {
-		Disease foundDisease = diseaseIoOperationRepository.getById(code);
+		Disease foundDisease = diseaseIoOperationRepository.getReferenceById(code);
 		testDisease.check(foundDisease);
 	}
 

--- a/src/test/java/org/isf/distype/test/Tests.java
+++ b/src/test/java/org/isf/distype/test/Tests.java
@@ -78,7 +78,7 @@ public class Tests extends OHCoreTestCase {
 	@Test
 	public void testIoGetDiseaseType() throws Exception {
 		String code = setupTestDiseaseType(false);
-		DiseaseType foundDiseaseType = diseaseTypeIoOperationRepository.getById(code);
+		DiseaseType foundDiseaseType = diseaseTypeIoOperationRepository.getReferenceById(code);
 		List<DiseaseType> diseaseTypes = diseaseTypeIoOperation.getDiseaseTypes();
 		assertThat(diseaseTypes).contains(foundDiseaseType);
 
@@ -87,10 +87,10 @@ public class Tests extends OHCoreTestCase {
 	@Test
 	public void testIoUpdateDiseaseType() throws Exception {
 		String code = setupTestDiseaseType(false);
-		DiseaseType foundDiseaseType = diseaseTypeIoOperationRepository.getById(code);
+		DiseaseType foundDiseaseType = diseaseTypeIoOperationRepository.getReferenceById(code);
 		foundDiseaseType.setDescription("Update");
 		boolean result = diseaseTypeIoOperation.updateDiseaseType(foundDiseaseType);
-		DiseaseType updateDiseaseType = diseaseTypeIoOperationRepository.getById(code);
+		DiseaseType updateDiseaseType = diseaseTypeIoOperationRepository.getReferenceById(code);
 		assertThat(result).isTrue();
 		assertThat(updateDiseaseType.getDescription()).isEqualTo("Update");
 	}
@@ -113,7 +113,7 @@ public class Tests extends OHCoreTestCase {
 	@Test
 	public void testIoDeleteDiseaseType() throws Exception {
 		String code = setupTestDiseaseType(false);
-		DiseaseType foundDiseaseType = diseaseTypeIoOperationRepository.getById(code);
+		DiseaseType foundDiseaseType = diseaseTypeIoOperationRepository.getReferenceById(code);
 		diseaseTypeBrowserManager.deleteDiseaseType(foundDiseaseType);
 		boolean result = diseaseTypeIoOperation.isCodePresent(code);
 		assertThat(result).isFalse();
@@ -122,7 +122,7 @@ public class Tests extends OHCoreTestCase {
 	@Test
 	public void testMgrGetDiseaseType() throws Exception {
 		String code = setupTestDiseaseType(false);
-		DiseaseType foundDiseaseType = diseaseTypeIoOperationRepository.getById(code);
+		DiseaseType foundDiseaseType = diseaseTypeIoOperationRepository.getReferenceById(code);
 		List<DiseaseType> diseaseTypes = diseaseTypeBrowserManager.getDiseaseType();
 		assertThat(diseaseTypes).contains(foundDiseaseType);
 
@@ -131,10 +131,10 @@ public class Tests extends OHCoreTestCase {
 	@Test
 	public void testMgrUpdateDiseaseType() throws Exception {
 		String code = setupTestDiseaseType(false);
-		DiseaseType foundDiseaseType = diseaseTypeIoOperationRepository.getById(code);
+		DiseaseType foundDiseaseType = diseaseTypeIoOperationRepository.getReferenceById(code);
 		foundDiseaseType.setDescription("Update");
 		boolean result = diseaseTypeBrowserManager.updateDiseaseType(foundDiseaseType);
-		DiseaseType updateDiseaseType = diseaseTypeIoOperationRepository.getById(code);
+		DiseaseType updateDiseaseType = diseaseTypeIoOperationRepository.getReferenceById(code);
 		assertThat(result).isTrue();
 		assertThat(updateDiseaseType.getDescription()).isEqualTo("Update");
 	}
@@ -157,7 +157,7 @@ public class Tests extends OHCoreTestCase {
 	@Test
 	public void testMgrDeleteDiseaseType() throws Exception {
 		String code = setupTestDiseaseType(false);
-		DiseaseType foundDiseaseType = diseaseTypeIoOperationRepository.getById(code);
+		DiseaseType foundDiseaseType = diseaseTypeIoOperationRepository.getReferenceById(code);
 		diseaseTypeBrowserManager.deleteDiseaseType(foundDiseaseType);
 		boolean result = diseaseTypeBrowserManager.isCodePresent(code);
 		assertThat(result).isFalse();
@@ -202,7 +202,7 @@ public class Tests extends OHCoreTestCase {
 	@Test
 	public void testMgrValidationInsert() throws Exception {
 		String code = setupTestDiseaseType(false);
-		DiseaseType diseaseType = diseaseTypeIoOperationRepository.getById(code);
+		DiseaseType diseaseType = diseaseTypeIoOperationRepository.getReferenceById(code);
 		// code already exists
 		DiseaseType diseaseType2 = new DiseaseType("ZZ", "TestDescription");
 		diseaseType2.setCode(code);
@@ -217,7 +217,7 @@ public class Tests extends OHCoreTestCase {
 	@Test
 	public void testDiseaseTypeEqualHashToString() throws Exception {
 		String code = setupTestDiseaseType(false);
-		DiseaseType diseaseType = diseaseTypeIoOperationRepository.getById(code);
+		DiseaseType diseaseType = diseaseTypeIoOperationRepository.getReferenceById(code);
 		DiseaseType diseaseType2 = new DiseaseType("code", "description");
 		assertThat(diseaseType).isEqualTo(diseaseType);
 		assertThat(diseaseType)
@@ -239,7 +239,7 @@ public class Tests extends OHCoreTestCase {
 	}
 
 	private void checkDiseaseTypeIntoDb(String code) throws OHException {
-		DiseaseType foundDiseaseType = diseaseTypeIoOperationRepository.getById(code);
+		DiseaseType foundDiseaseType = diseaseTypeIoOperationRepository.getReferenceById(code);
 		testDiseaseType.check(foundDiseaseType);
 	}
 }


### PR DESCRIPTION
Replace deprecated method usage in tests with more recent versions.

Rebuilt the CORE project and ran all the unit tests succesffully.