### PR TITLE
OP-219 Honor a preselected series when loading a DICOM file

### DIFF
--- a/src/main/java/org/isf/dicom/manager/SourceFiles.java
+++ b/src/main/java/org/isf/dicom/manager/SourceFiles.java
@@ -389,9 +389,13 @@ public class SourceFiles extends Thread {
 				studyUID = attributes.getString(Tag.StudyInstanceUID) == null ? studyUID : attributes.getString(Tag.StudyInstanceUID);
 				accessionNumber = attributes.getString(Tag.AccessionNumber) == null ? accessionNumber : attributes.getString(Tag.AccessionNumber);
 				studyDescription = attributes.getString(Tag.StudyDescription) == null ? studyDescription : attributes.getString(Tag.StudyDescription);
-				seriesUID = attributes.getString(Tag.SeriesInstanceUID) == null ? seriesUID : attributes.getString(Tag.SeriesInstanceUID);
-				seriesInstanceUID = attributes.getString(Tag.SeriesInstanceUID) == null ? seriesInstanceUID : attributes.getString(Tag.SeriesInstanceUID);
-				seriesNumber = attributes.getString(Tag.SeriesNumber) == null ? generateSeriesNumber(patient) : attributes.getString(Tag.SeriesNumber);
+				//OP-219: when the user chose to load into an existing series these identifiers are already set;
+				//only derive them from the DICOM file otherwise.
+				if (seriesInstanceUID.isEmpty()) {
+					seriesUID = attributes.getString(Tag.SeriesInstanceUID) == null ? seriesUID : attributes.getString(Tag.SeriesInstanceUID);
+					seriesInstanceUID = attributes.getString(Tag.SeriesInstanceUID) == null ? seriesInstanceUID : attributes.getString(Tag.SeriesInstanceUID);
+					seriesNumber = attributes.getString(Tag.SeriesNumber) == null ? generateSeriesNumber(patient) : attributes.getString(Tag.SeriesNumber);
+				}
 				seriesDescriptionCodeSequence = attributes.getString(Tag.SeriesDescriptionCodeSequence) == null ?
 						seriesDescriptionCodeSequence :
 						attributes.getString(Tag.SeriesDescriptionCodeSequence);


### PR DESCRIPTION
## What
Supports loading a DICOM image into an **already existing** series instead of always creating a new one.

Part of [OP-219](https://openhospital.atlassian.net/browse/OP-219). The user-facing GUI change is in informatici/openhospital-gui (companion PR, same branch name).

## Why
In `SourceFiles`, the DICOM branch read `seriesNumber` and `seriesInstanceUID` straight from the file and overwrote any value already set on the `FileDicom`. So when the GUI preselected an existing series, the choice was silently ignored for actual `.dcm` files (it worked only for plain images, whose branch already honored a preset series number).

## How
Derive the series number / instance UID from the DICOM file **only when no series was preselected** — detected by an empty `seriesInstanceUID` (never set by `preLoadDicom`, so it is a clean override signal). Default behaviour (single file and multi-series folders) is unchanged.

## Testing
- Existing core DICOM test suites pass (`TestSqlDicomManager`, `TestFileSystemDicomManager`, 38 tests).
- Verified end-to-end with the GUI and two real `.dcm` files: choosing the existing series loads both images into a single series (one `DM_FILE_SER_INST_UID`, 2 rows) instead of two.

[OP-219]: https://openhospital.atlassian.net/browse/OP-219?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ