### PR TITLE
OP-1130 JPA admtype changes (take 2)

### DIFF
--- a/src/main/java/org/isf/admtype/service/AdmissionTypeIoOperation.java
+++ b/src/main/java/org/isf/admtype/service/AdmissionTypeIoOperation.java
@@ -54,38 +54,36 @@ public class AdmissionTypeIoOperation
 	/**
 	 * Updates the specified {@link AdmissionType}.
 	 * @param admissionType the admission type to update.
-	 * @return <code>true</code> if the admission type has been updated, <code>false</code> otherwise.
+	 * @return the updated {@link AdmissionType} object.
 	 * @throws OHServiceException if an error occurs during the update.
 	 */
-	public boolean updateAdmissionType(AdmissionType admissionType) throws OHServiceException {
-		return repository.save(admissionType) != null;
+	public AdmissionType updateAdmissionType(AdmissionType admissionType) throws OHServiceException {
+		return repository.save(admissionType);
 	}
 
 	/**
 	 * Stores a new {@link AdmissionType}.
 	 * @param admissionType the admission type to store.
-	 * @return <code>true</code> if the admission type has been stored, <code>false</code> otherwise.
+	 * @return the new {@link AdmissionType} object.
 	 * @throws OHServiceException if an error occurs during the storing operation.
 	 */
-	public boolean newAdmissionType(AdmissionType admissionType) throws OHServiceException {
-		return repository.save(admissionType) != null;
+	public AdmissionType newAdmissionType(AdmissionType admissionType) throws OHServiceException {
+		return repository.save(admissionType);
 	}
 
 	/**
 	 * Deletes the specified {@link AdmissionType}.
 	 * @param admissionType the admission type to delete.
-	 * @return <code>true</code> if the admission type has been deleted, <code>false</code> otherwise.
 	 * @throws OHServiceException if an error occurs during the delete operation.
 	 */
-	public boolean deleteAdmissionType(AdmissionType admissionType) throws OHServiceException {
+	public void deleteAdmissionType(AdmissionType admissionType) throws OHServiceException {
 		repository.delete(admissionType);
-		return true;
 	}
 
 	/**
 	 * Checks if the specified Code is already used by others {@link AdmissionType}s.
 	 * @param code the admission type code to check.
-	 * @return <code>true</code> if the code is already used, <code>false</code> otherwise.
+	 * @return {@code true} if the code is already used, <code>false</code> otherwise.
 	 * @throws OHServiceException if an error occurs during the check.
 	 */
 	public boolean isCodePresent(String code) throws OHServiceException {

--- a/src/main/java/org/isf/utils/tuple/JPAImmutableTriple.java
+++ b/src/main/java/org/isf/utils/tuple/JPAImmutableTriple.java
@@ -1,0 +1,66 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2023 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.isf.utils.tuple;
+
+import java.util.List;
+
+public final class JPAImmutableTriple {
+
+	private boolean result;
+	private Object object;
+	private List<String> errors;
+
+	/**
+	 * Create a new JPA immutable triple instance.
+	 *
+	 * @param result the Boolean result of the action.
+	 * @param object the object of the action.
+	 * @param errors the {@code List<String>} of formatted error messages.
+	 */
+	public JPAImmutableTriple(boolean result, Object object, List<String> errors) {
+		this.result = result;
+		this.object = object;
+		this.errors = errors;
+	}
+
+	/**
+	 * @return {@code true} if successful, otherwise {@code false}.
+	 */
+	public boolean getResult() {
+		return result;
+	}
+
+	/**
+	 * @return the object associated with the operation.
+	 */
+	public Object getObject() {
+		return object;
+	}
+
+	/**
+	 * @return {@code List<String>} of formatted message text
+	 */
+	public List<String> getErrors() {
+		return errors;
+	}
+
+}


### PR DESCRIPTION
See OP-1130

This is a second attempt at implementing the issue.

The most significant change is the addition of `JPAImmutableTriple` which is used to return values from CRUD operations.  The attempt is to remove checked exceptions that litter the code and catch them in the `manager` level where possible and return appropriate information to the caller.

The `JPAImmutableTriple` has 3 fields (thus its name):

1. result:  true or false based on the success of the call
2. object:  the object being processed; the new object after save, the updated object after update, and null when the object is deleted
3. errors: a list of formatted string objects that are the associated error message text(s); if the operation was a success there are not messages and the value is null.

If this seems reasonable and acceptable I have the corresponding changes ready for GUI and API.