### PR TITLE
OP-164 Paginate the OPD list at the database level

### DIFF
--- a/src/main/java/org/isf/opd/service/OpdIoOperationRepository.java
+++ b/src/main/java/org/isf/opd/service/OpdIoOperationRepository.java
@@ -1,6 +1,6 @@
 /*
  * Open Hospital (www.open-hospital.org)
- * Copyright © 2006-2024 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ * Copyright © 2006-2026 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
  *
  * Open Hospital is a free and open source software for healthcare data management.
  *

--- a/src/main/java/org/isf/opd/service/OpdIoOperationRepository.java
+++ b/src/main/java/org/isf/opd/service/OpdIoOperationRepository.java
@@ -24,7 +24,6 @@ package org.isf.opd.service;
 import java.time.LocalDateTime;
 import java.util.List;
 
-import org.isf.distype.model.DiseaseType;
 import org.isf.opd.model.Opd;
 import org.isf.patient.model.Patient;
 import org.isf.ward.model.Ward;
@@ -70,13 +69,6 @@ public interface OpdIoOperationRepository extends JpaRepository<Opd, Integer>, O
 
 	@Query("select o from Opd o where o.patient.code = :code and o.ward = :ward order by o.prog_year")
 	Page<Opd> findAllByPatient_CodeAndWardOrderByProgYearDescPageable(@Param("code") int code, @Param("ward") Ward ward, Pageable pageable);
-
-	@Query(value = "select op from Opd op where op.ward = :ward or op.disease.diseaseType = :diseaseType or op.disease.code = :diseaseCode or (op.date >= :dateFrom and op.date < :dateTo) "
-					+ " or (op.age >= :ageFrom and op.age < :ageTo) or op.sex = :sex or op.newPatient = :newPatient")
-	Page<Opd> findOpdListPageable(@Param("ward") Ward ward, @Param("diseaseType") DiseaseType diseaseType, @Param("diseaseCode") String diseaseCode,
-					@Param("dateFrom") LocalDateTime dateFrom, @Param("dateTo") LocalDateTime dateTo, @Param("ageFrom") int ageFrom, @Param("ageTo") int ageTo,
-					@Param("sex") char sex,
-					@Param("newPatient") char newPatient, @Param("dateFrom") String user, Pageable pageable);
 
 	@Query(value = "SELECT OPD_CREATED_DATE FROM OH_OPD O WHERE OPD_ACTIVE=1 ORDER BY OPD_ID DESC LIMIT 1", nativeQuery = true)
 	LocalDateTime lastOpdCreationDate();

--- a/src/main/java/org/isf/opd/service/OpdIoOperationRepositoryCustom.java
+++ b/src/main/java/org/isf/opd/service/OpdIoOperationRepositoryCustom.java
@@ -1,6 +1,6 @@
 /*
  * Open Hospital (www.open-hospital.org)
- * Copyright © 2006-2023 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ * Copyright © 2006-2026 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
  *
  * Open Hospital is a free and open source software for healthcare data management.
  *

--- a/src/main/java/org/isf/opd/service/OpdIoOperationRepositoryCustom.java
+++ b/src/main/java/org/isf/opd/service/OpdIoOperationRepositoryCustom.java
@@ -26,10 +26,15 @@ import java.util.List;
 
 import org.isf.opd.model.Opd;
 import org.isf.ward.model.Ward;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 public interface OpdIoOperationRepositoryCustom {
 
 	List<Opd> findAllOpdWhereParams(Ward ward, String diseaseTypeCode, String diseaseCode, LocalDate dateFrom, LocalDate dateTo, int ageFrom, int ageTo, char sex,
 			char newPatient, String user);
+
+	Page<Opd> findAllOpdWhereParamsPageable(Ward ward, String diseaseTypeCode, String diseaseCode, LocalDate dateFrom, LocalDate dateTo, int ageFrom, int ageTo,
+			char sex, char newPatient, String user, Pageable pageable);
 
 }

--- a/src/main/java/org/isf/opd/service/OpdIoOperationRepositoryImpl.java
+++ b/src/main/java/org/isf/opd/service/OpdIoOperationRepositoryImpl.java
@@ -1,6 +1,6 @@
 /*
  * Open Hospital (www.open-hospital.org)
- * Copyright © 2006-2025 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ * Copyright © 2006-2026 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
  *
  * Open Hospital is a free and open source software for healthcare data management.
  *

--- a/src/main/java/org/isf/opd/service/OpdIoOperationRepositoryImpl.java
+++ b/src/main/java/org/isf/opd/service/OpdIoOperationRepositoryImpl.java
@@ -36,6 +36,9 @@ import jakarta.persistence.criteria.Root;
 
 import org.isf.opd.model.Opd;
 import org.isf.ward.model.Ward;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
 import org.springframework.transaction.annotation.Transactional;
 
 @Transactional
@@ -74,9 +77,76 @@ public class OpdIoOperationRepositoryImpl implements OpdIoOperationRepositoryCus
 		CriteriaBuilder cb = entityManager.getCriteriaBuilder();
 		CriteriaQuery<Opd> query = cb.createQuery(Opd.class);
 		Root<Opd> opd = query.from(Opd.class);
-		List<Predicate> predicates = new ArrayList<>();
-
 		query.select(opd);
+		List<Predicate> predicates = buildOpdPredicates(cb, opd, ward, diseaseTypeCode, diseaseCode, dateFrom, dateTo, ageFrom, ageTo, sex, newPatient, user);
+		query.where(cb.and(predicates.toArray(new Predicate[0])));
+
+		return entityManager.createQuery(query);
+	}
+
+	@Override
+	public Page<Opd> findAllOpdWhereParamsPageable(
+			Ward ward,
+			String diseaseTypeCode,
+			String diseaseCode,
+			LocalDate dateFrom,
+			LocalDate dateTo,
+			int ageFrom,
+			int ageTo,
+			char sex,
+			char newPatient,
+			String user,
+			Pageable pageable) {
+		CriteriaBuilder cb = entityManager.getCriteriaBuilder();
+		CriteriaQuery<Opd> query = cb.createQuery(Opd.class);
+		Root<Opd> opd = query.from(Opd.class);
+		query.select(opd);
+		List<Predicate> predicates = buildOpdPredicates(cb, opd, ward, diseaseTypeCode, diseaseCode, dateFrom, dateTo, ageFrom, ageTo, sex, newPatient, user);
+		query.where(cb.and(predicates.toArray(new Predicate[0])));
+		// a total order is required so DB-level LIMIT/OFFSET paging does not drop or duplicate rows across pages
+		query.orderBy(cb.asc(opd.get("prog_year")), cb.asc(opd.get("code")));
+		TypedQuery<Opd> typedQuery = entityManager.createQuery(query);
+		typedQuery.setFirstResult((int) pageable.getOffset());
+		typedQuery.setMaxResults(pageable.getPageSize());
+		List<Opd> content = typedQuery.getResultList();
+		long total = countOpdWhereParams(ward, diseaseTypeCode, diseaseCode, dateFrom, dateTo, ageFrom, ageTo, sex, newPatient, user);
+		return new PageImpl<>(content, pageable, total);
+	}
+
+	private long countOpdWhereParams(
+			Ward ward,
+			String diseaseTypeCode,
+			String diseaseCode,
+			LocalDate dateFrom,
+			LocalDate dateTo,
+			int ageFrom,
+			int ageTo,
+			char sex,
+			char newPatient,
+			String user) {
+		CriteriaBuilder cb = entityManager.getCriteriaBuilder();
+		CriteriaQuery<Long> query = cb.createQuery(Long.class);
+		Root<Opd> opd = query.from(Opd.class);
+		query.select(cb.count(opd));
+		List<Predicate> predicates = buildOpdPredicates(cb, opd, ward, diseaseTypeCode, diseaseCode, dateFrom, dateTo, ageFrom, ageTo, sex, newPatient, user);
+		query.where(cb.and(predicates.toArray(new Predicate[0])));
+		return entityManager.createQuery(query).getSingleResult();
+	}
+
+	private List<Predicate> buildOpdPredicates(
+			CriteriaBuilder cb,
+			Root<Opd> opd,
+			Ward ward,
+			String diseaseTypeCode,
+			String diseaseCode,
+			LocalDate dateFrom,
+			LocalDate dateTo,
+			int ageFrom,
+			int ageTo,
+			char sex,
+			char newPatient,
+			String user) {
+		List<Predicate> predicates = new ArrayList<>();
 		if (ward != null) {
 			predicates.add(
 					cb.equal(opd.join("ward").get("code"), ward.getCode())
@@ -115,9 +185,7 @@ public class OpdIoOperationRepositoryImpl implements OpdIoOperationRepositoryCus
 		predicates.add(
 				cb.between(opd.<LocalDateTime>get("date"), dateFrom.atStartOfDay(), dateTo.plusDays(1).atStartOfDay())
 		);
-		query.where(cb.and(predicates.toArray(new Predicate[0])));
-
-		return entityManager.createQuery(query);
+		return predicates;
 	}
 
 }

--- a/src/main/java/org/isf/opd/service/OpdIoOperations.java
+++ b/src/main/java/org/isf/opd/service/OpdIoOperations.java
@@ -1,6 +1,6 @@
 /*
  * Open Hospital (www.open-hospital.org)
- * Copyright © 2006-2024 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ * Copyright © 2006-2026 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
  *
  * Open Hospital is a free and open source software for healthcare data management.
  *

--- a/src/main/java/org/isf/opd/service/OpdIoOperations.java
+++ b/src/main/java/org/isf/opd/service/OpdIoOperations.java
@@ -34,7 +34,6 @@ import org.isf.utils.pagination.PageInfo;
 import org.isf.utils.pagination.PagedResponse;
 import org.isf.ward.model.Ward;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -260,11 +259,9 @@ public class OpdIoOperations {
 					int page,
 					int size) throws OHServiceException {
 		Pageable pageRequest = PageRequest.of(page, size);
-		List<Opd> ops = this.getOpdList(ward, diseaseTypeCode, diseaseCode, dateFrom, dateTo, ageFrom, ageTo, sex, newPatient, null);
-		int start = (int) pageRequest.getOffset();
-		int end = Math.min(start + pageRequest.getPageSize(), ops.size());
-		List<Opd> pageContent = ops.subList(start, end);
-		return setPaginationData(new PageImpl<>(pageContent, pageRequest, ops.size()));
+		Page<Opd> pagedResult = repository.findAllOpdWhereParamsPageable(ward, diseaseTypeCode, diseaseCode, dateFrom, dateTo, ageFrom, ageTo, sex, newPatient, user,
+						pageRequest);
+		return setPaginationData(pagedResult);
 	}
 
 	PagedResponse<Opd> setPaginationData(Page<Opd> pages) {

--- a/src/test/java/org/isf/opd/Tests.java
+++ b/src/test/java/org/isf/opd/Tests.java
@@ -1,6 +1,6 @@
 /*
  * Open Hospital (www.open-hospital.org)
- * Copyright © 2006-2024 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ * Copyright © 2006-2026 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
  *
  * Open Hospital is a free and open source software for healthcare data management.
  *

--- a/src/test/java/org/isf/opd/Tests.java
+++ b/src/test/java/org/isf/opd/Tests.java
@@ -26,6 +26,7 @@ import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Stream;
 
@@ -49,6 +50,7 @@ import org.isf.patient.service.PatientIoOperationRepository;
 import org.isf.utils.exception.OHDataValidationException;
 import org.isf.utils.exception.OHException;
 import org.isf.utils.exception.OHServiceException;
+import org.isf.utils.pagination.PagedResponse;
 import org.isf.utils.time.TimeTools;
 import org.isf.visits.TestVisit;
 import org.isf.visits.model.Visit;
@@ -147,6 +149,51 @@ class Tests extends OHCoreTestCase {
 				foundOpd.getNewPatient(),
 				foundOpd.getUserID());
 		assertThat(opds.get(opds.size() - 1).getCode()).isEqualTo(foundOpd.getCode());
+	}
+
+	@ParameterizedTest(name = "Test with OPDEXTENDED={0}")
+	@MethodSource("opdExtended")
+	void testIoGetOpdListPageable(boolean opdExtended) throws Exception {
+		GeneralData.OPDEXTENDED = opdExtended;
+		// three OPDs that all match a broad (date-only) filter, sharing the same patient/disease/ward/visit
+		Patient patient = testPatient.setup(false);
+		DiseaseType diseaseType = testDiseaseType.setup(false);
+		Disease disease = testDisease.setup(diseaseType, false);
+		disease.setCode("199");
+		Ward ward = testWard.setup(false);
+		Visit nextVisit = testVisit.setup(patient, false, ward);
+		patientIoOperationRepository.saveAndFlush(patient);
+		diseaseTypeIoOperationRepository.saveAndFlush(diseaseType);
+		diseaseIoOperationRepository.saveAndFlush(disease);
+		wardIoOperationRepository.saveAndFlush(ward);
+		visitsIoOperationRepository.saveAndFlush(nextVisit);
+
+		LocalDate day = LocalDate.of(2020, 1, 15);
+		List<Integer> codes = new ArrayList<>();
+		for (int i = 0; i < 3; i++) {
+			Opd opd = testOpd.setup(patient, disease, ward, nextVisit, false);
+			opd.setDate(day.atTime(8 + i, 0));
+			codes.add(opdIoOperationRepository.saveAndFlush(opd).getCode());
+		}
+
+		PagedResponse<Opd> page0 = opdIoOperation.getOpdListPageable(null, "", "", day, day, 0, 0, 'A', 'A', null, 0, 2);
+		PagedResponse<Opd> page1 = opdIoOperation.getOpdListPageable(null, "", "", day, day, 0, 0, 'A', 'A', null, 1, 2);
+
+		assertThat(page0.getData()).hasSize(2);
+		assertThat(page1.getData()).hasSize(1);
+		assertThat(page0.getPageInfo().getTotalNbOfElements()).isEqualTo(3);
+		assertThat(page0.getPageInfo().getTotalPages()).isEqualTo(2);
+
+		// the two pages together must cover every row exactly once (this is what the ORDER BY guarantees)
+		List<Integer> pagedCodes = new ArrayList<>();
+		page0.getData().forEach(opd -> pagedCodes.add(opd.getCode()));
+		page1.getData().forEach(opd -> pagedCodes.add(opd.getCode()));
+		assertThat(pagedCodes).containsExactlyInAnyOrderElementsOf(codes);
+
+		// a page past the end is empty but the total stays correct
+		PagedResponse<Opd> beyond = opdIoOperation.getOpdListPageable(null, "", "", day, day, 0, 0, 'A', 'A', null, 5, 2);
+		assertThat(beyond.getData()).isEmpty();
+		assertThat(beyond.getPageInfo().getTotalNbOfElements()).isEqualTo(3);
 	}
 
 	@ParameterizedTest(name = "Test with OPDEXTENDED={0}")


### PR DESCRIPTION
## OP-164 — Adopt DB-level pagination for the OPD list

Sub-task of OP-161 (ResultSet Pagination). OPD was the last core service still paginating in memory; the other paged services already query `Page<>` at the DB. This completes the "adopt the solution all over the code" item for the OPD list.

### Changes
- `OpdIoOperations.getOpdListPageable` no longer loads the full filtered list via `getOpdList(...)` and `subList`s it in memory. It now calls a new custom-repository method `findAllOpdWhereParamsPageable` that reuses the same CriteriaBuilder predicates (extracted into `buildOpdPredicates`, so the non-paged `getOpdList` / `findAllOpdWhereParams` are unchanged), applies the page offset/limit at the DB level, counts the total with a separate count query, and orders by `prog_year` then `id` so `LIMIT/OFFSET` pages are stable.
- Threads the real `user` filter through (the old paged path hard-coded `null`; the only caller passes `null`, so no behaviour change).
- Removed the dead, never-called `findOpdListPageable` JPQL query (its filters were `or`-chained and it had a duplicate `@Param("dateFrom")` bound to the `user` argument) and its now-unused `DiseaseType` import.

### Testing
- `org.isf.opd.Tests` 98/98 green (H2, MySQL-compatibility mode). Added a multi-page test asserting page sizes (2 + 1), total (3), total pages (2), that the two pages together cover every row exactly once (which the ORDER BY guarantees), and that a page past the end is empty with the total preserved.
- The generated pagination SQL shape (date-range filter + `ORDER BY OPD_PROG_YEAR, OPD_ID` + `LIMIT/OFFSET` + `COUNT`) was also validated directly on MariaDB 10.6.

### Notes
- This is a sub-task of OP-161 — please confirm whether the PR should be tracked against OP-164 or the parent.
- Core-only change: the manager/service signatures are unchanged, so no API/GUI changes are needed.
