### PR TITLE
Chore: combine recent dependabot upgrades

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -253,7 +253,7 @@
 		<dependency>
 			<groupId>com.h2database</groupId>
 			<artifactId>h2</artifactId>
-			<version>2.2.220</version>
+			<version>2.2.222</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
@@ -319,12 +319,12 @@
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-api</artifactId>
-			<version>2.0.7</version>
+			<version>2.0.9</version>
 		</dependency>
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-reload4j</artifactId>
-			<version>2.0.7</version>
+			<version>2.0.9</version>
 		</dependency>
 		<dependency>
 			<groupId>org.igniterealtime.smack</groupId>
@@ -418,7 +418,7 @@
 		<dependency>
 			<groupId>org.aspectj</groupId>
 			<artifactId>aspectjweaver</artifactId>
-			<version>1.9.20</version>
+			<version>1.9.20.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
Combine recent dependabot jar upgrades into single PR for testing.

`mvn clean test` ran successfully locally.

The individual PRs will be closed after this is committed.