### PR TITLE
Chore: use single character in String.indexOf() method

### DIFF
--- a/src/main/java/org/isf/dicom/manager/FileSystemDicomManager.java
+++ b/src/main/java/org/isf/dicom/manager/FileSystemDicomManager.java
@@ -125,7 +125,7 @@ public class FileSystemDicomManager implements DicomManagerInterface {
 			for (int i = 0; i < _longs.length; i++) {
 
 				try {
-					_longs[i] = Long.parseLong(files[i].getName().substring(0, files[i].getName().indexOf(".")));
+					_longs[i] = Long.parseLong(files[i].getName().substring(0, files[i].getName().indexOf('.')));
 				} catch (Exception e) {
 				}
 			}
@@ -578,7 +578,7 @@ public class FileSystemDicomManager implements DicomManagerInterface {
 
 		for (int i = 0; i < _longs.length; i++) {
 			try {
-				_longs[i] = Long.parseLong(files[i].getName().substring(0, files[i].getName().indexOf(".")));
+				_longs[i] = Long.parseLong(files[i].getName().substring(0, files[i].getName().indexOf('.')));
 			} catch (Exception e) {
 			}
 		}

--- a/src/main/java/org/isf/xmpp/manager/Interaction.java
+++ b/src/main/java/org/isf/xmpp/manager/Interaction.java
@@ -85,7 +85,7 @@ public class Interaction {
 
 	public String userFromAddress(String address) {
 		int index;
-		index = address.indexOf("@");
+		index = address.indexOf('@');
 		return address.substring(0, index);
 	}
 


### PR DESCRIPTION
gets a small performance boast