### PR TITLE
Chore: remove `final` on static methods

### DIFF
--- a/src/main/java/org/isf/generaldata/ConfigurationProperties.java
+++ b/src/main/java/org/isf/generaldata/ConfigurationProperties.java
@@ -66,7 +66,7 @@ public abstract class ConfigurationProperties {
 	 * @param fileProperties - the file name (to be available in the classpath)
 	 * @param logger - the {@link Logger} of the concrete class
 	 */
-	public static final Properties loadPropertiesFile(String fileProperties, Logger logger) {
+	public static Properties loadPropertiesFile(String fileProperties, Logger logger) {
 		return loadPropertiesFile(fileProperties, logger, false);
 	}
 

--- a/src/main/java/org/isf/generaldata/ConfigurationProperties.java
+++ b/src/main/java/org/isf/generaldata/ConfigurationProperties.java
@@ -77,7 +77,7 @@ public abstract class ConfigurationProperties {
 	 * @param exitOnFail - if {@code true} the application will exit if configuration 
 	 * is missing, otherwise default values will be used
 	 */
-	private static final Properties loadPropertiesFile(String fileProperties, Logger logger, boolean exitOnFail) {
+	private static Properties loadPropertiesFile(String fileProperties, Logger logger, boolean exitOnFail) {
 		Properties prop = new Properties();
 		try (InputStream in = Thread.currentThread().getContextClassLoader().getResourceAsStream(fileProperties)) {
 			if (null == in) {


### PR DESCRIPTION
Specifying `final` on a `static` methods is redundant an the method can't be overridden anyway