### PR TITLE
OP-1412 Send a custom User-Agent on the remote configuration fetch (fixes HTTP 403)

### DIFF
--- a/src/main/java/org/isf/generaldata/configProvider/ApiConfigProvider.java
+++ b/src/main/java/org/isf/generaldata/configProvider/ApiConfigProvider.java
@@ -61,6 +61,7 @@ class ApiConfigProvider implements ConfigProvider {
 		} else {
 			LOGGER.debug("Configuration URL is: {}", baseUrl);
 			return Feign.builder()
+							.requestInterceptor(template -> template.header("User-Agent", "OpenHospital/" + version))
 							.decoder(new GsonDecoder())
 							.target(ParamsApi.class, baseUrl);
 		}

--- a/src/main/java/org/isf/generaldata/configProvider/JsonFileConfigProvider.java
+++ b/src/main/java/org/isf/generaldata/configProvider/JsonFileConfigProvider.java
@@ -54,6 +54,7 @@ class JsonFileConfigProvider implements ConfigProvider {
 			URL url = new URL(GeneralData.PARAMSURL);
 			HttpURLConnection connection = (HttpURLConnection) url.openConnection();
 			connection.setRequestMethod("GET");
+			connection.setRequestProperty("User-Agent", "OpenHospital/" + VERSION);
 
 			int responseCode = connection.getResponseCode();
 			if (responseCode == HttpURLConnection.HTTP_OK) {

--- a/src/test/java/org/isf/generaldata/configProvider/TestApiConfigProvider.java
+++ b/src/test/java/org/isf/generaldata/configProvider/TestApiConfigProvider.java
@@ -45,7 +45,7 @@ public class TestApiConfigProvider {
 
 	private static final String CONFIG_JSON = """
 		{
-		  "1.15.0": {
+		  "anyCurrentVersion": {
 		    "parameter": "https://version-url.com"
 		  },
 		  "default": {
@@ -116,7 +116,7 @@ public class TestApiConfigProvider {
 			// Mock the Version.getVersion() method to return a specific version
 			Version mockVersion = mock(Version.class);
 			mockedVersion.when(Version::getVersion).thenReturn(mockVersion);
-			when(mockVersion.toString()).thenReturn("1.15.0");
+			when(mockVersion.toString()).thenReturn("anyCurrentVersion");
 
 			// Mock the initialization to set PARAMSURL to the mock server URL
 			mockedGeneralData.when(GeneralData::initialize).thenAnswer(invocation -> {
@@ -132,7 +132,7 @@ public class TestApiConfigProvider {
 			assertThat(apiConfigProvider.get("parameter")).isEqualTo("https://version-url.com");
 
 			// The Feign client must send the custom User-Agent, otherwise the migrated server rejects it with HTTP 403.
-			mockServer.verify(request().withMethod("GET").withPath("/test").withHeader("User-Agent", "OpenHospital/1.15.0"));
+			mockServer.verify(request().withMethod("GET").withPath("/test").withHeader("User-Agent", "OpenHospital/anyCurrentVersion"));
 
 			apiConfigProvider.close();
 		}

--- a/src/test/java/org/isf/generaldata/configProvider/TestApiConfigProvider.java
+++ b/src/test/java/org/isf/generaldata/configProvider/TestApiConfigProvider.java
@@ -131,6 +131,9 @@ public class TestApiConfigProvider {
 
 			assertThat(apiConfigProvider.get("parameter")).isEqualTo("https://version-url.com");
 
+			// The Feign client must send the custom User-Agent, otherwise the migrated server rejects it with HTTP 403.
+			mockServer.verify(request().withMethod("GET").withPath("/test").withHeader("User-Agent", "OpenHospital/1.15.0"));
+
 			apiConfigProvider.close();
 		}
 	}

--- a/src/test/java/org/isf/generaldata/configProvider/TestJsonFileConfigProvider.java
+++ b/src/test/java/org/isf/generaldata/configProvider/TestJsonFileConfigProvider.java
@@ -22,23 +22,78 @@
 package org.isf.generaldata.configProvider;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockserver.integration.ClientAndServer.startClientAndServer;
+import static org.mockserver.model.HttpRequest.request;
+import static org.mockserver.model.HttpResponse.response;
 
 import java.util.Map;
 
 import org.isf.generaldata.GeneralData;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockserver.integration.ClientAndServer;
+import org.mockserver.model.MediaType;
 
 public class TestJsonFileConfigProvider {
 
+	private static final String CONFIG_JSON = """
+		{
+		  "default": {
+		    "oh_telemetry_url": "https://default-url.com"
+		  }
+		}""";
+
+	private ClientAndServer mockServer;
+
+	@BeforeEach
+	public void startServer() {
+		mockServer = startClientAndServer();
+	}
+
+	@AfterEach
+	public void stopServer() {
+		mockServer.stop();
+	}
+
 	@Test
 	void testJsonFileConfigProvider() throws Exception {
+		mockServer.when(request().withMethod("GET").withPath("/oh-conf.json"))
+			.respond(response().withStatusCode(200)
+				.withContentType(MediaType.APPLICATION_JSON)
+				.withBody(CONFIG_JSON));
+
 		GeneralData.initialize();
+		GeneralData.PARAMSURL = "http://localhost:" + mockServer.getLocalPort() + "/oh-conf.json";
+
 		JsonFileConfigProvider jsonFileConfigProvider = new JsonFileConfigProvider();
 
 		Map<String, Object> configData = jsonFileConfigProvider.getConfigData();
 
 		assertThat(configData).containsKey("oh_telemetry_url");
-		assertThat(configData.get("oh_telemetry_url")).isNotNull();
+		assertThat(jsonFileConfigProvider.get("oh_telemetry_url")).isEqualTo("https://default-url.com");
+		assertThat(jsonFileConfigProvider.get("someParam")).isNull();
+
+		// The request must carry a custom User-Agent: the migrated server rejects the default Java one with HTTP 403.
+		mockServer.verify(request().withPath("/oh-conf.json").withHeader("User-Agent", "OpenHospital/.+"));
+
+		// void method
+		jsonFileConfigProvider.close();
+	}
+
+	@Test
+	void testJsonFileConfigProviderServerRejects() throws Exception {
+		// Characterizes the reported bug: a non-200 response (such as the 403 the migrated server returned to
+		// requests without a proper User-Agent) must yield an empty configuration rather than a failure.
+		mockServer.when(request().withMethod("GET").withPath("/oh-conf.json"))
+			.respond(response().withStatusCode(403));
+
+		GeneralData.initialize();
+		GeneralData.PARAMSURL = "http://localhost:" + mockServer.getLocalPort() + "/oh-conf.json";
+
+		JsonFileConfigProvider jsonFileConfigProvider = new JsonFileConfigProvider();
+
+		assertThat(jsonFileConfigProvider.getConfigData()).isEmpty();
 		assertThat(jsonFileConfigProvider.get("someParam")).isNull();
 
 		// void method


### PR DESCRIPTION
## What & why

After the recent migration of the Open Hospital website, fetching the remote configuration file from `https://conf.open-hospital.org/oh-conf.json` (property `PARAMSURL`) returns **HTTP 403**. The migrated server rejects requests sent with the default Java `User-Agent` (or with no `User-Agent` at all), which is exactly what the config-provider code did. Same root cause, two symptoms:

- **App startup** logs `ERROR - Failed to fetch configuration URL. HTTP response code: 403` and the remote configuration is never loaded (silent fallback to an empty map).
- **CI** — `TestJsonFileConfigProvider` performs a live HTTP GET against `PARAMSURL`, so it now fails with 403 on every core PR.

Verified with curl against the live URL: the default `Java/17` User-Agent (and no User-Agent) → **403**, while any custom User-Agent (e.g. `OpenHospital/1.15.0`) → **200**.

## Changes

- **`JsonFileConfigProvider`** (the production path — `ConfigProviderFactory` selects it when `PARAMSURL` ends in `.json`): set `User-Agent: OpenHospital/<version>` on the `HttpURLConnection` before reading the response.
- **`ApiConfigProvider`** (the Feign path): add a request interceptor that sets the same `User-Agent` header.
- **`TestJsonFileConfigProvider`**: refactored to be hermetic with MockServer (no live network) — asserts the config is parsed, that the request carries the custom `User-Agent`, and that a non-200 response yields an empty configuration. Added a matching `User-Agent` assertion to **`TestApiConfigProvider`** so the Feign interceptor is covered too.

## Testing

- `configProvider` tests green (7/7), `mvn` build OK.
- Confirmed the User-Agent assertion **fails without the fix** (the request otherwise carries `Java/17...`, which the server rejects).
- Real end-to-end check against the live URL: the configuration is now fetched successfully (no 403).

Jira: OP-1412
