### PR TITLE
OP-1202 Fix Pharmaceutical deletions error message

### DIFF
--- a/src/main/java/org/isf/medicals/service/MedicalsIoOperations.java
+++ b/src/main/java/org/isf/medicals/service/MedicalsIoOperations.java
@@ -219,7 +219,7 @@ public class MedicalsIoOperations
 	 * @throws OHServiceException if an error occurs during the check.
 	 */
 	public boolean isMedicalReferencedInStockMovement(int code) throws OHServiceException {
-		return moveRepository.findAllByMedicalCode(code) != null;
+		return moveRepository.findAllByMedicalCode(code).size() > 0;
 	}
 
 	/**

--- a/src/main/java/org/isf/medicalstock/service/MovementIoOperationRepository.java
+++ b/src/main/java/org/isf/medicalstock/service/MovementIoOperationRepository.java
@@ -35,7 +35,7 @@ import org.springframework.stereotype.Repository;
 public interface MovementIoOperationRepository extends JpaRepository<Movement, Integer>, MovementIoOperationRepositoryCustom {
 
 	@Query(value = "select m from Movement m join m.medical med where med.code = :code")
-	Movement findAllByMedicalCode(@Param("code") Integer code);
+	List<Movement> findAllByMedicalCode(@Param("code") Integer code);
 
 	@Query(value = "select m from Movement m join m.medical med where med.code = :code")
 	Movement findAllByMedicalCodeOrderByLot_(@Param("code") Integer code);


### PR DESCRIPTION
See OP-1202

The failure was caused by throwing an exception because the query result expects a single `Movement` and not a `List` of `Movement`s which is the case here.