### PR TITLE
Chore: remove TODO comment as the change was made in the code

### DIFF
--- a/src/main/java/org/isf/admission/service/AdmissionIoOperations.java
+++ b/src/main/java/org/isf/admission/service/AdmissionIoOperations.java
@@ -253,8 +253,6 @@ public class AdmissionIoOperations {
 	 * The default path ({@code testing == false}) ensures that the code performs as it
 	 * always has in the past.
 	 * This code permits the unit testing of maternity wards with dates before and after June.
-	 * TODO: once the LocalDateTime object is replaced by Java 8+ date/time objects this can be revisited
-	 * as there is more flexibility in modifying the new objects in Java 8+.
 	 */
 	public static boolean testing;
 	public static boolean afterJune;


### PR DESCRIPTION
The change to use JAVA 8+ objects was made in OP-282 and OP-101 12/10/2021