### PR TITLE
Chore: fix Javadoc errors

### DIFF
--- a/src/main/java/org/isf/medicalinventory/manager/MedicalInventoryManager.java
+++ b/src/main/java/org/isf/medicalinventory/manager/MedicalInventoryManager.java
@@ -133,7 +133,7 @@ public class MedicalInventoryManager {
 	 * Return a list {@link MedicalInventory}s for passed params.
 	 *
 	 * @param status - the {@link MedicalInventory} status.
-	 * @param type - the {@link MedicalInventory} type.
+	 * @param inventoryType - the {@link MedicalInventory} type.
 	 * @return the list of {@link MedicalInventory}s. It could be {@code empty}.
 	 * @throws OHServiceException
 	 */
@@ -253,7 +253,7 @@ public class MedicalInventoryManager {
 
 		// TODO: To decide if to make allMedicals parameter
 		boolean allMedicals = true;
-		List<Movement> movs = new ArrayList<Movement>();
+		List<Movement> movs = new ArrayList<>();
 		List<Medical> inventoryMedicalsList = inventoryRowSearchList.stream()
 						.map(MedicalInventoryRow::getMedical)
 						.distinct()

--- a/src/main/java/org/isf/medicalinventory/service/MedicalInventoryIoOperation.java
+++ b/src/main/java/org/isf/medicalinventory/service/MedicalInventoryIoOperation.java
@@ -108,7 +108,7 @@ public class MedicalInventoryIoOperation {
 	 * Return a list of {@link MedicalInventory}s for passed params.
 	 *
 	 * @param status - the {@link MedicalInventory} status.
-	 * @param type - the {@link MedicalInventory} type.
+	 * @param inventoryType - the {@link MedicalInventory} type.
 	 * @return the list of {@link MedicalInventory}s. It could be {@code empty}.
 	 * @throws OHServiceException
 	 */

--- a/src/main/java/org/isf/medicalstock/manager/MovStockInsertingManager.java
+++ b/src/main/java/org/isf/medicalstock/manager/MovStockInsertingManager.java
@@ -463,7 +463,7 @@ public class MovStockInsertingManager {
 	/**
 	 * Retrieves all medicals referencing the specified code.
 	 * 
-	 * @param lotCode the lot code.
+	 * @param code the lot code.
 	 * @return the ids of medicals referencing the specified lot.
 	 * @throws OHServiceException if an error occurs retrieving the referencing medicals.
 	 */


### PR DESCRIPTION
In the process removed declaring the type in `new ArrayList<>()`