### PR TITLE
Chore: use equals() for boxed types

### DIFF
--- a/src/main/java/org/isf/medicalinventory/manager/MedicalInventoryManager.java
+++ b/src/main/java/org/isf/medicalinventory/manager/MedicalInventoryManager.java
@@ -579,7 +579,7 @@ public class MedicalInventoryManager {
 		boolean existWithSuffixCharge = movStockInsertingManager.refNoExists(chargeReferenceNumber);
 		boolean existWithSuffixDischarge = movStockInsertingManager.refNoExists(dischargeReferenceNumber);
 		MedicalInventory inventory = this.getInventoryByReference(reference);
-		if (existWithSuffixCharge || existWithSuffixDischarge || inventory != null && inventory.getId() != medicalInventory.getId()) {
+		if (existWithSuffixCharge || existWithSuffixDischarge || inventory != null && !inventory.getId().equals(medicalInventory.getId())) {
 			errors.add(new OHExceptionMessage(MessageBundle.getMessage("angal.inventory.referencealreadyused.msg")));
 		}
 		if (!errors.isEmpty()) {


### PR DESCRIPTION
It is wrong to use reference equality (== or !=) for java.lang.Integer (and other boxed types and strings) because it is not comparing actual values but locations in memory.