### PR TITLE
Chore: update maven.yml for JDK 17

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -14,10 +14,12 @@ jobs:
       matrix:
         java: [ 17 ]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up JDK ${{ matrix.java }}
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v4
       with:
+        distribution: 'zulu'
         java-version: ${{ matrix.java }}
+        java-package: jdk
     - name: Build with Maven
       run: mvn -B package --file pom.xml


### PR DESCRIPTION
Need to explicitly require the JDK and it doesn't hurt to specify the distribution.