### PR TITLE
Chore: combine recent dependabot updates together for testing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
 			</plugin>
 			<plugin>
 			  <artifactId>maven-surefire-plugin</artifactId>
-			  <version>3.1.0</version>
+			  <version>3.1.2</version>
 			  <dependencies>
 				<dependency>
 			        <groupId>org.junit.vintage</groupId>
@@ -510,12 +510,12 @@
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-annotations</artifactId>
-			<version>2.15.1</version>
+			<version>2.15.2</version>
 		</dependency>
 		<dependency>
 			<groupId>com.fasterxml.jackson.module</groupId>
 			<artifactId>jackson-modules-java8</artifactId>
-			<version>2.15.1</version>
+			<version>2.15.2</version>
 			<type>pom</type>
 			<scope>runtime</scope>
 		</dependency>


### PR DESCRIPTION
Run `mvn clean test` without issue.