### PR TITLE
Upgrade all junit dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,22 +42,18 @@
 				<dependency>
 			        <groupId>org.junit.vintage</groupId>
 			        <artifactId>junit-vintage-engine</artifactId>
-			        <version>5.9.3</version>
+			        <version>5.10.0</version>
 			    </dependency>
 			    <dependency>
 			        <groupId>org.junit.jupiter</groupId>
 			        <artifactId>junit-jupiter-engine</artifactId>
-			        <version>5.9.3</version>
+			        <version>5.10.0</version>
 			    </dependency>
 			  </dependencies>
 			  <configuration>
 			    <redirectTestOutputToFile>true</redirectTestOutputToFile>
 			    <reportsDirectory>${project.build.directory}/test-reports</reportsDirectory>
 			  </configuration>
-			</plugin>
-			<plugin>
-				<artifactId>maven-surefire-plugin</artifactId>
-				<version>3.1.2</version>
 			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
@@ -190,7 +186,7 @@
 			<dependency>
 				<groupId>org.junit</groupId>
 				<artifactId>junit-bom</artifactId>
-				<version>5.9.3</version>
+				<version>5.10.0</version>
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>


### PR DESCRIPTION
Combine all recent dependabot updates to Junit into a single PR.

Also removed a duplicate definition of the surefire plugin.

Ran `mvn clean test` without error.