### PR TITLE
Chore: update SpringBoot 3.2.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.2.4</version>
+		<version>3.2.5</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 
@@ -166,7 +166,7 @@
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-reload4j</artifactId>
-			<version>2.0.12</version>
+			<version>2.0.13</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>


### PR DESCRIPTION
Update SpringBoot 3.2.5 and related dependencies 

Release Notes:  https://github.com/spring-projects/spring-boot/releases/tag/v3.2.5