### PR TITLE
OP-1148: change jar and version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -145,8 +145,8 @@
 		</dependency>
 		<dependency>
 			<groupId>org.dcm4che</groupId>
-			<artifactId>dcm4che-imageio-opencv</artifactId>
-			<version>5.31.1</version>
+			<artifactId>dcm4che-imageio</artifactId>
+			<version>5.31.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.igniterealtime.smack</groupId>


### PR DESCRIPTION
See OP-1148

Change because `dcm4che-imageio-opencv` jar is not needed; `dcm4che-imageio` is sufficient.

Note that `dcm4che-imageio` brings with it `dcm4he-core` and `dcm4che-image`

Updated the version too.