### PR TITLE
OP-1419 Fixes an issue where a NPE caused by using the JPMS  with >= JDK 16

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -251,6 +251,10 @@
 				<configuration>
 					<redirectTestOutputToFile>true</redirectTestOutputToFile>
 					<reportsDirectory>${project.build.directory}/test-reports</reportsDirectory>
+					<argLine>
+						--add-opens java.desktop/javax.imageio.stream=ALL-UNNAMED
+						--add-opens java.base/java.io=ALL-UNNAMED
+					</argLine>
 				</configuration>
 			</plugin>
 			<plugin>


### PR DESCRIPTION
See OP-1419.

Fixes an issue where a NPE caused by using the JPMS  (Java Platform Module System) on Java 16 or higher without granting the necessary deep reflection permissions to dcm4che. 

Added args to configuration to allow the deep reflection.