### PR TITLE
OP-1062 Deprecate legacy String-based Laboratory insert methods

### DIFF
--- a/src/main/java/org/isf/lab/manager/LabManager.java
+++ b/src/main/java/org/isf/lab/manager/LabManager.java
@@ -211,7 +211,9 @@ public class LabManager {
 	 * @param labRow the list of results (Procedure 2); it can be {@code null}
 	 * @return the newly persisted {@link Laboratory} object.
 	 * @throws OHServiceException
+	 * @deprecated use {@link #newLaboratory2(Laboratory, List)} instead
 	 */
+	@Deprecated
 	public Laboratory newLaboratory(Laboratory laboratory, List<String> labRow) throws OHServiceException {
 		validateLaboratory(laboratory);
 		setPatientConsistency(laboratory);
@@ -312,7 +314,9 @@ public class LabManager {
 	 * @param labRowList the list of results, it can be {@code null}
 	 * @return the first of the newly persisted {@link Laboratory} objects in the list.
 	 * @throws OHServiceException
+	 * @deprecated use {@link #newLaboratory2(List, List)} instead
 	 */
+	@Deprecated
 	@Transactional(rollbackFor = OHServiceException.class)
 	@TranslateOHServiceException
 	public Laboratory newLaboratory(List<Laboratory> labList, List<List<String>> labRowList) throws OHServiceException {
@@ -371,7 +375,9 @@ public class LabManager {
 	 * @param labRow the list of results ({@link String}s)
 	 * @return the newly persisted {@link Laboratory} object.
 	 * @throws OHServiceException
+	 * @deprecated use {@link LabIoOperations#newLabSecondProcedure2(Laboratory, List)} instead
 	 */
+	@Deprecated
 	protected Laboratory newLabSecondProcedure(Laboratory laboratory, List<String> labRow) throws OHServiceException {
 		return ioOperations.newLabSecondProcedure(laboratory, labRow);
 	}

--- a/src/main/java/org/isf/lab/service/LabIoOperations.java
+++ b/src/main/java/org/isf/lab/service/LabIoOperations.java
@@ -242,7 +242,9 @@ public class LabIoOperations {
 	 * @param labRow - the list of results ({@link String}s)
 	 * @return the newly persisted {@link Laboratory} object.
 	 * @throws OHServiceException
+	 * @deprecated use {@link #newLabSecondProcedure2(Laboratory, List)} instead
 	 */
+	@Deprecated
 	public Laboratory newLabSecondProcedure(Laboratory laboratory, List<String> labRow) throws OHServiceException {
 		Laboratory newLaboratory = newLaboratory(laboratory);
 		if (newLaboratory.getCode() > 0) {


### PR DESCRIPTION
## OP-1062 — Laboratory Manager methods optimization (first slice)

The Laboratory insert methods exist in a legacy String-based **v1** form and a `LaboratoryRow`-based **v2** form that do the same thing. This marks the v1 methods `@Deprecated` in favour of v2, keeping them fully functional (GUI/API still call them — back-compat preserved):

- `LabManager.newLaboratory(Laboratory, List<String>)` → `newLaboratory2`
- `LabManager.newLaboratory(List<Laboratory>, List<List<String>>)` → `newLaboratory2`
- `LabManager.newLabSecondProcedure(Laboratory, List<String>)`
- `LabIoOperations.newLabSecondProcedure(Laboratory, List<String>)` → `newLabSecondProcedure2`

No behavior change; only annotations + javadoc `@deprecated`. Confirmed no new production deprecation warnings (the only internal callers are themselves the deprecated v1 methods).

**Scope note:** full removal of the v1 methods + migration of their callers (GUI `LabEdit`/`LabEditExtended`, API `LaboratoryController`, ~20 test sites) is the natural follow-up (OP-1063); kept out here to make this change core-only and low-risk.

Verified: `org.isf.lab.Tests` 194 green (BUILD SUCCESS).