### PR TITLE
Chore: remove AttributeOverrides annotation

### DIFF
--- a/src/main/java/org/isf/admission/model/Admission.java
+++ b/src/main/java/org/isf/admission/model/Admission.java
@@ -24,7 +24,6 @@ package org.isf.admission.model;
 import java.time.LocalDateTime;
 
 import javax.persistence.AttributeOverride;
-import javax.persistence.AttributeOverrides;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.EntityListeners;
@@ -68,16 +67,13 @@ entities={
 		@EntityResult(entityClass=org.isf.patient.model.Patient.class),
 		@EntityResult(entityClass=org.isf.admission.model.Admission.class)}
 )
-@EntityListeners(AuditingEntityListener.class) 
-@AttributeOverrides({
-    @AttributeOverride(name="createdBy", column=@Column(name="ADM_CREATED_BY")),
-    @AttributeOverride(name="createdDate", column=@Column(name="ADM_CREATED_DATE")),
-    @AttributeOverride(name="lastModifiedBy", column=@Column(name="ADM_LAST_MODIFIED_BY")),
-    @AttributeOverride(name="active", column=@Column(name="ADM_ACTIVE")),
-    @AttributeOverride(name="lastModifiedDate", column=@Column(name="ADM_LAST_MODIFIED_DATE"))
-})
-public class Admission extends Auditable<String> implements Comparable<Admission> 
-{
+@EntityListeners(AuditingEntityListener.class)
+@AttributeOverride(name="createdBy", column=@Column(name="ADM_CREATED_BY"))
+@AttributeOverride(name="createdDate", column=@Column(name="ADM_CREATED_DATE"))
+@AttributeOverride(name="lastModifiedBy", column=@Column(name="ADM_LAST_MODIFIED_BY"))
+@AttributeOverride(name="active", column=@Column(name="ADM_ACTIVE"))
+@AttributeOverride(name="lastModifiedDate", column=@Column(name="ADM_LAST_MODIFIED_DATE"))
+public class Admission extends Auditable<String> implements Comparable<Admission> {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.AUTO)

--- a/src/main/java/org/isf/anamnesis/model/PatientHistory.java
+++ b/src/main/java/org/isf/anamnesis/model/PatientHistory.java
@@ -22,7 +22,6 @@
 package org.isf.anamnesis.model;
 
 import javax.persistence.AttributeOverride;
-import javax.persistence.AttributeOverrides;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.EntityListeners;
@@ -41,11 +40,11 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 @Entity
 @Table(name = "OH_PATIENTHISTORY")
 @EntityListeners(AuditingEntityListener.class)
-@AttributeOverrides({ @AttributeOverride(name = "createdBy", column = @Column(name = "PAH_CREATED_BY")),
-		@AttributeOverride(name = "createdDate", column = @Column(name = "PAH_CREATED_DATE")),
-		@AttributeOverride(name = "lastModifiedBy", column = @Column(name = "PAH_LAST_MODIFIED_BY")),
-		@AttributeOverride(name = "active", column = @Column(name = "PAH_ACTIVE")),
-		@AttributeOverride(name = "lastModifiedDate", column = @Column(name = "PAH_LAST_MODIFIED_DATE")) })
+@AttributeOverride(name = "createdBy", column = @Column(name = "PAH_CREATED_BY"))
+@AttributeOverride(name = "createdDate", column = @Column(name = "PAH_CREATED_DATE"))
+@AttributeOverride(name = "lastModifiedBy", column = @Column(name = "PAH_LAST_MODIFIED_BY"))
+@AttributeOverride(name = "active", column = @Column(name = "PAH_ACTIVE"))
+@AttributeOverride(name = "lastModifiedDate", column = @Column(name = "PAH_LAST_MODIFIED_DATE"))
 public class PatientHistory extends Auditable<String> implements Comparable<PatientHistory> {
 
 	@Id

--- a/src/main/java/org/isf/permissions/model/GroupPermission.java
+++ b/src/main/java/org/isf/permissions/model/GroupPermission.java
@@ -22,7 +22,6 @@
 package org.isf.permissions.model;
 
 import javax.persistence.AttributeOverride;
-import javax.persistence.AttributeOverrides;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
@@ -45,12 +44,11 @@ import org.isf.utils.db.Auditable;
  *------------------------------------------*/
 @Entity
 @Table(name = "OH_GROUPPERMISSION")
-		@AttributeOverrides({ 
-			@AttributeOverride(name = "createdBy", column = @Column(name = "GP_CREATED_BY")), 
-			@AttributeOverride(name = "createdDate", column = @Column(name = "GP_CREATED_DATE")), 
-			@AttributeOverride(name = "lastModifiedBy", column = @Column(name = "GP_LAST_MODIFIED_BY")),
-			@AttributeOverride(name = "lastModifiedDate", column = @Column(name = "GP_LAST_MODIFIED_DATE")), 
-			@AttributeOverride(name = "active", column = @Column(name = "GP_ACTIVE"))})
+@AttributeOverride(name = "createdBy", column = @Column(name = "GP_CREATED_BY"))
+@AttributeOverride(name = "createdDate", column = @Column(name = "GP_CREATED_DATE"))
+@AttributeOverride(name = "lastModifiedBy", column = @Column(name = "GP_LAST_MODIFIED_BY"))
+@AttributeOverride(name = "lastModifiedDate", column = @Column(name = "GP_LAST_MODIFIED_DATE"))
+@AttributeOverride(name = "active", column = @Column(name = "GP_ACTIVE"))
 public class GroupPermission extends Auditable<String> {
 	@Id
 	@GeneratedValue(strategy = GenerationType.AUTO)

--- a/src/main/java/org/isf/permissions/model/Permission.java
+++ b/src/main/java/org/isf/permissions/model/Permission.java
@@ -24,7 +24,6 @@ package org.isf.permissions.model;
 import java.util.List;
 
 import javax.persistence.AttributeOverride;
-import javax.persistence.AttributeOverrides;
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -45,12 +44,11 @@ import org.isf.utils.db.Auditable;
  *------------------------------------------*/
 @Entity
 @Table(name = "OH_PERMISSIONS")
-@AttributeOverrides({ 
-		@AttributeOverride(name = "createdBy", column = @Column(name = "P_CREATED_BY")), 
-		@AttributeOverride(name = "createdDate", column = @Column(name = "P_CREATED_DATE")), 
-		@AttributeOverride(name = "lastModifiedBy", column = @Column(name = "P_LAST_MODIFIED_BY")),
-		@AttributeOverride(name = "lastModifiedDate", column = @Column(name = "P_LAST_MODIFIED_DATE")), 
-		@AttributeOverride(name = "active", column = @Column(name = "P_ACTIVE"))})
+@AttributeOverride(name = "createdBy", column = @Column(name = "P_CREATED_BY"))
+@AttributeOverride(name = "createdDate", column = @Column(name = "P_CREATED_DATE"))
+@AttributeOverride(name = "lastModifiedBy", column = @Column(name = "P_LAST_MODIFIED_BY"))
+@AttributeOverride(name = "lastModifiedDate", column = @Column(name = "P_LAST_MODIFIED_DATE"))
+@AttributeOverride(name = "active", column = @Column(name = "P_ACTIVE"))
 public class Permission extends Auditable<String> {
 	
 	@Id


### PR DESCRIPTION
Before Java 8, a container annotation was required as wrapper to use multiple instances of the same annotation. As of Java 8, this is no longer necessary. Instead, these annotations should be used directly without a wrapper, resulting in cleaner and more readable code.

All tests ran cleanly.