### PR TITLE
Chore: upgrade to Spring Framework 5.3.31

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 		<oh.version>1.13.0-SNAPSHOT</oh.version>
 		<java.version>11</java.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<spring.framework.version>5.3.30</spring.framework.version>
+		<spring.framework.version>5.3.31</spring.framework.version>
 		<spring.boot.version>2.7.17</spring.boot.version>
 		<jasperreports.version>6.20.6</jasperreports.version>
 		<spring.cloud.starter.openfeign.version>3.1.8</spring.cloud.starter.openfeign.version>


### PR DESCRIPTION
Release Notes:  https://github.com/spring-projects/spring-framework/releases/tag/v5.3.31