### PR TITLE
Chore: remove deprecated method

### DIFF
--- a/src/main/java/org/isf/malnutrition/service/MalnutritionIoOperation.java
+++ b/src/main/java/org/isf/malnutrition/service/MalnutritionIoOperation.java
@@ -78,8 +78,9 @@ public class MalnutritionIoOperation {
 	 * @throws OHServiceException if an error occurs updating the malnutrition.
 	 */
 	public Malnutrition getMalnutrition(int code) throws OHServiceException {
-		return repository.getById(code);
+		return repository.getReferenceById(code);
 	}
+
 	/**
 	 * Returns the last {@link Malnutrition} entry for specified patient ID
 	 * @param patientID - the patient ID


### PR DESCRIPTION
The deprecated method `getById(code)` is now replaced by `getReferenceById(code)`.

Here is the Javadoc
<pre>
	/**
	 * Returns a reference to the entity with the given identifier. Depending on how the JPA persistence provider is
	 * implemented this is very likely to always return an instance and throw an
	 * {@link javax.persistence.EntityNotFoundException} on first access. Some of them will reject invalid identifiers
	 * immediately.
	 *
	 * @param id must not be {@literal null}.
	 * @return a reference to the entity with the given identifier.
	 * @see EntityManager#getReference(Class, Object) for details on when an exception is thrown.
	 * @deprecated use {@link JpaRepository#getReferenceById(ID)} instead.
	 * @since 2.5
	 */
	@Deprecated
	T getById(ID id);
</pre>