### PR TITLE
Chore bump versions of openfeign and feign-gson

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,7 @@
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-starter-openfeign</artifactId>
-			<version>4.0.6</version>
+			<version>4.3.1</version>
 		</dependency>
 		<dependency>
 		    <groupId>net.java.dev.jna</groupId>
@@ -101,7 +101,12 @@
 		<dependency>
 			<groupId>io.github.openfeign</groupId>
 			<artifactId>feign-gson</artifactId>
-			<version>13.6</version>
+			<version>13.11</version>
+		</dependency>
+		<dependency>
+			<groupId>io.github.openfeign</groupId>
+			<artifactId>feign-core</artifactId>
+			<version>13.11</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.commons</groupId>


### PR DESCRIPTION
This is an intermediate fix for updating openfeign and feign-gson.

This is the same update as https://github.com/informatici/openhospital-core/pull/1568
That is feign-gson moves from 13.6 to 13.11 and added fiegn-core to resolve a compile dependency.

And updates this https://github.com/informatici/openhospital-core/pull/1551 but not all the way to version 5.
That is spring-cloud-starter-openfeign moves from 4.0.6 to 4.3.1 (the last version of the 4.x.x track) instead the major update to version 5.

Once this is there we can address the class incompatibility in the compile step. This is an intermediate fix for updating openfeign and feign-gson.

It made more sense then trying to fix everything in one PR.