### PR TITLE
OP-1380: deprecate Lot constructor without Medical

### DIFF
--- a/src/main/java/org/isf/medicalstock/model/Lot.java
+++ b/src/main/java/org/isf/medicalstock/model/Lot.java
@@ -129,15 +129,8 @@ public class Lot extends Auditable<String> {
 		code = aCode;
 	}
 
-	/**
-	 * This method should not exist without a (@link Medical}, this method can lead to bad coding
-	 * @param aCode
-	 * @param aPreparationDate
-	 * @param aDueDate
-	 * @deprecated
-	 */
-	@Deprecated
-	public Lot(String aCode, LocalDateTime aPreparationDate, LocalDateTime aDueDate) {
+	public Lot(Medical aMedical, String aCode, LocalDateTime aPreparationDate, LocalDateTime aDueDate) {
+		medical = aMedical;
 		code = aCode;
 		preparationDate = TimeTools.truncateToSeconds(aPreparationDate);
 		dueDate = TimeTools.truncateToSeconds(aDueDate);

--- a/src/main/java/org/isf/medicalstock/model/Lot.java
+++ b/src/main/java/org/isf/medicalstock/model/Lot.java
@@ -129,6 +129,14 @@ public class Lot extends Auditable<String> {
 		code = aCode;
 	}
 
+	/**
+	 * This method should not exist without a (@link Medical}, this method can lead to bad coding
+	 * @param aCode
+	 * @param aPreparationDate
+	 * @param aDueDate
+	 * @deprecated
+	 */
+	@Deprecated
 	public Lot(String aCode, LocalDateTime aPreparationDate, LocalDateTime aDueDate) {
 		code = aCode;
 		preparationDate = TimeTools.truncateToSeconds(aPreparationDate);

--- a/src/test/java/org/isf/medicalstock/Tests.java
+++ b/src/test/java/org/isf/medicalstock/Tests.java
@@ -1262,8 +1262,12 @@ class Tests extends OHCoreTestCase {
 
 	@ParameterizedTest(name = "Test with AUTOMATICLOT_IN={0}, AUTOMATICLOT_OUT={1}, AUTOMATICLOTWARD_TOWARD={2}")
 	@MethodSource("automaticlot")
-	void testLotHashCode() {
-		Lot lot = new Lot("aCode", TimeTools.getNow(), TimeTools.getNow());
+	void testLotHashCode() throws Exception {
+		MedicalType medicalType = testMedicalType.setup(false);
+		medicalTypeIoOperationRepository.saveAndFlush(medicalType);
+		Medical medical = testMedical.setup(medicalType, true);
+		medicalsIoOperationRepository.saveAndFlush(medical);
+		Lot lot = new Lot(medical, "aCode", TimeTools.getNow(), TimeTools.getNow(), new BigDecimal(10.10));
 		int hashCode = lot.hashCode();
 		assertThat(hashCode).isPositive();
 		// use computed value


### PR DESCRIPTION
See OP-1380

There 4 uses of the deprecated method in GUI

- WardPharmacyRectify
- MovStockMultipleDischarging
- MovStockMultipeCharging (twice)
