### PR TITLE
Chore: upgrade to Spring Boot 2.7.12

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 		<java.version>11</java.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<spring.framework.version>5.3.27</spring.framework.version>
-		<spring.boot.version>2.7.11</spring.boot.version>
+		<spring.boot.version>2.7.12</spring.boot.version>
 		<jasperreports.version>6.20.5</jasperreports.version>
 		<spring.cloud.starter.openfeign.version>3.1.7</spring.cloud.starter.openfeign.version>
 		<license.maven.plugin.version>4.2</license.maven.plugin.version>


### PR DESCRIPTION
This release includes a fix for [CVE-2023-20883: Spring Boot Welcome Page DoS Vulnerability](http://spring.io/security/cve-2023-20883).

Release Notes: https://github.com/spring-projects/spring-boot/releases/tag/v2.7.12