### PR TITLE
Chore: remove pre-sized array

### DIFF
--- a/src/main/java/org/isf/opd/service/OpdIoOperationRepositoryImpl.java
+++ b/src/main/java/org/isf/opd/service/OpdIoOperationRepositoryImpl.java
@@ -115,7 +115,7 @@ public class OpdIoOperationRepositoryImpl implements OpdIoOperationRepositoryCus
 		predicates.add(
 				cb.between(opd.<LocalDateTime>get("date"), dateFrom.atStartOfDay(), dateTo.plusDays(1).atStartOfDay())
 		);
-		query.where(cb.and(predicates.toArray(new Predicate[predicates.size()])));
+		query.where(cb.and(predicates.toArray(new Predicate[0])));
 
 		return entityManager.createQuery(query);
 	}

--- a/src/main/java/org/isf/patient/service/PatientIoOperationRepositoryImpl.java
+++ b/src/main/java/org/isf/patient/service/PatientIoOperationRepositoryImpl.java
@@ -83,7 +83,7 @@ public class PatientIoOperationRepositoryImpl implements PatientIoOperationRepos
 				cb.isNull(patientRoot.get("deleted"))
 		));
 
-		query.where(cb.and(where.toArray(new Predicate[where.size()])));
+		query.where(cb.and(where.toArray(new Predicate[0])));
 		query.orderBy(cb.desc(patientRoot.get("code")));
 
 		return query;
@@ -132,7 +132,7 @@ public class PatientIoOperationRepositoryImpl implements PatientIoOperationRepos
 				}
 			}
 		}
-		query.select(patient).where(cb.and(predicates.toArray(new Predicate[predicates.size()])));
+		query.select(patient).where(cb.and(predicates.toArray(new Predicate[0])));
 
 		return entityManager.createQuery(query).getResultList();
 	}

--- a/src/main/java/org/isf/patvac/service/PatVacIoOperationRepositoryImpl.java
+++ b/src/main/java/org/isf/patvac/service/PatVacIoOperationRepositoryImpl.java
@@ -102,7 +102,7 @@ public class PatVacIoOperationRepositoryImpl implements PatVacIoOperationReposit
 				cb.between(pvRoot.join("patient").<Integer>get("age"), ageFrom, ageTo)
 			);
 		}
-		query.where(cb.and(predicates.toArray(new Predicate[predicates.size()])));
+		query.where(cb.and(predicates.toArray(new Predicate[0])));
 		query.orderBy(cb.desc(pvRoot.get("vaccineDate")), cb.asc(pvRoot.get("code")));
 
 		return query;


### PR DESCRIPTION
There are two styles to convert a collection to an array:

- A pre-sized array, for example, c.toArray(new String[c.size()])
- An empty array, for example, c.toArray(new String[0])

In older Java versions, using a pre-sized array was recommended, as the reflection call necessary to create an array of proper size was quite slow.

However, since late updates of OpenJDK 6, this call was intrinsified, making the performance of the empty array version the same, and sometimes even better, compared to the pre-sized version. Also, passing a pre-sized array is dangerous for a concurrent or synchronized collection as a data race is possible between the size and toArray calls. This may result in extra nulls at the end of the array if the collection was concurrently shrunk during the operation.