### PR TITLE
Chore: upgrade to Spring Boot 2.7.18

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 		<java.version>11</java.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<spring.framework.version>5.3.31</spring.framework.version>
-		<spring.boot.version>2.7.17</spring.boot.version>
+		<spring.boot.version>2.7.18</spring.boot.version>
 		<jasperreports.version>6.20.6</jasperreports.version>
 		<spring.cloud.starter.openfeign.version>3.1.8</spring.cloud.starter.openfeign.version>
 		<license.maven.plugin.version>4.3</license.maven.plugin.version>


### PR DESCRIPTION
Release Notes: https://github.com/spring-projects/spring-boot/releases/tag/v2.7.18