### PR TITLE
Chore: make all the dcm4che jars the same level

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -303,7 +303,7 @@
 		<dependency>
 			<groupId>org.dcm4che</groupId>
 			<artifactId>dcm4che-core</artifactId>
-			<version>5.31.0</version>
+			<version>5.31.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.dcm4che</groupId>


### PR DESCRIPTION
All the other jars are 5.31.2