### PR TITLE
OP-1413 Pin commons-collections4 to 4.5.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,6 +28,7 @@
 		<jasperreports.version>7.0.6</jasperreports.version>
 		<license.maven.plugin.version>5.0.0</license.maven.plugin.version>
 		<spring-cloud.version>2025.0.1</spring-cloud.version>
+		<commons-collections4.version>4.5.0</commons-collections4.version>
 	</properties>
 	
 	<dependencyManagement>
@@ -38,6 +39,15 @@
 	            <version>${spring-cloud.version}</version>
 	            <type>pom</type>
 	            <scope>import</scope>
+	        </dependency>
+	        <!--
+	            Force commons-collections4 4.5.0: jasperreports 7.0.6 (via commons-beanutils2) needs 4.5.0, but poi-ooxml pulls 4.4 and wins
+	            version mediation. With 4.4 any JRBeanCollectionDataSource print fails at runtime (missing ConcurrentReferenceHashMap). See OP-1413.
+	        -->
+	        <dependency>
+	            <groupId>org.apache.commons</groupId>
+	            <artifactId>commons-collections4</artifactId>
+	            <version>${commons-collections4.version}</version>
 	        </dependency>
 	    </dependencies>
 	</dependencyManagement>


### PR DESCRIPTION
## OP-1413 — Bean-collection report printing broken (dependency convergence)

CORE part (companion GUI PR linked below).

### Problem
Printing any report built from a `JRBeanCollectionDataSource` (e.g. Laboratory → Print table) fails at runtime:
```
java.lang.NoClassDefFoundError: org/apache/commons/collections4/map/ConcurrentReferenceHashMap
  at org.apache.commons.beanutils2.BeanUtils.createCache(...)
  at net.sf.jasperreports.engine.data.JRBeanCollectionDataSource.getFieldValue(...)
  at net.sf.jasperreports.engine.fill.JasperFillManager.fillReport(...)
  at org.isf.serviceprinting.manager.PrintManager.print(...)
```

### Root cause (`mvn dependency:tree -Dverbose`)
- `org.apache.poi:poi-ooxml:5.3.0 → poi:5.3.0 → commons-collections4:4.4`
- `net.sf.jasperreports:7.0.6` (and its `commons-beanutils2:2.0.0-M2`) require `commons-collections4:4.5.0`
- Maven mediation keeps **4.4** (`4.5.0 omitted for conflict with 4.4`)
- `commons-beanutils2 2.0.0-M2` uses `ConcurrentReferenceHashMap`, which only exists from collections4 **4.5.0** → missing at runtime.

### Fix
Manage `commons-collections4` to `4.5.0` in `dependencyManagement` (4.5.0 is backward compatible with POI 5.3.0).

### Verification
- `mvn dependency:tree` now resolves collections4 **4.5.0**; full core suite **2448** green.
- Real Swing run of the Laboratory Browser **Print table** now opens the report viewer correctly (previously threw the NoClassDefFoundError).

Companion PR (the GUI module needs the same pin since dependencyManagement is not inherited from the core artifact):
- GUI: _linked in a comment_