### PR TITLE
OP-214: Fix report bundle fallback for EN language

### DIFF
--- a/src/main/java/org/isf/stat/manager/JasperReportsManager.java
+++ b/src/main/java/org/isf/stat/manager/JasperReportsManager.java
@@ -1030,6 +1030,7 @@ public class JasperReportsManager {
 	}
 
 	private void addReportBundleParameter(String jasperParameter, String jasperFileFolder, String jasperFileName, Map<String, Object> parameters) {
+		// This is needed because new Locale() returns lowercase codes (eg. "am_et") and this would fail the path case matching
 		String language = GeneralData.LANGUAGE;
 		Path langSpecificPath = Path.of(jasperFileFolder, language, jasperFileName + ".properties");
 		// TODO: Remove legacy fallback after all installations include file migrations (OP-214)

--- a/src/main/java/org/isf/stat/manager/JasperReportsManager.java
+++ b/src/main/java/org/isf/stat/manager/JasperReportsManager.java
@@ -25,7 +25,6 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
-import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -71,6 +70,7 @@ import org.isf.ward.model.Ward;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
+
 import net.sf.jasperreports.engine.JRBand;
 import net.sf.jasperreports.engine.JRChild;
 import net.sf.jasperreports.engine.JRException;
@@ -100,7 +100,7 @@ public class JasperReportsManager {
 	private HospitalBrowsingManager hospitalManager;
 
 	private DataSource dataSource;
-	
+
 	private WardBrowserManager wardManager;
 
 	public JasperReportsManager(HospitalBrowsingManager hospitalBrowsingManager, DataSource dataSource, WardBrowserManager wardManager) {
@@ -250,7 +250,7 @@ public class JasperReportsManager {
 	}
 
 	public JasperReportResultDto getGenericReportBillGroupedPdf(Integer billID, String jasperFileName, Patient patient, List<Integer> billListId,
-					String dateFrom, String dateTo, boolean show, boolean askForPrint) throws OHServiceException {
+		String dateFrom, String dateTo, boolean show, boolean askForPrint) throws OHServiceException {
 
 		try {
 			HashMap<String, Object> parameters = getHospitalParameters();
@@ -271,7 +271,7 @@ public class JasperReportsManager {
 	}
 
 	public JasperReportResultDto getGenericReportBillGroupedTxt(Integer billID, String jasperFileName, Patient patient, List<Integer> billListId,
-					String dateFrom, String dateTo, boolean show, boolean askForPrint) throws OHServiceException {
+		String dateFrom, String dateTo, boolean show, boolean askForPrint) throws OHServiceException {
 
 		try {
 			HashMap<String, Object> parameters = getHospitalParameters();
@@ -366,7 +366,7 @@ public class JasperReportsManager {
 			parameters.put("date", toDate(date)); // real param
 
 			String pdfFilename = compilePDFFilename(RPT_BASE, jasperFileName, Arrays.asList(String.valueOf(wardID), TimeTools.formatDateTime(date, YYYY_M_MDD)),
-							"pdf");
+				"pdf");
 
 			JasperReportResultDto result = generateJasperReport(compileJasperFilename(RPT_BASE, jasperFileName), pdfFilename, parameters);
 			JasperExportManager.exportReportToPdfFile(result.getJasperPrint(), pdfFilename);
@@ -381,7 +381,7 @@ public class JasperReportsManager {
 	}
 
 	public JasperReportResultDto getGenericReportPatientVersion2Pdf(Integer patientID, String parametersString, LocalDateTime dateFrom, LocalDateTime dateTo,
-					String jasperFileName) throws OHServiceException {
+		String jasperFileName) throws OHServiceException {
 
 		try {
 
@@ -515,7 +515,7 @@ public class JasperReportsManager {
 	}
 
 	public void getGenericReportPharmaceuticalStockExcel(LocalDateTime date, String jasperFileName, String exportFilename, String filter, String groupBy,
-					String sortBy) throws OHServiceException {
+		String sortBy) throws OHServiceException {
 
 		try {
 			if (date == null) {
@@ -556,7 +556,7 @@ public class JasperReportsManager {
 	}
 
 	public JasperReportResultDto getGenericReportPharmaceuticalStockPdf(LocalDateTime date, String jasperFileName, String filter, String groupBy, String sortBy)
-					throws OHServiceException {
+		throws OHServiceException {
 
 		try {
 			HashMap<String, Object> parameters = getHospitalParameters();
@@ -596,7 +596,7 @@ public class JasperReportsManager {
 	}
 
 	public JasperReportResultDto getGenericReportPharmaceuticalStockCardPdf(String jasperFileName, String exportFileName, LocalDateTime dateFrom,
-					LocalDateTime dateTo, Medical medical, Ward ward) throws OHServiceException {
+		LocalDateTime dateTo, Medical medical, Ward ward) throws OHServiceException {
 
 		try {
 			if (dateFrom == null) {
@@ -631,7 +631,7 @@ public class JasperReportsManager {
 	}
 
 	public void getGenericReportPharmaceuticalStockCardExcel(String jasperFileName, String exportFileName, LocalDateTime dateFrom, LocalDateTime dateTo,
-					Medical medical, Ward ward) throws OHServiceException {
+		Medical medical, Ward ward) throws OHServiceException {
 
 		try {
 			if (dateFrom == null) {
@@ -766,7 +766,7 @@ public class JasperReportsManager {
 	}
 
 	public JasperReportResultDto getGenericReportFromDateToDatePdf(LocalDate fromDate, LocalDate toDate, String jasperFileFolder, String jasperFileName)
-					throws OHServiceException {
+		throws OHServiceException {
 
 		try {
 			HashMap<String, Object> parameters = compileGenericReportFromDateToDateParameters(fromDate, toDate);
@@ -785,7 +785,7 @@ public class JasperReportsManager {
 	}
 
 	public JasperReportResultDto getGenericReportFromDateToDatePdf(String fromDate, String toDate, String jasperFileFolder, String jasperFileName)
-					throws OHServiceException {
+		throws OHServiceException {
 
 		try {
 			HashMap<String, Object> parameters = compileGenericReportFromDateToDateParameters(fromDate, toDate);
@@ -804,7 +804,7 @@ public class JasperReportsManager {
 	}
 
 	public void getGenericReportFromDateToDateExcel(LocalDate fromDate, LocalDate toDate, String jasperFileFolder, String jasperFileName, String exportFilename)
-					throws OHServiceException {
+		throws OHServiceException {
 
 		try {
 			String filename = compileJasperFilename(jasperFileFolder, jasperFileName);
@@ -833,7 +833,7 @@ public class JasperReportsManager {
 	}
 
 	public void getGenericReportFromDateToDateExcel(String fromDate, String toDate, String jasperFileFolder, String jasperFileName, String exportFilename)
-					throws OHServiceException {
+		throws OHServiceException {
 
 		try {
 			File jasperFile = new File(compileJasperFilename(jasperFileFolder, jasperFileName));
@@ -878,7 +878,7 @@ public class JasperReportsManager {
 	}
 
 	public void getGenericReportMYExcel(Integer month, Integer year, String jasperFileFolder, String jasperFileName, String exportFilename)
-					throws OHServiceException {
+		throws OHServiceException {
 
 		try {
 			File jasperFile = new File(compileJasperFilename(jasperFileFolder, jasperFileName));
@@ -928,7 +928,7 @@ public class JasperReportsManager {
 	}
 
 	private Map<String, Object> compileGenericReportMYParameters(Integer month, Integer year, String jasperFileFolder, String jasperFileName)
-					throws OHServiceException {
+		throws OHServiceException {
 		HashMap<String, Object> parameters = getHospitalParameters();
 		addBundleParameter(jasperFileFolder, jasperFileName, parameters);
 
@@ -967,10 +967,6 @@ public class JasperReportsManager {
 		 */
 		parameters.put(JRParameter.REPORT_LOCALE, Locale.getDefault());
 
-		/*
-		 * Jasper Report seems failing to decode resource bundles in UTF-8 encoding. For this reason we pass also the resource for the specific report read with
-		 * UTF8Control()
-		 */
 		addReportBundleParameter(JRParameter.REPORT_RESOURCE_BUNDLE, jasperFileFolder, jasperFileName, parameters);
 
 		/*
@@ -1034,36 +1030,32 @@ public class JasperReportsManager {
 	}
 
 	private void addReportBundleParameter(String jasperParameter, String jasperFileFolder, String jasperFileName, Map<String, Object> parameters) {
-		String language = new Locale(GeneralData.LANGUAGE).getLanguage();
+		String language = new Locale(GeneralData.LANGUAGE).getLanguage(); // will be deprecated in Java 19+, replace with Locale.forLanguageTag()
 		Path langSpecificPath = Path.of(jasperFileFolder, language, jasperFileName + ".properties");
 		// TODO: Remove legacy fallback after all installations include file migrations (OP-214)
 		Path legacyPath = Path.of(jasperFileFolder, jasperFileName + "_" + GeneralData.LANGUAGE + ".properties");
-		Path defaultPath = Path.of(jasperFileFolder, jasperFileName + ".properties");
 
-		Path propsPath;
+		Path propsPath = null;
 		if (Files.exists(langSpecificPath)) {
 			propsPath = langSpecificPath;
-		}
-		else if (Files.exists(legacyPath)) {
-			LOGGER.warn(">> using legacy bundle path for '{}'; migrate to language subfolder structure", jasperFileName);
+		} else if (Files.exists(legacyPath)) {
+			LOGGER.warn(">> using legacy bundle path for '{}'; migrate to language subfolder structure.", jasperFileName);
 			propsPath = legacyPath;
 		}
-		else {
-			propsPath = defaultPath;
-		}
 
-		try (InputStream stream = new FileInputStream(propsPath.toFile());
-			InputStreamReader reader = new InputStreamReader(stream, StandardCharsets.UTF_8)) {
-			parameters.put(jasperParameter, new PropertyResourceBundle(reader));
-		}
-		catch (IOException e) {
-			LOGGER.error(">> no resource bundle for language '{}' found for report {}", GeneralData.LANGUAGE, jasperFileName);
-			// no REPORT_RESOURCE_BUNDLE set → Jasper fallback to default
+		if (propsPath != null) {
+			try (InputStreamReader reader = new InputStreamReader(new FileInputStream(propsPath.toFile()), StandardCharsets.UTF_8)) {
+				parameters.put(jasperParameter, new PropertyResourceBundle(reader));
+			} catch (IOException e) {
+				LOGGER.error(">> error loading bundle for report {}", jasperFileName);
+			}
+		} else if (!Locale.ENGLISH.getLanguage().equals(language)) {
+			LOGGER.debug(">> no resource bundle for language '{}' found for report '{}', using JRXML default.", language, jasperFileName);
 		}
 	}
 
 	private JasperReportResultDto generateJasperReport(String jasperFilename, String filename, Map<String, Object> parameters)
-					throws JRException, SQLException {
+		throws JRException, SQLException {
 		File jasperFile = new File(jasperFilename);
 		final JasperReport jasperReport = (JasperReport) JRLoader.loadObject(jasperFile);
 		Connection connection = dataSource.getConnection();

--- a/src/main/java/org/isf/stat/manager/JasperReportsManager.java
+++ b/src/main/java/org/isf/stat/manager/JasperReportsManager.java
@@ -1030,7 +1030,7 @@ public class JasperReportsManager {
 	}
 
 	private void addReportBundleParameter(String jasperParameter, String jasperFileFolder, String jasperFileName, Map<String, Object> parameters) {
-		String language = new Locale(GeneralData.LANGUAGE).getLanguage(); // will be deprecated in Java 19+, replace with Locale.forLanguageTag()
+		String language = GeneralData.LANGUAGE;
 		Path langSpecificPath = Path.of(jasperFileFolder, language, jasperFileName + ".properties");
 		// TODO: Remove legacy fallback after all installations include file migrations (OP-214)
 		Path legacyPath = Path.of(jasperFileFolder, jasperFileName + "_" + GeneralData.LANGUAGE + ".properties");


### PR DESCRIPTION
See OP-214.

As continuation of #1592 we are going to fix the "en" fallback as Transifex doesn't need `en/` folder.
