### PR TITLE
Fix: restore class used in GUI

### DIFF
--- a/src/main/java/org/isf/xmpp/manager/AbstractCommunicationFrame.java
+++ b/src/main/java/org/isf/xmpp/manager/AbstractCommunicationFrame.java
@@ -1,0 +1,37 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2023 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.isf.xmpp.manager;
+
+import javax.swing.JFrame;
+
+import org.jivesoftware.smack.ChatManagerListener;
+import org.jivesoftware.smack.MessageListener;
+import org.jivesoftware.smackx.filetransfer.FileTransferListener;
+
+/**
+ * @author Nanni
+ */
+public abstract class AbstractCommunicationFrame extends JFrame implements MessageListener, FileTransferListener, ChatManagerListener {
+
+	private static final long serialVersionUID = 1L;
+
+}


### PR DESCRIPTION
Class is strange as it is an abstract class that extends from a concrete class which shouldn't be done.   And since it really is a GUI class it is in the wrong project IMHO.