### PR TITLE
Chore: previous test proves it is empty so remove next test

### DIFF
--- a/src/test/java/org/isf/generaldata/configProvider/TestJsonFileConfigProvider.java
+++ b/src/test/java/org/isf/generaldata/configProvider/TestJsonFileConfigProvider.java
@@ -55,7 +55,6 @@ public class TestJsonFileConfigProvider {
 		Map<String, Object> configData = jsonFileConfigProvider.getConfigData();
 
 		assertThat(configData).isEmpty();
-		assertThat(configData.get("oh_telemetry_url")).isNull();
 
 		assertThat(jsonFileConfigProvider.get("someParam")).isNull();
 


### PR DESCRIPTION
Line 57 shows `configData` is empty so testing a `get` on the object is silly.