### PR TITLE
Chore: removed unused `insert` parameter

### DIFF
--- a/src/main/java/org/isf/menu/manager/UserBrowsingManager.java
+++ b/src/main/java/org/isf/menu/manager/UserBrowsingManager.java
@@ -244,7 +244,7 @@ public class UserBrowsingManager {
 	 * @return <code>true</code> if the menu has been replaced, <code>false</code> otherwise.
 	 */
 	public boolean setGroupMenu(UserGroup aGroup, List<UserMenuItem> menu) throws OHServiceException {
-		return ioOperations.setGroupMenu(aGroup, menu, false);
+		return ioOperations.setGroupMenu(aGroup, menu);
 	}
 
 	/**

--- a/src/main/java/org/isf/menu/service/MenuIoOperations.java
+++ b/src/main/java/org/isf/menu/service/MenuIoOperations.java
@@ -240,17 +240,15 @@ public class MenuIoOperations
 	 * 
 	 * @param aGroup - the {@link UserGroup}
 	 * @param menu - the list of {@link UserMenuItem}s
-	 * @param insert - specify if is an insert or an update
-	 * @return <code>true</code> if the menu has been replaced, <code>false</code> otherwise.
+	 * @return <code>true</code>
 	 * @throws OHServiceException 
 	 */
-	public boolean setGroupMenu(UserGroup aGroup, List<UserMenuItem> menu, boolean insert) throws OHServiceException {
-		boolean result = true;
-		result = deleteGroupMenu(aGroup);
+	public boolean setGroupMenu(UserGroup aGroup, List<UserMenuItem> menu) throws OHServiceException {
+		deleteGroupMenu(aGroup);
 		for (UserMenuItem item : menu) {
-			result = result && insertGroupMenu(aGroup, item, insert);
+			insertGroupMenu(aGroup, item);
 		}
-		return result;
+		return true;
 	}
 
 	private boolean deleteGroupMenu(UserGroup aGroup) throws OHServiceException {
@@ -258,7 +256,7 @@ public class MenuIoOperations
 		return true;
 	}
 
-	private boolean insertGroupMenu(UserGroup aGroup, UserMenuItem item, boolean insert) throws OHServiceException {
+	private boolean insertGroupMenu(UserGroup aGroup, UserMenuItem item) throws OHServiceException {
 		GroupMenu groupMenu = new GroupMenu();
 		groupMenu.setUserGroup(aGroup.getCode());
 		groupMenu.setMenuItem(item.getCode());

--- a/src/test/java/org/isf/menu/test/Tests.java
+++ b/src/test/java/org/isf/menu/test/Tests.java
@@ -253,7 +253,7 @@ public class Tests extends OHCoreTestCase {
 		UserMenuItem menuItem = testUserMenu.setup(false);
 		List<UserMenuItem> userMenuItems = new ArrayList<>();
 		userMenuItems.add(menuItem);
-		assertThat(menuIoOperation.setGroupMenu(userGroup, userMenuItems, true)).isTrue();
+		assertThat(menuIoOperation.setGroupMenu(userGroup, userMenuItems)).isTrue();
 	}
 
 	@Test


### PR DESCRIPTION
Started removing the unused `insert` parameter which was left over from 2015 when it was used to determine whether to close the DB connection.

Also noticed that the routines always returned `true` so there was no need to `and` the `result` from the calls.

Built the new jar and recompiled and tested GUI and API without error.