### PR TITLE
Chore: upgrade to Spring Boot 3.3.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.3.4</version>
+		<version>3.3.5</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 


### PR DESCRIPTION
See Release Notes: https://github.com/spring-projects/spring-boot/releases/tag/v3.3.5

Includes Spring Framework 6.1.14 which fixes two CVEs; see https://spring.io/blog/2024/10/17/spring-framework-cve-2024-38819-and-cve-2024-38820-published

Tests run cleanly.