### PR TITLE
Chore: fix assertThat() without condition

### DIFF
--- a/src/test/java/org/isf/accounting/test/Tests.java
+++ b/src/test/java/org/isf/accounting/test/Tests.java
@@ -427,7 +427,7 @@ public class Tests extends OHCoreTestCase {
 		assertThat(foundBillPayment).isNotEqualTo(foundBillPayment2);
 		foundBillPayment.setId(id);
 
-		assertThat(billPayment.compareTo(billPayment)).isEqualTo(0);
+		assertThat(billPayment.compareTo(billPayment)).isZero();
 
 		assertThat(billPayment.hashCode()).isPositive();
 	}

--- a/src/test/java/org/isf/admission/test/Tests.java
+++ b/src/test/java/org/isf/admission/test/Tests.java
@@ -452,7 +452,7 @@ public class Tests extends OHCoreTestCase {
 	public void testIoNewAdmission() throws Exception {
 		Admission admission = buildNewAdmission();
 		Admission result = admissionIoOperation.newAdmission(admission);
-		assertThat(result);
+		assertThat(result).isNotNull();
 		admission = admissionBrowserManager.getAdmission(admission.getId());
 		testAdmission.check(admission);
 	}
@@ -470,9 +470,9 @@ public class Tests extends OHCoreTestCase {
 		Admission foundAdmission = admissionIoOperation.getAdmission(id);
 		foundAdmission.setNote("Update");
 		Admission result = admissionIoOperation.updateAdmission(foundAdmission);
+		assertThat(result).isNotNull();
 		Admission updateAdmission = admissionIoOperation.getAdmission(id);
-
-		assertThat(result);
+		assertThat(updateAdmission).isNotNull();
 		assertThat(updateAdmission.getNote()).isEqualTo("Update");
 	}
 
@@ -940,8 +940,9 @@ public class Tests extends OHCoreTestCase {
 		int id = admission.getId();
 		admission.setNote("Update");
 		Admission result = admissionBrowserManager.updateAdmission(admission);
-		assertThat(result);
+		assertThat(result).isNotNull();
 		Admission updateAdmission = admissionBrowserManager.getAdmission(id);
+		assertThat(updateAdmission).isNotNull();
 		assertThat(updateAdmission.getNote()).isEqualTo("Update");
 	}
 

--- a/src/test/java/org/isf/exa/test/Tests.java
+++ b/src/test/java/org/isf/exa/test/Tests.java
@@ -201,8 +201,9 @@ public class Tests extends OHCoreTestCase {
 		Exam foundExam = examIoOperationRepository.findById(code).get();
 		foundExam.setDescription("Update");
 		Exam result = examIoOperation.updateExam(foundExam);
-		assertThat(result);
+		assertThat(result).isNotNull();
 		Exam updateExam = examIoOperationRepository.findById(code).get();
+		assertThat(updateExam).isNotNull();
 		assertThat(updateExam.getDescription()).isEqualTo("Update");
 	}
 
@@ -212,8 +213,9 @@ public class Tests extends OHCoreTestCase {
 		ExamRow examRow = examRowIoOperationRepository.findById(code).get();
 		examRow.setDescription("Update");
 		ExamRow result = examRowIoOperation.updateExamRow(examRow);
-		assertThat(result);
+		assertThat(result).isNotNull();
 		ExamRow updateExamRow = examRowIoOperationRepository.findById(code).get();
+		assertThat(updateExamRow).isNotNull();
 		assertThat(updateExamRow.getDescription()).isEqualTo("Update");
 	}
 
@@ -341,7 +343,7 @@ public class Tests extends OHCoreTestCase {
 		examTypeIoOperationRepository.saveAndFlush(examType);
 		examIoOperationRepository.saveAndFlush(exam);
 		ExamRow result = examRowBrowsingManager.newExamRow(examRow);
-		assertThat(result);
+		assertThat(result).isNotNull();
 		checkExamRowIntoDb(examRow.getCode());
 	}
 
@@ -361,8 +363,9 @@ public class Tests extends OHCoreTestCase {
 		Exam foundExam = examIoOperationRepository.findById(code).get();
 		foundExam.setDescription("Update");
 		Exam result = examBrowsingManager.updateExam(foundExam);
-		assertThat(result);
+		assertThat(result).isNotNull();
 		Exam updateExam = examIoOperationRepository.findById(code).get();
+		assertThat(updateExam).isNotNull();
 		assertThat(updateExam.getDescription()).isEqualTo("Update");
 	}
 

--- a/src/test/java/org/isf/exatype/test/Tests.java
+++ b/src/test/java/org/isf/exatype/test/Tests.java
@@ -88,8 +88,9 @@ public class Tests extends OHCoreTestCase {
 		ExamType foundExamType = examTypeIoOperationRepository.findById(code).get();
 		foundExamType.setDescription("Update");
 		ExamType result = examTypeIoOperation.updateExamType(foundExamType);
-		assertThat(result);
+		assertThat(result).isNotNull();
 		ExamType updateExamType = examTypeIoOperationRepository.findById(code).get();
+		assertThat(updateExamType).isNotNull();
 		assertThat(updateExamType.getDescription()).isEqualTo("Update");
 	}
 
@@ -97,7 +98,7 @@ public class Tests extends OHCoreTestCase {
 	public void testIoNewExamType() throws Exception {
 		ExamType examType = testExamType.setup(true);
 		ExamType result = examTypeIoOperation.newExamType(examType);
-		assertThat(result);
+		assertThat(result).isNotNull();
 		checkExamTypeIntoDb(examType.getCode());
 	}
 
@@ -132,8 +133,9 @@ public class Tests extends OHCoreTestCase {
 		ExamType foundExamType = examTypeIoOperationRepository.findById(code).get();
 		foundExamType.setDescription("Update");
 		ExamType result = examTypeBrowserManager.updateExamType(foundExamType);
-		assertThat(result);
+		assertThat(result).isNotNull();
 		ExamType updateExamType = examTypeIoOperationRepository.findById(code).get();
+		assertThat(updateExamType).isNotNull();
 		assertThat(updateExamType.getDescription()).isEqualTo("Update");
 	}
 
@@ -141,7 +143,7 @@ public class Tests extends OHCoreTestCase {
 	public void testMgrNewExamType() throws Exception {
 		ExamType examType = testExamType.setup(true);
 		ExamType result = examTypeBrowserManager.newExamType(examType);
-		assertThat(result);
+		assertThat(result).isNotNull();
 		checkExamTypeIntoDb(examType.getCode());
 	}
 

--- a/src/test/java/org/isf/malnutrition/test/Tests.java
+++ b/src/test/java/org/isf/malnutrition/test/Tests.java
@@ -225,7 +225,7 @@ public class Tests extends OHCoreTestCase {
 
 		Malnutrition malnutrition = testMalnutrition.setup(admission, true);
 		Malnutrition result = malnutritionIoOperation.newMalnutrition(malnutrition);
-		assertThat(result);
+		assertThat(result).isNotNull();
 		checkMalnutritionIntoDb(malnutrition.getCode());
 	}
 
@@ -308,7 +308,7 @@ public class Tests extends OHCoreTestCase {
 
 		Malnutrition malnutrition = testMalnutrition.setup(admission, true);
 		Malnutrition result = malnutritionManager.newMalnutrition(malnutrition);
-		assertThat(result);
+		assertThat(result).isNotNull();
 		checkMalnutritionIntoDb(malnutrition.getCode());
 	}
 

--- a/src/test/java/org/isf/medicals/test/Tests.java
+++ b/src/test/java/org/isf/medicals/test/Tests.java
@@ -276,7 +276,7 @@ public class Tests extends OHCoreTestCase {
 		medicalTypeIoOperationRepository.saveAndFlush(medicalType);
 		Medical medical = testMedical.setup(medicalType, true);
 		Medical result = medicalsIoOperations.newMedical(medical);
-		assertThat(result);
+		assertThat(result).isNotNull();
 		checkMedicalIntoDb(medical.getCode());
 	}
 
@@ -286,8 +286,9 @@ public class Tests extends OHCoreTestCase {
 		Medical foundMedical = medicalsIoOperationRepository.findById(code).get();
 		foundMedical.setDescription("Update");
 		Medical result = medicalsIoOperations.updateMedical(foundMedical);
-		assertThat(result);
+		assertThat(result).isNotNull();
 		Medical updateMedical = medicalsIoOperationRepository.findById(code).get();
+		assertThat(updateMedical).isNotNull();
 		assertThat(updateMedical.getDescription()).isEqualTo("Update");
 	}
 
@@ -376,7 +377,7 @@ public class Tests extends OHCoreTestCase {
 		MedicalType medicalType = testMedicalType.setup(false);
 		medicalTypeIoOperationRepository.saveAndFlush(medicalType);
 		Medical medical = testMedical.setup(medicalType, true);
-		assertThat(medicalBrowsingManager.newMedical(medical));
+		assertThat(medicalBrowsingManager.newMedical(medical)).isNotNull();
 		checkMedicalIntoDb(medical.getCode());
 	}
 
@@ -385,7 +386,7 @@ public class Tests extends OHCoreTestCase {
 		MedicalType medicalType = testMedicalType.setup(false);
 		medicalTypeIoOperationRepository.saveAndFlush(medicalType);
 		Medical medical = testMedical.setup(medicalType, true);
-		assertThat(medicalBrowsingManager.newMedical(medical, false));
+		assertThat(medicalBrowsingManager.newMedical(medical, false)).isNotNull();
 		checkMedicalIntoDb(medical.getCode());
 	}
 
@@ -394,8 +395,9 @@ public class Tests extends OHCoreTestCase {
 		int code = setupTestMedical(false);
 		Medical foundMedical = medicalsIoOperationRepository.findById(code).get();
 		foundMedical.setDescription("Update");
-		assertThat(medicalBrowsingManager.updateMedical(foundMedical));
+		assertThat(medicalBrowsingManager.updateMedical(foundMedical)).isNotNull();
 		Medical updateMedical = medicalsIoOperationRepository.findById(code).get();
+		assertThat(updateMedical).isNotNull();
 		assertThat(updateMedical.getDescription()).isEqualTo("Update");
 	}
 
@@ -404,8 +406,9 @@ public class Tests extends OHCoreTestCase {
 		int code = setupTestMedical(false);
 		Medical foundMedical = medicalsIoOperationRepository.findById(code).get();
 		foundMedical.setDescription("Update");
-		assertThat(medicalBrowsingManager.updateMedical(foundMedical, true));
+		assertThat(medicalBrowsingManager.updateMedical(foundMedical, true)).isNotNull();
 		Medical updateMedical = medicalsIoOperationRepository.findById(code).get();
+		assertThat(updateMedical).isNotNull();
 		assertThat(updateMedical.getDescription()).isEqualTo("Update");
 	}
 
@@ -414,8 +417,9 @@ public class Tests extends OHCoreTestCase {
 		int code = setupTestMedical(false);
 		Medical foundMedical = medicalsIoOperationRepository.findById(code).get();
 		foundMedical.setDescription("Update");
-		assertThat(medicalBrowsingManager.updateMedical(foundMedical, false));
+		assertThat(medicalBrowsingManager.updateMedical(foundMedical, false)).isNotNull();
 		Medical updateMedical = medicalsIoOperationRepository.findById(code).get();
+		assertThat(updateMedical).isNotNull();
 		assertThat(updateMedical.getDescription()).isEqualTo("Update");
 	}
 

--- a/src/test/java/org/isf/medstockmovtype/test/Tests.java
+++ b/src/test/java/org/isf/medstockmovtype/test/Tests.java
@@ -91,7 +91,7 @@ public class Tests extends OHCoreTestCase {
 		MovementType foundMovementType = medicalDsrStockMovementTypeIoOperation.findOneByCode(code);
 		foundMovementType.setDescription("Update");
 		MovementType result = medicalDsrStockMovementTypeIoOperation.updateMedicalDsrStockMovementType(foundMovementType);
-		assertThat(result);
+		assertThat(result).isNotNull();
 		MovementType updateMovementType = medicalDsrStockMovementTypeIoOperation.findOneByCode(code);
 		assertThat(updateMovementType.getDescription()).isEqualTo("Update");
 	}
@@ -100,7 +100,7 @@ public class Tests extends OHCoreTestCase {
 	public void testIoNewMovementType() throws Exception {
 		MovementType movementType = testMovementType.setup(true);
 		MovementType result = medicalDsrStockMovementTypeIoOperation.newMedicalDsrStockMovementType(movementType);
-		assertThat(result);
+		assertThat(result).isNotNull();
 		checkMovementTypeIntoDb(movementType.getCode());
 	}
 
@@ -139,15 +139,16 @@ public class Tests extends OHCoreTestCase {
 		String code = setupTestMovementType(false);
 		MovementType foundMovementType = medicalDsrStockMovementTypeBrowserManager.getMovementType(code);
 		foundMovementType.setDescription("Update");
-		assertThat(medicalDsrStockMovementTypeBrowserManager.updateMedicalDsrStockMovementType(foundMovementType));
+		assertThat(medicalDsrStockMovementTypeBrowserManager.updateMedicalDsrStockMovementType(foundMovementType)).isNotNull();
 		MovementType updateMovementType = medicalDsrStockMovementTypeBrowserManager.getMovementType(code);
+		assertThat(updateMovementType).isNotNull();
 		assertThat(updateMovementType.getDescription()).isEqualTo("Update");
 	}
 
 	@Test
 	public void testMgrNewMovementType() throws Exception {
 		MovementType movementType = testMovementType.setup(true);
-		assertThat(medicalDsrStockMovementTypeBrowserManager.newMedicalDsrStockMovementType(movementType));
+		assertThat(medicalDsrStockMovementTypeBrowserManager.newMedicalDsrStockMovementType(movementType)).isNotNull();
 		checkMovementTypeIntoDb(movementType.getCode());
 	}
 

--- a/src/test/java/org/isf/medtype/test/Tests.java
+++ b/src/test/java/org/isf/medtype/test/Tests.java
@@ -86,8 +86,9 @@ public class Tests extends OHCoreTestCase {
 		MedicalType foundMedicalType = medicalTypeIoOperationRepository.findById(code).get();
 		foundMedicalType.setDescription("Update");
 		MedicalType result = medicalTypeIoOperation.updateMedicalType(foundMedicalType);
-		assertThat(result);
+		assertThat(result).isNotNull();
 		MedicalType updateMedicalType = medicalTypeIoOperationRepository.findById(code).get();
+		assertThat(updateMedicalType).isNotNull();
 		assertThat(updateMedicalType.getDescription()).isEqualTo("Update");
 	}
 
@@ -95,7 +96,7 @@ public class Tests extends OHCoreTestCase {
 	public void testIoNewMedicalType() throws Exception {
 		MedicalType medicalType = testMedicalType.setup(true);
 		MedicalType result = medicalTypeIoOperation.newMedicalType(medicalType);
-		assertThat(result);
+		assertThat(result).isNotNull();
 		checkMedicalTypeIntoDb(medicalType.getCode());
 	}
 
@@ -129,15 +130,16 @@ public class Tests extends OHCoreTestCase {
 		String code = setupTestMedicalType(false);
 		MedicalType foundMedicalType = medicalTypeIoOperationRepository.findById(code).get();
 		foundMedicalType.setDescription("Update");
-		assertThat(medicalTypeBrowserManager.updateMedicalType(foundMedicalType));
+		assertThat(medicalTypeBrowserManager.updateMedicalType(foundMedicalType)).isNotNull();
 		MedicalType updateMedicalType = medicalTypeIoOperationRepository.findById(code).get();
+		assertThat(updateMedicalType).isNotNull();
 		assertThat(updateMedicalType.getDescription()).isEqualTo("Update");
 	}
 
 	@Test
 	public void testMgrNewMedicalType() throws Exception {
 		MedicalType medicalType = testMedicalType.setup(true);
-		assertThat(medicalTypeBrowserManager.newMedicalType(medicalType));
+		assertThat(medicalTypeBrowserManager.newMedicalType(medicalType)).isNotNull();
 		checkMedicalTypeIntoDb(medicalType.getCode());
 	}
 

--- a/src/test/java/org/isf/opd/test/Tests.java
+++ b/src/test/java/org/isf/opd/test/Tests.java
@@ -614,7 +614,7 @@ public class Tests extends OHCoreTestCase {
 		diseaseIoOperationRepository.saveAndFlush(disease3);
 		opd.setDisease2(disease2);
 		opd.setDisease3(disease3);
-		assertThat(opdBrowserManager.newOpd(opd));
+		assertThat(opdBrowserManager.newOpd(opd)).isNotNull();
 		checkOpdIntoDb(opd.getCode());
 	}
 

--- a/src/test/java/org/isf/operation/test/Tests.java
+++ b/src/test/java/org/isf/operation/test/Tests.java
@@ -281,7 +281,7 @@ public class Tests extends OHCoreTestCase {
 		OperationType operationType = testOperationType.setup(false);
 		operationTypeIoOperationRepository.saveAndFlush(operationType);
 		Operation operation = testOperation.setup(operationType, true);
-		assertThat(operationIoOperations.newOperation(operation));
+		assertThat(operationIoOperations.newOperation(operation)).isNotNull();
 		checkOperationIntoDb(operation.getCode());
 	}
 
@@ -291,8 +291,9 @@ public class Tests extends OHCoreTestCase {
 		Operation foundOperation = operationIoOperations.findByCode(code);
 		int lock = foundOperation.getLock();
 		foundOperation.setDescription("Update");
-		assertThat(operationIoOperations.updateOperation(foundOperation));
+		assertThat(operationIoOperations.updateOperation(foundOperation)).isNotNull();
 		Operation updateOperation = operationIoOperations.findByCode(code);
+		assertThat(updateOperation).isNotNull();
 		assertThat(updateOperation.getDescription()).isEqualTo("Update");
 		assertThat(updateOperation.getLock().intValue()).isEqualTo(lock + 1);
 	}
@@ -412,7 +413,7 @@ public class Tests extends OHCoreTestCase {
 		OperationType operationType = testOperationType.setup(false);
 		operationTypeIoOperationRepository.saveAndFlush(operationType);
 		Operation operation = testOperation.setup(operationType, true);
-		assertThat(operationBrowserManager.newOperation(operation));
+		assertThat(operationBrowserManager.newOperation(operation)).isNotNull();
 		checkOperationIntoDb(operation.getCode());
 	}
 
@@ -422,8 +423,9 @@ public class Tests extends OHCoreTestCase {
 		Operation foundOperation = operationBrowserManager.getOperationByCode(code);
 		int lock = foundOperation.getLock();
 		foundOperation.setDescription("Update");
-		assertThat(operationBrowserManager.updateOperation(foundOperation));
+		assertThat(operationBrowserManager.updateOperation(foundOperation)).isNotNull();
 		Operation updateOperation = operationBrowserManager.getOperationByCode(code);
+		assertThat(updateOperation).isNotNull();
 		assertThat(updateOperation.getDescription()).isEqualTo("Update");
 		assertThat(updateOperation.getLock().intValue()).isEqualTo(lock + 1);
 	}

--- a/src/test/java/org/isf/opetype/test/Tests.java
+++ b/src/test/java/org/isf/opetype/test/Tests.java
@@ -85,8 +85,9 @@ public class Tests extends OHCoreTestCase {
 		OperationType foundOperationType = operationTypeIoOperationRepository.findById(code).get();
 		foundOperationType.setDescription("Update");
 		OperationType result = operationTypeIoOperation.updateOperationType(foundOperationType);
-		assertThat(result);
+		assertThat(result).isNotNull();
 		OperationType updateOperationType = operationTypeIoOperationRepository.findById(code).get();
+		assertThat(updateOperationType).isNotNull();
 		assertThat(updateOperationType.getDescription()).isEqualTo("Update");
 	}
 
@@ -94,7 +95,7 @@ public class Tests extends OHCoreTestCase {
 	public void testIoNewOperationType() throws Exception {
 		OperationType operationType = testOperationType.setup(true);
 		OperationType result = operationTypeIoOperation.newOperationType(operationType);
-		assertThat(result);
+		assertThat(result).isNotNull();
 		checkOperationTypeIntoDb(operationType.getCode());
 	}
 
@@ -128,15 +129,16 @@ public class Tests extends OHCoreTestCase {
 		String code = setupTestOperationType(false);
 		OperationType foundOperationType = operationTypeIoOperationRepository.findById(code).get();
 		foundOperationType.setDescription("Update");
-		assertThat(operationTypeBrowserManager.updateOperationType(foundOperationType));
+		assertThat(operationTypeBrowserManager.updateOperationType(foundOperationType)).isNotNull();
 		OperationType updateOperationType = operationTypeIoOperationRepository.findById(code).get();
+		assertThat(updateOperationType).isNotNull();
 		assertThat(updateOperationType.getDescription()).isEqualTo("Update");
 	}
 
 	@Test
 	public void testMgrNewOperationType() throws Exception {
 		OperationType operationType = testOperationType.setup(true);
-		assertThat(operationTypeBrowserManager.newOperationType(operationType));
+		assertThat(operationTypeBrowserManager.newOperationType(operationType)).isNotNull();
 		checkOperationTypeIntoDb(operationType.getCode());
 	}
 

--- a/src/test/java/org/isf/patvac/test/Tests.java
+++ b/src/test/java/org/isf/patvac/test/Tests.java
@@ -159,9 +159,10 @@ public class Tests extends OHCoreTestCase {
 		LocalDateTime newDate = TimeTools.getNow();
 		foundPatientVaccine.setVaccineDate(newDate);
 		PatientVaccine result = patvacIoOperation.updatePatientVaccine(foundPatientVaccine);
-		assertThat(result);
+		assertThat(result).isNotNull();
 		PatientVaccine updatePatientVaccine = patVacIoOperationRepository.findById(code).get();
-		assertThat(updatePatientVaccine.getVaccineDate().equals(newDate));
+		assertThat(updatePatientVaccine).isNotNull();
+		assertThat(updatePatientVaccine.getVaccineDate()).isEqualTo(newDate);
 	}
 
 	@Test
@@ -174,7 +175,7 @@ public class Tests extends OHCoreTestCase {
 		vaccineIoOperationRepository.saveAndFlush(vaccine);
 		PatientVaccine patientVaccine = testPatientVaccine.setup(patient, vaccine, true);
 		PatientVaccine result = patvacIoOperation.newPatientVaccine(patientVaccine);
-		assertThat(result);
+		assertThat(result).isNotNull();
 		checkPatientVaccineIntoDb(patientVaccine.getCode());
 	}
 
@@ -327,9 +328,10 @@ public class Tests extends OHCoreTestCase {
 		LocalDateTime newDate = TimeTools.getNow();
 		foundPatientVaccine.setVaccineDate(newDate);
 		PatientVaccine result = patVacManager.updatePatientVaccine(foundPatientVaccine);
-		assertThat(result);
+		assertThat(result).isNotNull();
 		PatientVaccine updatePatientVaccine = patVacIoOperationRepository.findById(code).get();
-		assertThat(updatePatientVaccine.getVaccineDate().equals(newDate));
+		assertThat(updatePatientVaccine).isNotNull();
+		assertThat(updatePatientVaccine.getVaccineDate()).isEqualTo(newDate);
 	}
 
 	@Test
@@ -342,7 +344,7 @@ public class Tests extends OHCoreTestCase {
 		vaccineIoOperationRepository.saveAndFlush(vaccine);
 		PatientVaccine patientVaccine = testPatientVaccine.setup(patient, vaccine, true);
 		PatientVaccine result = patVacManager.newPatientVaccine(patientVaccine);
-		assertThat(result);
+		assertThat(result).isNotNull();
 		checkPatientVaccineIntoDb(patientVaccine.getCode());
 	}
 

--- a/src/test/java/org/isf/pregtreattype/test/Tests.java
+++ b/src/test/java/org/isf/pregtreattype/test/Tests.java
@@ -90,8 +90,9 @@ public class Tests extends OHCoreTestCase {
 		PregnantTreatmentType foundPregnantTreatmentType = pregnantTreatmentTypeIoOperationRepository.findById(code).get();
 		foundPregnantTreatmentType.setDescription("Update");
 		PregnantTreatmentType result = pregnantTreatmentTypeIoOperation.updatePregnantTreatmentType(foundPregnantTreatmentType);
-		assertThat(result);
+		assertThat(result).isNotNull();
 		PregnantTreatmentType updatePregnantTreatmentType = pregnantTreatmentTypeIoOperationRepository.findById(code).get();
+		assertThat(updatePregnantTreatmentType).isNotNull();
 		assertThat(updatePregnantTreatmentType.getDescription()).isEqualTo("Update");
 	}
 
@@ -99,8 +100,7 @@ public class Tests extends OHCoreTestCase {
 	public void testIoNewPregnantTreatmentType() throws Exception {
 		PregnantTreatmentType pregnantTreatmentType = testPregnantTreatmentType.setup(true);
 		PregnantTreatmentType result = pregnantTreatmentTypeIoOperation.newPregnantTreatmentType(pregnantTreatmentType);
-
-		assertThat(result);
+		assertThat(result).isNotNull();
 		checkPregnantTreatmentTypeIntoDb(pregnantTreatmentType.getCode());
 	}
 
@@ -147,15 +147,16 @@ public class Tests extends OHCoreTestCase {
 		String code = setupTestPregnantTreatmentType(false);
 		PregnantTreatmentType foundPregnantTreatmentType = pregnantTreatmentTypeIoOperationRepository.findById(code).get();
 		foundPregnantTreatmentType.setDescription("Update");
-		assertThat(pregnantTreatmentTypeBrowserManager.updatePregnantTreatmentType(foundPregnantTreatmentType));
+		assertThat(pregnantTreatmentTypeBrowserManager.updatePregnantTreatmentType(foundPregnantTreatmentType)).isNotNull();
 		PregnantTreatmentType updatePregnantTreatmentType = pregnantTreatmentTypeIoOperationRepository.findById(code).get();
+		assertThat(updatePregnantTreatmentType).isNotNull();
 		assertThat(updatePregnantTreatmentType.getDescription()).isEqualTo("Update");
 	}
 
 	@Test
 	public void testMgrNewPregnantTreatmentType() throws Exception {
 		PregnantTreatmentType pregnantTreatmentType = testPregnantTreatmentType.setup(true);
-		assertThat(pregnantTreatmentTypeBrowserManager.newPregnantTreatmentType(pregnantTreatmentType));
+		assertThat(pregnantTreatmentTypeBrowserManager.newPregnantTreatmentType(pregnantTreatmentType)).isNotNull();
 		checkPregnantTreatmentTypeIntoDb(pregnantTreatmentType.getCode());
 	}
 

--- a/src/test/java/org/isf/pricesothers/test/Tests.java
+++ b/src/test/java/org/isf/pricesothers/test/Tests.java
@@ -103,7 +103,8 @@ public class Tests extends OHCoreTestCase {
 		PricesOthers updatePricesOthers = priceOthersIoOperationRepository.findById(id).get();
 
 		// then:
-		assertThat(result);
+		assertThat(result).isNotNull();
+		assertThat(updatePricesOthers).isNotNull();
 		assertThat(updatePricesOthers.getDescription()).isEqualTo("Update");
 	}
 
@@ -116,7 +117,7 @@ public class Tests extends OHCoreTestCase {
 		PricesOthers result = priceOthersIoOperations.newOthers(pricesOthers);
 
 		// then:
-		assertThat(result);
+		assertThat(result).isNotNull();
 		checkPricesOthersIntoDb(pricesOthers.getId());
 	}
 
@@ -155,15 +156,16 @@ public class Tests extends OHCoreTestCase {
 		int id = setupTestPricesOthers(false);
 		PricesOthers foundPricesOthers = priceOthersIoOperationRepository.findById(id).get();
 		foundPricesOthers.setDescription("Update");
-		assertThat(pricesOthersManager.updateOther(foundPricesOthers));
+		assertThat(pricesOthersManager.updateOther(foundPricesOthers)).isNotNull();
 		PricesOthers updatePricesOthers = priceOthersIoOperationRepository.findById(id).get();
+		assertThat(updatePricesOthers).isNotNull();
 		assertThat(updatePricesOthers.getDescription()).isEqualTo("Update");
 	}
 
 	@Test
 	public void testMgrNewPricesOther() throws Exception {
 		PricesOthers pricesOthers = testPricesOthers.setup(true);
-		assertThat(pricesOthersManager.newOther(pricesOthers));
+		assertThat(pricesOthersManager.newOther(pricesOthers)).isNotNull();
 		checkPricesOthersIntoDb(pricesOthers.getId());
 	}
 

--- a/src/test/java/org/isf/supplier/test/Tests.java
+++ b/src/test/java/org/isf/supplier/test/Tests.java
@@ -75,8 +75,7 @@ public class Tests extends OHCoreTestCase {
 	public void testIoSupplierSaveOrUpdate() throws Exception {
 		Supplier supplier = testSupplier.setup(true);
 		Supplier result = supplierIoOperation.saveOrUpdate(supplier);
-
-		assertThat(result);
+		assertThat(result).isNotNull();
 		checkSupplierIntoDb(supplier.getSupId());
 	}
 
@@ -106,7 +105,7 @@ public class Tests extends OHCoreTestCase {
 	@Test
 	public void testMgrSupplierSaveOrUpdate() throws Exception {
 		Supplier supplier = testSupplier.setup(true);
-		assertThat(supplierBrowserManager.saveOrUpdate(supplier));
+		assertThat(supplierBrowserManager.saveOrUpdate(supplier)).isNotNull();
 		checkSupplierIntoDb(supplier.getSupId());
 	}
 

--- a/src/test/java/org/isf/vactype/test/Tests.java
+++ b/src/test/java/org/isf/vactype/test/Tests.java
@@ -88,8 +88,9 @@ public class Tests extends OHCoreTestCase {
 		VaccineType foundVaccineType = vaccineTypeIoOperation.findVaccineType(code);
 		foundVaccineType.setDescription("Update");
 		VaccineType result = vaccineTypeIoOperation.updateVaccineType(foundVaccineType);
-		assertThat(result);
+		assertThat(result).isNotNull();
 		VaccineType updateVaccineType = vaccineTypeIoOperation.findVaccineType(code);
+		assertThat(updateVaccineType).isNotNull();
 		assertThat(updateVaccineType.getDescription()).isEqualTo("Update");
 	}
 
@@ -97,7 +98,7 @@ public class Tests extends OHCoreTestCase {
 	public void testIoNewVaccineType() throws Exception {
 		VaccineType vaccineType = testVaccineType.setup(true);
 		VaccineType result = vaccineTypeIoOperation.newVaccineType(vaccineType);
-		assertThat(result);
+		assertThat(result).isNotNull();
 		checkVaccineTypeIntoDb(vaccineType.getCode());
 	}
 
@@ -139,15 +140,16 @@ public class Tests extends OHCoreTestCase {
 		String code = setupTestVaccineType(false);
 		VaccineType foundVaccineType = vaccineTypeBrowserManager.findVaccineType(code);
 		foundVaccineType.setDescription("Update");
-		assertThat(vaccineTypeBrowserManager.updateVaccineType(foundVaccineType));
+		assertThat(vaccineTypeBrowserManager.updateVaccineType(foundVaccineType)).isNotNull();
 		VaccineType updateVaccineType = vaccineTypeBrowserManager.findVaccineType(code);
+		assertThat(updateVaccineType).isNotNull();
 		assertThat(updateVaccineType.getDescription()).isEqualTo("Update");
 	}
 
 	@Test
 	public void testMgrNewVaccineType() throws Exception {
 		VaccineType vaccineType = testVaccineType.setup(true);
-		assertThat(vaccineTypeBrowserManager.newVaccineType(vaccineType));
+		assertThat(vaccineTypeBrowserManager.newVaccineType(vaccineType)).isNotNull();
 		checkVaccineTypeIntoDb(vaccineType.getCode());
 	}
 

--- a/src/test/java/org/isf/ward/test/Tests.java
+++ b/src/test/java/org/isf/ward/test/Tests.java
@@ -146,7 +146,7 @@ public class Tests extends OHCoreTestCase {
 		List<Ward> wards = wardIoOperation.getIpdWards();
 		
 		// then:
-		assertThat(wards.size() == 1);
+		assertThat(wards).hasSize(1);
 		
 		// given:
 		foundWard.setBeds(0);
@@ -156,7 +156,7 @@ public class Tests extends OHCoreTestCase {
 		wards = wardIoOperation.getIpdWards();
 		
 		// then:
-		assertThat(wards.size() == 0);
+		assertThat(wards).hasSize(0);
 	}
 
 	@Test
@@ -169,7 +169,7 @@ public class Tests extends OHCoreTestCase {
 		List<Ward> wards = wardIoOperation.getOpdWards();
 		
 		// then:
-		assertThat(wards.size() == 0);
+		assertThat(wards).hasSize(1);
 		
 		// given:
 		foundWard.setBeds(0);
@@ -179,7 +179,7 @@ public class Tests extends OHCoreTestCase {
 		wards = wardIoOperation.getOpdWards();
 		
 		// then:
-		assertThat(wards.size() == 1);
+		assertThat(wards).hasSize(1);
 	}
 	
 	@Test
@@ -339,7 +339,7 @@ public class Tests extends OHCoreTestCase {
 		wardIoOperationRepository.saveAndFlush(opdWard);
 		
 		List<Ward> wards = wardBrowserManager.getIpdWards();
-		assertThat(wards.size() == 0);
+		assertThat(wards).hasSize(0);
 	}
 	
 	@Test
@@ -350,7 +350,7 @@ public class Tests extends OHCoreTestCase {
 		wardIoOperationRepository.saveAndFlush(opdWard);
 		
 		List<Ward> wards = wardBrowserManager.getOpdWards();
-		assertThat(wards.size() == 1);
+		assertThat(wards).hasSize(1);
 	}
 
 	@Test


### PR DESCRIPTION
The primary change was to add a condition to the `assertThat()`.   As it was the statement was incomplete and was really a no-op.

So instead of just `assertThat(someObject);` the statement becomes something like `assertThat(someObject).isNotNull();`.

There are a few other minor changes to improve the tests.