### PR TITLE
OP-1236 Update JNA dependecies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,6 +73,16 @@
 			<version>4.0.6</version>
 		</dependency>
 		<dependency>
+		    <groupId>net.java.dev.jna</groupId>
+		    <artifactId>jna</artifactId>
+		    <version>5.14.0</version>
+		</dependency>
+		<dependency>
+		    <groupId>net.java.dev.jna</groupId>
+		    <artifactId>jna-platform</artifactId>
+		    <version>5.14.0</version>
+		</dependency>
+		<dependency>
 			<groupId>org.apache.poi</groupId>
 			<artifactId>poi-ooxml</artifactId>
 			<version>5.2.5</version>


### PR DESCRIPTION
See OP-1236.

It seems that some tests fail in some environment without an updated JNA version.