### PR TITLE
Chore: redundant operation on java.time object

### DIFF
--- a/src/main/java/org/isf/accounting/manager/BillBrowserManager.java
+++ b/src/main/java/org/isf/accounting/manager/BillBrowserManager.java
@@ -60,8 +60,8 @@ public class BillBrowserManager {
 
 		LocalDateTime today = TimeTools.getNow();
 		LocalDateTime upDate;
-		LocalDateTime firstPay = LocalDateTime.from(today);
-		LocalDateTime lastPay = LocalDateTime.from(today);
+		LocalDateTime firstPay = today;
+		LocalDateTime lastPay = today;
 
 		LocalDateTime billDate = bill.getDate();
 		if (!billPayments.isEmpty()) {


### PR DESCRIPTION
If you look at the implementation of `LocalDataTime.from()' you will find:

<pre>
  public static LocalDateTime from(TemporalAccessor temporal) {
        if (temporal instanceof LocalDateTime) {
            return (LocalDateTime) temporal;
        } else if (temporal instanceof ZonedDateTime) {
</pre>

So the existing line:
<pre>
LocalDateTime firstPay = LocalDateTime.from(today);
</pre>

would take the first if-branch and just return the parameter passed in.

So there is no need to call the method as `today` is a `LocalDateTime` object.