### PR TITLE
Chore: remove unused methods

### DIFF
--- a/src/main/java/org/isf/malnutrition/manager/MalnutritionManager.java
+++ b/src/main/java/org/isf/malnutrition/manager/MalnutritionManager.java
@@ -119,17 +119,6 @@ public class MalnutritionManager {
 		validateMalnutrition(malnutrition);
 		return ioOperation.updateMalnutrition(malnutrition);
 	}
-	
-	/**
-	 * Get the specified {@link Malnutrition}.
-	 *
-	 * @param code of {@link Malnutrition}
-	 * @return the {@link Malnutrition}
-	 * @throws OHServiceException
-	 */
-	public Malnutrition getMalnutrition(int code) throws OHServiceException {
-		return ioOperation.getMalnutrition(code);
-	}
 
 	/**
 	 * Deletes the specified {@link Malnutrition}.

--- a/src/main/java/org/isf/malnutrition/service/MalnutritionIoOperation.java
+++ b/src/main/java/org/isf/malnutrition/service/MalnutritionIoOperation.java
@@ -70,16 +70,7 @@ public class MalnutritionIoOperation {
 	public Malnutrition updateMalnutrition(Malnutrition malnutrition) throws OHServiceException {
 		return repository.save(malnutrition);
 	}
-	
-	/**
-	 * Get the specified {@link Malnutrition}.
-	 * @param code of the malnutrition.
-	 * @return {@link Malnutrition}
-	 * @throws OHServiceException if an error occurs updating the malnutrition.
-	 */
-	public Malnutrition getMalnutrition(int code) throws OHServiceException {
-		return repository.getById(code);
-	}
+
 	/**
 	 * Returns the last {@link Malnutrition} entry for specified patient ID
 	 * @param patientID - the patient ID


### PR DESCRIPTION
This started off by trying to replace the deprecated method in `repository.getById(code);`.   The replacement method is `getReferenceById(ID)`.  When searching for the new method I found that there were no other occurrences.  That led me to see where the method (`public Malnutrition getMalnutrition(int code)`) was used and I found that it was only used once in the Manager class and that method was never called or tested.   So this PR just removes the unused methods.

FWIW, I rebuilt the CORE jar with this change and then built the GUI project cleanly.