### PR TITLE
OP-1163 revert update to dcm4ch3 jars because of JDK17

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -289,22 +289,22 @@
 		<dependency>
 			<groupId>org.dcm4che</groupId>
 			<artifactId>dcm4che-core</artifactId>
-			<version>5.31.2</version>
+			<version>5.31.0</version>
 		</dependency>
 		<dependency>
 			<groupId>org.dcm4che</groupId>
 			<artifactId>dcm4che-image</artifactId>
-			<version>5.31.2</version>
+			<version>5.31.0</version>
 		</dependency>
 		<dependency>
 			<groupId>org.dcm4che</groupId>
 			<artifactId>dcm4che-imageio</artifactId>
-			<version>5.31.2</version>
+			<version>5.31.0</version>
 		</dependency>
 		<dependency>
 			<groupId>org.dcm4che</groupId>
 			<artifactId>dcm4che-imageio-opencv</artifactId>
-			<version>5.31.2</version>
+			<version>5.31.0</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.poi</groupId>


### PR DESCRIPTION
See OP-1163

Guess this is another reason to move to JDK 17 :smirk: 