### PR TITLE
Chore: use consistent form for float and double literals

### DIFF
--- a/src/main/java/org/isf/accounting/model/Bill.java
+++ b/src/main/java/org/isf/accounting/model/Bill.java
@@ -128,8 +128,8 @@ public class Bill extends Auditable<String> implements Cloneable, Comparable<Bil
 		this.isPatient = false;
 		this.patName = "";
 		this.status = "";
-		this.amount = 0.;
-		this.balance = 0.;
+		this.amount = 0.0;
+		this.balance = 0.0;
 		this.user = "admin";
 	}
 

--- a/src/main/java/org/isf/examination/model/PatientExamination.java
+++ b/src/main/java/org/isf/examination/model/PatientExamination.java
@@ -422,7 +422,7 @@ public class PatientExamination extends Auditable<String> implements Comparable<
 	public double getBMI() {
 		if (pex_height != null) {
 			double temp = Math.pow(10, 2); // 2 <-- decimal digits;
-			double height = pex_height * (1. / 100); // convert to m
+			double height = pex_height * (1.0 / 100); // convert to m
 			double weight = pex_weight; // Kg
 			return Math.round(weight / Math.pow(height, 2) * temp) / temp ; //getting Kg/m2
 		} else {

--- a/src/main/java/org/isf/medicalstock/manager/MovStockInsertingManager.java
+++ b/src/main/java/org/isf/medicalstock/manager/MovStockInsertingManager.java
@@ -144,7 +144,7 @@ public class MovStockInsertingManager {
 			}
 			if (GeneralData.LOTWITHCOST && chargingType) {
 				BigDecimal cost = lot.getCost();
-				if (cost == null || cost.doubleValue() <= 0.) {
+				if (cost == null || cost.doubleValue() <= 0.0) {
 					errors.add(new OHExceptionMessage(MessageBundle.getMessage("angal.medicalstock.multiplecharging.zerocostsarenotallowed.msg")));
 				}
 			}

--- a/src/main/java/org/isf/operation/model/OperationRow.java
+++ b/src/main/java/org/isf/operation/model/OperationRow.java
@@ -95,7 +95,7 @@ public class OperationRow extends Auditable<String> {
     private Bill bill;
 
     @Column(name = "OPER_TRANS_UNIT", columnDefinition = "float default 0")
-    private Float transUnit = 0f;
+    private Float transUnit = 0.0f;
     
     @Transient
     private volatile int hashCode;

--- a/src/main/java/org/isf/priceslist/manager/PriceListManager.java
+++ b/src/main/java/org/isf/priceslist/manager/PriceListManager.java
@@ -118,7 +118,7 @@ public class PriceListManager {
 	 * @throws OHServiceException
 	 */
 	public boolean copyList(PriceList list) throws OHServiceException {
-		return copyList(list, 1., 0.);
+		return copyList(list, 1.0, 0.0);
 	}
 
 	/**
@@ -137,7 +137,7 @@ public class PriceListManager {
 	public List<PriceForPrint> convertPrice(PriceList listSelected, Iterable<Price> prices) {
 		List<PriceForPrint> pricePrint = new ArrayList<>();
 		for (Price price : prices) {
-			if (price.getList().getId() == listSelected.getId() && price.getPrice() != 0.) {
+			if (price.getList().getId() == listSelected.getId() && price.getPrice() != 0.0) {
 				PriceForPrint price4print = new PriceForPrint();
 				price4print.setList(listSelected.getName());
 				price4print.setCurrency(listSelected.getCurrency());

--- a/src/test/java/org/isf/examination/test/TestPatientExamination.java
+++ b/src/test/java/org/isf/examination/test/TestPatientExamination.java
@@ -33,12 +33,12 @@ public class TestPatientExamination {
 
 	private LocalDateTime pex_date = LocalDateTime.of(2020, 1, 10, 0, 0, 0);
 	private Integer pex_height = 170;
-	private Double pex_weight = 60.;
+	private Double pex_weight = 60.0;
 	private Integer pex_ap_min = 80;
 	private Integer pex_ap_max = 120;
 	private Integer pex_hr = 60;
-	private Double pex_temp = 36.;
-	private Double pex_sat = 1.;
+	private Double pex_temp = 36.0;
+	private Double pex_sat = 1.0;
 	private Integer pex_hgt = 85;
 	private Integer pex_diuresis = 100;
 	private String pex_diuresis_desc = "physiological";

--- a/src/test/java/org/isf/examination/test/Tests.java
+++ b/src/test/java/org/isf/examination/test/Tests.java
@@ -292,13 +292,13 @@ public class Tests extends OHCoreTestCase {
 	@Test
 	public void testGetBMIdescription() throws Exception {
 		// TODO: if message resources are added to the project this code needs to be changed
-		assertThat(examinationBrowserManager.getBMIdescription(0D)).isEqualTo("angal.examination.bmi.severeunderweight.txt");
-		assertThat(examinationBrowserManager.getBMIdescription(17D)).isEqualTo("angal.examination.bmi.underweight.txt");
-		assertThat(examinationBrowserManager.getBMIdescription(20D)).isEqualTo("angal.examination.bmi.normalweight.txt");
-		assertThat(examinationBrowserManager.getBMIdescription(27D)).isEqualTo("angal.examination.bmi.overweight.txt");
-		assertThat(examinationBrowserManager.getBMIdescription(33D)).isEqualTo("angal.examination.bmi.obesityclassilight.txt");
-		assertThat(examinationBrowserManager.getBMIdescription(37D)).isEqualTo("angal.examination.bmi.obesityclassiimedium.txt");
-		assertThat(examinationBrowserManager.getBMIdescription(100D)).isEqualTo("angal.examination.bmi.obesityclassiiisevere.txt");
+		assertThat(examinationBrowserManager.getBMIdescription(0.0d)).isEqualTo("angal.examination.bmi.severeunderweight.txt");
+		assertThat(examinationBrowserManager.getBMIdescription(17.0d)).isEqualTo("angal.examination.bmi.underweight.txt");
+		assertThat(examinationBrowserManager.getBMIdescription(20.0d)).isEqualTo("angal.examination.bmi.normalweight.txt");
+		assertThat(examinationBrowserManager.getBMIdescription(27.0d)).isEqualTo("angal.examination.bmi.overweight.txt");
+		assertThat(examinationBrowserManager.getBMIdescription(33.0d)).isEqualTo("angal.examination.bmi.obesityclassilight.txt");
+		assertThat(examinationBrowserManager.getBMIdescription(37.0d)).isEqualTo("angal.examination.bmi.obesityclassiimedium.txt");
+		assertThat(examinationBrowserManager.getBMIdescription(100.0d)).isEqualTo("angal.examination.bmi.obesityclassiiisevere.txt");
 	}
 
 	@Test

--- a/src/test/java/org/isf/malnutrition/test/Tests.java
+++ b/src/test/java/org/isf/malnutrition/test/Tests.java
@@ -181,7 +181,7 @@ public class Tests extends OHCoreTestCase {
 		Malnutrition result = malnutritionIoOperation.updateMalnutrition(foundMalnutrition);
 		assertThat(result).isNotNull();
 		Malnutrition updateMalnutrition = malnutritionIoOperationRepository.findById(code).get();
-		assertThat(updateMalnutrition.getHeight()).isCloseTo(200.0F, within(0.000001F));
+		assertThat(updateMalnutrition.getHeight()).isCloseTo(200.0f, within(0.000001f));
 	}
 
 	@Test
@@ -264,7 +264,7 @@ public class Tests extends OHCoreTestCase {
 		Malnutrition result = malnutritionManager.updateMalnutrition(foundMalnutrition);
 		assertThat(result).isNotNull();
 		Malnutrition updateMalnutrition = malnutritionIoOperationRepository.findById(code).get();
-		assertThat(updateMalnutrition.getHeight()).isCloseTo(200.0F, within(0.000001F));
+		assertThat(updateMalnutrition.getHeight()).isCloseTo(200.0f, within(0.000001f));
 	}
 
 	@Test

--- a/src/test/java/org/isf/medicalstock/test/Tests.java
+++ b/src/test/java/org/isf/medicalstock/test/Tests.java
@@ -918,7 +918,7 @@ public class Tests extends OHCoreTestCase {
 			int code = setupTestMovement(false);
 			Movement movement = movementIoOperationRepository.findById(code).get();
 			Lot lot = movement.getLot();
-			lot.setCost(new BigDecimal(0.));
+			lot.setCost(new BigDecimal(0.0));
 			lotIoOperationRepository.saveAndFlush(lot);
 			List<Movement> movements = new ArrayList<>(1);
 			movements.add(movement);

--- a/src/test/java/org/isf/medicalstockward/test/TestMovementWard.java
+++ b/src/test/java/org/isf/medicalstockward/test/TestMovementWard.java
@@ -43,7 +43,7 @@ public class TestMovementWard {
 	private int age = 10;
 	private float weight = 78;
 	private String description = "TestDescriptionm";
-	private Double quantity = 46.;
+	private Double quantity = 46.0;
 	private String units = "TestUni";
 
 	public MovementWard setup(

--- a/src/test/java/org/isf/medicalstockward/test/Tests.java
+++ b/src/test/java/org/isf/medicalstockward/test/Tests.java
@@ -281,10 +281,10 @@ public class Tests extends OHCoreTestCase {
 		patientIoOperationRepository.saveAndFlush(patient);
 		lotIoOperationRepository.saveAndFlush(lot);
 
-		MedicalWard medicalWard = new MedicalWard(ward, medical, 10.0F, 5.0F, lot);
+		MedicalWard medicalWard = new MedicalWard(ward, medical, 10.0f, 5.0f, lot);
 		medicalStockWardIoOperationRepository.saveAndFlush(medicalWard);
 
-		MedicalWard medicalWardTo = new MedicalWard(wardTo, medical, 10.0F, 15.0F, lot);
+		MedicalWard medicalWardTo = new MedicalWard(wardTo, medical, 10.0f, 15.0f, lot);
 		medicalStockWardIoOperationRepository.saveAndFlush(medicalWardTo);
 
 		medicalStockWardIoOperations.newMovementWard(movementWard);
@@ -310,10 +310,10 @@ public class Tests extends OHCoreTestCase {
 		patientIoOperationRepository.saveAndFlush(patient);
 		lotIoOperationRepository.saveAndFlush(lot);
 
-		MedicalWard medicalWard = new MedicalWard(ward, medical, 10.0F, 5.0F, lot);
+		MedicalWard medicalWard = new MedicalWard(ward, medical, 10.0f, 5.0f, lot);
 		medicalStockWardIoOperationRepository.saveAndFlush(medicalWard);
 
-		MedicalWard medicalWardTo = new MedicalWard(wardTo, medical, 10.0F, 15.0F, lot);
+		MedicalWard medicalWardTo = new MedicalWard(wardTo, medical, 10.0f, 15.0f, lot);
 		medicalStockWardIoOperationRepository.saveAndFlush(medicalWardTo);
 
 		medicalStockWardIoOperations.newMovementWard(movementWard);
@@ -407,8 +407,8 @@ public class Tests extends OHCoreTestCase {
 	public void testIoGetMedicalsWardStripEmptyLots() throws Exception {
 		MedicalWardId code = setupTestMedicalWard(false);
 		MedicalWard medicalWard = medicalStockWardIoOperationRepository.findOneWhereCodeAndMedical(code.getWard().getCode(), code.getMedical().getCode());
-		medicalWard.setIn_quantity(10F);
-		medicalWard.setOut_quantity(10F);
+		medicalWard.setIn_quantity(10.0f);
+		medicalWard.setOut_quantity(10.0f);
 		medicalStockWardIoOperationRepository.saveAndFlush(medicalWard);
 		List<MedicalWard> medicalWards = medicalStockWardIoOperations.getMedicalsWard(medicalWard.getWard().getCode().charAt(0), true);
 		assertThat(medicalWards).isEmpty();
@@ -1139,7 +1139,7 @@ public class Tests extends OHCoreTestCase {
 		wardIoOperationRepository.saveAndFlush(ward);
 		patientIoOperationRepository.saveAndFlush(patient);
 
-		assertThat(new MovementWard(ward, LocalDateTime.of(1, 1, 1, 0, 0, 0), true, patient, 32, 150.0F, "description", medical, 100D, "kilo")).isNotNull();
+		assertThat(new MovementWard(ward, LocalDateTime.of(1, 1, 1, 0, 0, 0), true, patient, 32, 150.0f, "description", medical, 100.0d, "kilo")).isNotNull();
 	}
 
 	@Test
@@ -1156,7 +1156,7 @@ public class Tests extends OHCoreTestCase {
 		patientIoOperationRepository.saveAndFlush(patient);
 		lotIoOperationRepository.saveAndFlush(lot);
 
-		assertThat(new MovementWard(ward, LocalDateTime.of(1, 1, 1, 0, 0, 0), true, patient, 32, 150.0F, "description", medical, 100D, "kilo", lot)).isNotNull();
+		assertThat(new MovementWard(ward, LocalDateTime.of(1, 1, 1, 0, 0, 0), true, patient, 32, 150.0f, "description", medical, 100.0d, "kilo", lot)).isNotNull();
 	}
 
 	@Test
@@ -1173,7 +1173,7 @@ public class Tests extends OHCoreTestCase {
 		patientIoOperationRepository.saveAndFlush(patient);
 		lotIoOperationRepository.saveAndFlush(lot);
 
-		assertThat(new MovementWard(ward, lot, "description", medical, 100D, "kilo")).isNotNull();
+		assertThat(new MovementWard(ward, lot, "description", medical, 100.0d, "kilo")).isNotNull();
 	}
 
 	@Test
@@ -1190,8 +1190,8 @@ public class Tests extends OHCoreTestCase {
 		patientIoOperationRepository.saveAndFlush(patient);
 		lotIoOperationRepository.saveAndFlush(lot);
 
-		MovementWard movementWard1 = new MovementWard(ward, lot, "description", medical, 100D, "kilo");
-		MovementWard movementWard2 = new MovementWard(ward, lot, "description", medical, 100D, "kilo");
+		MovementWard movementWard1 = new MovementWard(ward, lot, "description", medical, 100.0d, "kilo");
+		MovementWard movementWard2 = new MovementWard(ward, lot, "description", medical, 100.0d, "kilo");
 		movementWard2.setCode(-1);
 
 		assertThat(movementWard1).isEqualTo(movementWard1);
@@ -1219,7 +1219,7 @@ public class Tests extends OHCoreTestCase {
 		patientIoOperationRepository.saveAndFlush(patient);
 		lotIoOperationRepository.saveAndFlush(lot);
 
-		MovementWard movementWard = new MovementWard(ward, lot, "description", medical, 100D, "kilo");
+		MovementWard movementWard = new MovementWard(ward, lot, "description", medical, 100.0d, "kilo");
 		movementWard.setCode(1);
 
 		// generate hashCode
@@ -1234,7 +1234,7 @@ public class Tests extends OHCoreTestCase {
 	public void testMedicalWardConstructorWith2Parameters() throws Exception {
 		MedicalType medicalType = testMedicalType.setup(true);
 		Medical medical = testMedical.setup(medicalType, true);
-		assertThat(new MedicalWard(medical, 10.0D)).isNotNull();
+		assertThat(new MedicalWard(medical, 10.0d)).isNotNull();
 	}
 
 	@Test
@@ -1242,7 +1242,7 @@ public class Tests extends OHCoreTestCase {
 		MedicalType medicalType = testMedicalType.setup(false);
 		Medical medical = testMedical.setup(medicalType, true);
 		Lot lot = testLot.setup(medical, true);
-		MedicalWard medicalWard = new MedicalWard(medical, 10.0D, lot);
+		MedicalWard medicalWard = new MedicalWard(medical, 10.0d, lot);
 		assertThat(medicalWard.getLot()).isEqualTo(lot);
 	}
 
@@ -1252,7 +1252,7 @@ public class Tests extends OHCoreTestCase {
 		Medical medical = testMedical.setup(medicalType, false);
 		Lot lot = testLot.setup(medical, true);
 		Ward ward = testWard.setup(true);
-		MedicalWard medicalWard = new MedicalWard(medical, 10.0D, lot);
+		MedicalWard medicalWard = new MedicalWard(medical, 10.0d, lot);
 		medicalWard.setId(ward, medical, lot);
 		assertThat(medicalWard.getId()).isEqualTo(new MedicalWardId(ward, medical, lot));
 	}
@@ -1263,7 +1263,7 @@ public class Tests extends OHCoreTestCase {
 		Medical medical = testMedical.setup(medicalType, false);
 		Lot lot = testLot.setup(medical, true);
 		Ward ward = testWard.setup(true);
-		MedicalWard medicalWard = new MedicalWard(medical, 10.0D, lot);
+		MedicalWard medicalWard = new MedicalWard(medical, 10.0d, lot);
 		assertThat(medicalWard.getLot()).isEqualTo(lot);
 	}
 
@@ -1273,14 +1273,14 @@ public class Tests extends OHCoreTestCase {
 		Medical medical1 = testMedical.setup(medicalType1, false);
 		Lot lot1 = testLot.setup(medical1, true);
 		Ward ward1 = testWard.setup(true);
-		MedicalWard medicalWard1 = new MedicalWard(medical1, 10.0D, lot1);
+		MedicalWard medicalWard1 = new MedicalWard(medical1, 10.0d, lot1);
 
 		MedicalType medicalType2 = testMedicalType.setup(true);
 		Medical medical2 = testMedical.setup(medicalType2, false);
 		Lot lot2 = testLot.setup(medical2, true);
 		lot2.setCode("second");
 		Ward ward2 = testWard.setup(true);
-		MedicalWard medicalWard2 = new MedicalWard(medical2, 10.0D, lot2);
+		MedicalWard medicalWard2 = new MedicalWard(medical2, 10.0d, lot2);
 
 		assertThat(medicalWard1.compareTo(1)).isZero();
 		assertThat(medicalWard1.compareTo(medicalWard2)).isZero();
@@ -1299,14 +1299,14 @@ public class Tests extends OHCoreTestCase {
 		Medical medical1 = testMedical.setup(medicalType1, false);
 		Lot lot1 = testLot.setup(medical1, true);
 		Ward ward1 = testWard.setup(true);
-		MedicalWard medicalWard1 = new MedicalWard(medical1, 10.0D, lot1);
+		MedicalWard medicalWard1 = new MedicalWard(medical1, 10.0d, lot1);
 
 		MedicalType medicalType2 = testMedicalType.setup(true);
 		Medical medical2 = testMedical.setup(medicalType2, false);
 		Lot lot2 = testLot.setup(medical2, true);
 		lot2.setCode("second");
 		Ward ward2 = testWard.setup(true);
-		MedicalWard medicalWard2 = new MedicalWard(medical2, 10.0D, lot2);
+		MedicalWard medicalWard2 = new MedicalWard(medical2, 10.0d, lot2);
 
 		assertThat(medicalWard1).isEqualTo(medicalWard1);
 		assertThat(medicalWard1)

--- a/src/test/java/org/isf/operation/test/TestOperationRow.java
+++ b/src/test/java/org/isf/operation/test/TestOperationRow.java
@@ -41,7 +41,7 @@ public class TestOperationRow {
 	private Admission admission;
 	private Opd opd;
 	private Bill bill;
-	private Float transUnit = 10.F;
+	private Float transUnit = 10.0f;
 
 	public OperationRow setup(Operation operation, boolean usingSet) throws OHException {
 		OperationRow operationRow;

--- a/src/test/java/org/isf/operation/test/Tests.java
+++ b/src/test/java/org/isf/operation/test/Tests.java
@@ -976,10 +976,10 @@ public class Tests extends OHCoreTestCase {
 				deliveryType, deliveryResult, false);
 
 		OperationRow operationRow1 = new OperationRow(operation, "prescriber", "opResult", LocalDateTime.of(2021, 1, 1, 0, 0, 0), "remarks", admission, new Opd(),
-				null, 10.0F);
+				null, 10.0f);
 
 		OperationRow operationRow2 = new OperationRow(1, operation, "prescriber", "opResult", LocalDateTime.of(2021, 1, 1, 0, 0, 0), "remarks", admission,
-				new Opd(), null, 10.0F);
+				new Opd(), null, 10.0f);
 
 		operationRow1.setId(1);
 		assertThat(operationRow1).isEqualTo(operationRow2);

--- a/src/test/java/org/isf/priceslist/test/Tests.java
+++ b/src/test/java/org/isf/priceslist/test/Tests.java
@@ -202,7 +202,7 @@ public class Tests extends OHCoreTestCase {
 		// then:
 		Price copyPrice = priceIoOperationRepository.findAll().get(1);
 		assertThat(copyPrice.getId()).isEqualTo(id + 1);
-		assertThat(copyPrice.getPrice()).isCloseTo(2 * price.getPrice(), within(0.10D));
+		assertThat(copyPrice.getPrice()).isCloseTo(2 * price.getPrice(), within(0.10d));
 	}
 
 	@Test
@@ -218,7 +218,7 @@ public class Tests extends OHCoreTestCase {
 		// then:
 		Price copyPrice = priceIoOperationRepository.findAll().get(1);
 		assertThat(copyPrice.getId()).isEqualTo(id + 1);
-		assertThat(copyPrice.getPrice()).isCloseTo(Math.round(2 * price.getPrice() / 3) * 3, within(0.10D));
+		assertThat(copyPrice.getPrice()).isCloseTo(Math.round(2 * price.getPrice() / 3) * 3, within(0.10d));
 	}
 
 	@Test
@@ -282,7 +282,7 @@ public class Tests extends OHCoreTestCase {
 		priceListManager.copyList(priceList, 2, 0);
 		Price copyPrice = priceIoOperationRepository.findAll().get(1);
 		assertThat(copyPrice.getId()).isEqualTo(id + 1);
-		assertThat(copyPrice.getPrice()).isCloseTo(2 * price.getPrice(), within(0.10D));
+		assertThat(copyPrice.getPrice()).isCloseTo(2 * price.getPrice(), within(0.10d));
 	}
 
 	@Test
@@ -293,7 +293,7 @@ public class Tests extends OHCoreTestCase {
 		priceListManager.copyList(priceList, 2, 3);
 		Price copyPrice = priceIoOperationRepository.findAll().get(1);
 		assertThat(copyPrice.getId()).isEqualTo(id + 1);
-		assertThat(copyPrice.getPrice()).isCloseTo(Math.round(2 * price.getPrice() / 3) * 3, within(0.10D));
+		assertThat(copyPrice.getPrice()).isCloseTo(Math.round(2 * price.getPrice() / 3) * 3, within(0.10d));
 	}
 
 	@Test


### PR DESCRIPTION
The code used a mixture of formats for numeric literals so changed them to the most common form which has a value after the period (`1.0` instead of `1.`) and lower case for the numeric type (`f` instead of `F` and `d` instead of `D`),