### PR TITLE
Chore: update to Spring Boot 3.2.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.2.5</version>
+		<version>3.2.7</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 


### PR DESCRIPTION
Both GUI and API tested after the change without any obvious issues

This seemed like a safer change then the one suggested in https://github.com/informatici/openhospital-core/pull/1339