### PR TITLE
Chore: move to last 3.x.x version of Spring Boot

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.6</version>
+		<version>3.5.14</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -21,13 +21,26 @@
 	<artifactId>OH-core</artifactId>
 	<packaging>jar</packaging>
 	<version>1.15.0</version>
-
+	
 	<properties>
 		<java.version>17</java.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<jasperreports.version>7.0.6</jasperreports.version>
 		<license.maven.plugin.version>5.0.0</license.maven.plugin.version>
+		<spring-cloud.version>2025.0.1</spring-cloud.version>
 	</properties>
+	
+	<dependencyManagement>
+	    <dependencies>
+	        <dependency>
+	            <groupId>org.springframework.cloud</groupId>
+	            <artifactId>spring-cloud-dependencies</artifactId>
+	            <version>${spring-cloud.version}</version>
+	            <type>pom</type>
+	            <scope>import</scope>
+	        </dependency>
+	    </dependencies>
+	</dependencyManagement>
 
 	<dependencies>
 		<dependency>
@@ -81,7 +94,7 @@
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-starter-openfeign</artifactId>
-			<version>4.3.1</version>
+			<!--<version>4.3.1</version> got from dependencies management above -->
 		</dependency>
 		<dependency>
 		    <groupId>net.java.dev.jna</groupId>

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -15,7 +15,4 @@ spring:
         format_sql: ${hibernate.format_sql:true}
         hbm2ddl:
           auto: ${hibernate.hbm2ddl.auto:none}
-  cloud:
-    compatibility-verifier:
-      enabled: false
 

--- a/src/test/java/org/isf/sms/Tests.java
+++ b/src/test/java/org/isf/sms/Tests.java
@@ -38,6 +38,7 @@ import org.isf.menu.model.UserGroup;
 import org.isf.sessionaudit.model.UserSession;
 import org.isf.sms.manager.SmsManager;
 import org.isf.sms.model.Sms;
+import org.isf.sms.providers.SmsSenderInterface;
 import org.isf.sms.service.SmsIoOperationRepository;
 import org.isf.sms.service.SmsOperations;
 import org.isf.sms.service.SmsSender;
@@ -371,16 +372,16 @@ class Tests extends OHCoreTestCase {
 		assertThat(dummySmsSenderOperatinos.sendSMS(sms)).isFalse();
 	}
 
-//	Waiting for OP-1354 fix
-//	@Test
-//	void testSmsSenderOperationsSendSMSFailure() throws Exception {
-//		Sms sms = testSms.setup(true);
-//		sms.setSmsNumber("+1320241494");
-//		sms.setSmsText("SomeText");
-//		assertThat(smsSenderOperations.initialize()).isTrue();
-//		smsSenderOperations.preSMSSending(sms);
-//		assertThat(smsSenderOperations.sendSMS(sms)).isFalse();
-//	}
+	@Test
+	void testSmsSenderOperationsSendSMSFailure() throws Exception {
+		Sms sms = testSms.setup(true);
+		sms.setSmsNumber("+1320241494");
+		sms.setSmsText("SomeText");
+		SmsSenderOperations failingSmsSenderOperations = new SmsSenderOperations(new ConfiguredSmsGatewayEnvironmentStub(), List.of(new FailingSmsGateway()));
+		assertThat(failingSmsSenderOperations.initialize()).isTrue();
+		failingSmsSenderOperations.preSMSSending(sms);
+		assertThat(failingSmsSenderOperations.sendSMS(sms)).isFalse();
+	}
 
 	@Test
 	void testSmsSenderOperationsTerminate() throws Exception {
@@ -499,6 +500,45 @@ class Tests extends OHCoreTestCase {
 		Sms foundSms = smsIoOperation.getByID(code);
 		assertThat(foundSms).isNotNull();
 		testSms.check(foundSms);
+	}
+
+	private static class ConfiguredSmsGatewayEnvironmentStub extends EnvironmentStub {
+
+		@Override
+		public String getProperty(String key) {
+			return switch (key) {
+			case "sms.gateway" -> "failing-test-gateway";
+			default -> "";
+			};
+		}
+	}
+
+	private static class FailingSmsGateway implements SmsSenderInterface {
+
+		@Override
+		public boolean initialize() {
+			return true;
+		}
+
+		@Override
+		public boolean sendSMS(Sms sms) {
+			return false;
+		}
+
+		@Override
+		public String getName() {
+			return "failing-test-gateway";
+		}
+
+		@Override
+		public String getRootKey() {
+			return "failing-test-gateway";
+		}
+
+		@Override
+		public boolean terminate() {
+			return true;
+		}
 	}
 
 }

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -12,6 +12,4 @@ spring:
       hibernate:
         show_sql: false
         format_sql: true
-  cloud:
-    compatibility-verifier:
-      enabled: false
+


### PR DESCRIPTION
Upgrade Spring Boot to 3.5.14 and align Spring Cloud release train

- update Spring Boot parent to 3.5.14
- import Spring Cloud 2025.0.x BOM in OH-core
- remove explicit spring-cloud-starter-openfeign version
- keep compatibility verifier enabled

After this is merged work on the 4.x.x. track can start with its braking changes.

Tested Core/GUI/API