### PR TITLE
Chore: changes found from bad local variable naming conventions

### DIFF
--- a/src/test/java/org/isf/lab/Tests.java
+++ b/src/test/java/org/isf/lab/Tests.java
@@ -65,6 +65,7 @@ import org.springframework.context.ApplicationEventPublisher;
 
 class Tests extends OHCoreTestCase {
 
+	private static final String DRAFT = LaboratoryStatus.draft.toString();
 	private static TestLaboratory testLaboratory;
 	private static TestLaboratoryRow testLaboratoryRow;
 	private static TestExam testExam;
@@ -842,7 +843,6 @@ class Tests extends OHCoreTestCase {
 	@MethodSource("labExtended")
 	void testMgrUpdateExamRequest(boolean labExtended) throws Exception {
 		GeneralData.LABEXTENDED = labExtended;
-		String DRAFT = LaboratoryStatus.draft.toString();
 		ExamType examType = testExamType.setup(false);
 		Exam exam = testExam.setup(examType, 1, false);
 		Patient patient = testPatient.setup(false);

--- a/src/test/java/org/isf/utils/excel/MockResultSet.java
+++ b/src/test/java/org/isf/utils/excel/MockResultSet.java
@@ -44,7 +44,6 @@ public class MockResultSet {
 
 	private MockResultSet(String[] columnNames, Object[][] data) {
 		// create a map of column name to column index
-		Object LinkedHashMap;
 		this.columnIndices = IntStream.range(0, columnNames.length)
 						.boxed()
 						.collect(Collectors.toMap(


### PR DESCRIPTION
Found local variables that started with a capital letter.  In one case it should be a `static final` and in the other the variable isn't needed.