### PR TITLE
OP-1308 Fix deprecated SELECT ... INTO construct in step_a106 stored procedure

### DIFF
--- a/sql/step_a106_medicaldsrstock_control.sql
+++ b/sql/step_a106_medicaldsrstock_control.sql
@@ -55,10 +55,10 @@ BEGIN
         SET v_ms_id = NULL;
         SET v_balance = NULL;
         
-        SELECT MAX(MS_ID)
+        SELECT MAX(MS_ID) INTO v_ms_id
 			FROM OH_MEDICALDSRSTOCK
             WHERE MS_MDSR_ID = v_mdsr_id
-            AND MS_DATE_BALANCE < v_date INTO v_ms_id;
+            AND MS_DATE_BALANCE < v_date;
             
             
 		IF v_qty <> 0 THEN
@@ -67,7 +67,7 @@ BEGIN
 					MS_DATE_NEXT_MOV = v_date,
 					MS_DAYS = DATEDIFF(v_date, MS_DATE_BALANCE)
 					WHERE MS_ID = v_ms_id;
-				SELECT MS_BALANCE FROM OH_MEDICALDSRSTOCK WHERE MS_ID = v_ms_id INTO v_balance;
+				SELECT MS_BALANCE INTO v_balance FROM OH_MEDICALDSRSTOCK WHERE MS_ID = v_ms_id;
 				SET v_balance = v_balance + v_qty;
                 INSERT INTO OH_MEDICALDSRSTOCK VALUES (0, v_mdsr_id, v_date, v_balance, NULL, NULL, 'admin', NULL, 'admin', NULL, 1);
 			ELSE 


### PR DESCRIPTION
## OP-1308 — Fix deprecated `SELECT ... INTO` in the step_a106 stored procedure

JIRA: https://openhospital.atlassian.net/browse/OP-1308

The `populateMSTable` procedure in `sql/step_a106_medicaldsrstock_control.sql` used the deprecated form `SELECT <expr> ... INTO <dest>` with `INTO` at the **end** of the statement, which MariaDB reports as warning 1287 (`'<select expression> INTO <destination>;' is deprecated and will be removed`). Both occurrences are rewritten to the recommended `SELECT <list> INTO <dest> FROM ...` form (INTO right after the select list). Pure syntactic change.

### Why edit the step file in place
`populateMSTable` is a one-shot procedure: created and `CALL`ed once at the end of the file to back-fill `OH_MEDICALDSRSTOCK`, then never re-invoked. Databases that already ran this migration executed the old form (still functional on the MariaDB versions OH targets, where the syntax is deprecated but not yet removed) and are unaffected. The deprecated syntax only bites someone running the step sequence now on a newer MariaDB, where it would fail at parse time. Fixing the canonical source the fresh-install / step path consumes is the minimal correct fix; a new DROP+CREATE step would have no persisted, re-invoked procedure to repair.

### Verification
Tested on MariaDB 10.6: created the prerequisite tables plus two movements on different dates (so both `SELECT ... INTO` execute in the cursor loop) and ran the original vs. the fixed procedure — the original emits 2x warning 1287, the fixed emits 0, and the populated balances are identical. No other deprecated `SELECT ... INTO` exists elsewhere in `sql/` (all other `INTO` are `INSERT` / `FETCH` / `LOAD DATA` / `DUMPFILE`). The leftover (never-dropped) `populateMSTable` procedure is pre-existing and left out of this narrow fix.
