### PR TITLE
OP-1395 Manage Bill items and payments through JPA one-to-many relationships

### DIFF
--- a/src/main/java/org/isf/accounting/model/Bill.java
+++ b/src/main/java/org/isf/accounting/model/Bill.java
@@ -1,6 +1,6 @@
 /*
  * Open Hospital (www.open-hospital.org)
- * Copyright © 2006-2024 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ * Copyright © 2006-2026 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
  *
  * Open Hospital is a free and open source software for healthcare data management.
  *

--- a/src/main/java/org/isf/accounting/model/Bill.java
+++ b/src/main/java/org/isf/accounting/model/Bill.java
@@ -23,8 +23,11 @@ package org.isf.accounting.model;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 import jakarta.persistence.AttributeOverride;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EntityListeners;
@@ -33,6 +36,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import jakarta.persistence.Transient;
 import jakarta.persistence.Version;
@@ -110,6 +114,12 @@ public class Bill extends Auditable<String> implements Cloneable, Comparable<Bil
 	@ManyToOne
 	@JoinColumn(name = "BLL_ADM_ID")
 	private Admission admission;
+
+	@OneToMany(mappedBy = "bill", cascade = CascadeType.ALL, orphanRemoval = true)
+	private List<BillItems> items = new ArrayList<>();
+
+	@OneToMany(mappedBy = "bill", cascade = CascadeType.ALL, orphanRemoval = true)
+	private List<BillPayments> payments = new ArrayList<>();
 
 	@Transient
 	private volatile int hashCode;
@@ -259,6 +269,14 @@ public class Bill extends Auditable<String> implements Cloneable, Comparable<Bil
 
 	public void setAdmission(Admission admission) {
 		this.admission = admission;
+	}
+
+	public List<BillItems> getItems() {
+		return items;
+	}
+
+	public List<BillPayments> getPayments() {
+		return payments;
 	}
 
 	public int getLock() {

--- a/src/main/java/org/isf/accounting/service/AccountingBillItemsIoOperationRepository.java
+++ b/src/main/java/org/isf/accounting/service/AccountingBillItemsIoOperationRepository.java
@@ -1,6 +1,6 @@
 /*
  * Open Hospital (www.open-hospital.org)
- * Copyright © 2006-2023 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ * Copyright © 2006-2026 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
  *
  * Open Hospital is a free and open source software for healthcare data management.
  *

--- a/src/main/java/org/isf/accounting/service/AccountingBillItemsIoOperationRepository.java
+++ b/src/main/java/org/isf/accounting/service/AccountingBillItemsIoOperationRepository.java
@@ -25,9 +25,7 @@ import java.util.List;
 
 import org.isf.accounting.model.BillItems;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -39,9 +37,5 @@ public interface AccountingBillItemsIoOperationRepository extends JpaRepository<
 
 	@Query("select b from BillItems b group by b.itemDescription")
 	List<BillItems> findAllGroupByDescription();
-
-	@Modifying
-	@Query(value = "delete from BillItems b where b.bill.id = :billId")
-	void deleteWhereId(@Param("billId") Integer billId);
 
 }

--- a/src/main/java/org/isf/accounting/service/AccountingBillPaymentIoOperationRepository.java
+++ b/src/main/java/org/isf/accounting/service/AccountingBillPaymentIoOperationRepository.java
@@ -1,6 +1,6 @@
 /*
  * Open Hospital (www.open-hospital.org)
- * Copyright © 2006-2023 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ * Copyright © 2006-2026 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
  *
  * Open Hospital is a free and open source software for healthcare data management.
  *

--- a/src/main/java/org/isf/accounting/service/AccountingBillPaymentIoOperationRepository.java
+++ b/src/main/java/org/isf/accounting/service/AccountingBillPaymentIoOperationRepository.java
@@ -28,7 +28,6 @@ import java.util.List;
 import org.isf.accounting.model.Bill;
 import org.isf.accounting.model.BillPayments;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
@@ -49,10 +48,6 @@ public interface AccountingBillPaymentIoOperationRepository extends JpaRepositor
 
 	@Query(value = "SELECT BP FROM BillPayments BP WHERE BP.bill.id = :billId ORDER BY BP.bill, BP.date ASC")
 	List<BillPayments> findAllWherBillIdByOrderByBillAndDate(@Param("billId") Integer billId);
-
-	@Modifying
-	@Query(value = "DELETE FROM BillPayments BP where BP.bill.id = :billId")
-	void deleteWhereId(@Param("billId") Integer billId);
 
 	@Query(value = "SELECT BP FROM BillPayments BP WHERE " +
 			"BP.bill.billPatient.code = :patientCode and " +

--- a/src/main/java/org/isf/accounting/service/AccountingIoOperations.java
+++ b/src/main/java/org/isf/accounting/service/AccountingIoOperations.java
@@ -1,6 +1,6 @@
 /*
  * Open Hospital (www.open-hospital.org)
- * Copyright © 2006-2024 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ * Copyright © 2006-2026 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
  *
  * Open Hospital is a free and open source software for healthcare data management.
  *

--- a/src/main/java/org/isf/accounting/service/AccountingIoOperations.java
+++ b/src/main/java/org/isf/accounting/service/AccountingIoOperations.java
@@ -23,6 +23,7 @@ package org.isf.accounting.service;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
@@ -33,6 +34,7 @@ import org.isf.accounting.model.BillPayments;
 import org.isf.patient.model.Patient;
 import org.isf.utils.db.TranslateOHServiceException;
 import org.isf.utils.exception.OHServiceException;
+import org.isf.utils.exception.model.OHExceptionMessage;
 import org.isf.utils.time.TimeTools;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -150,53 +152,145 @@ public class AccountingIoOperations {
 	 * 
 	 * @param newBill the bill to store.
 	 * @return the persisted Bill object
-	 * @throws OHServiceException if an error occurs storing the bill.
+	 * @throws OHServiceException if the bill already exists or an error occurs storing the bill.
 	 */
 	public Bill newBill(Bill newBill) throws OHServiceException {
+		if (newBill.getId() != 0) {
+			throw new OHServiceException(new OHExceptionMessage("Bill '" + newBill.getId() + "' already exists."));
+		}
 		return billRepository.save(newBill);
 	}
 
 	/**
-	 * Stores a list of {@link BillItems} associated to a {@link Bill}.
-	 * 
+	 * Synchronizes the {@link BillItems} of the specified {@link Bill} with the passed list. Items with a matching id are updated in place, items with id
+	 * {@code 0} are inserted as new rows and stored items missing from the list are deleted (orphan removal).
+	 *
 	 * @param bill the bill.
 	 * @param billItems the bill items to store.
-	 * @throws OHServiceException if an error occurs during the store operation.
+	 * @throws OHServiceException if the bill is not found or an error occurs during the store operation.
 	 */
 	public void newBillItems(Bill bill, List<BillItems> billItems) throws OHServiceException {
-		billItemsRepository.deleteWhereId(bill.getId());
-		for (BillItems item : billItems) {
-			item.setBill(bill);
-			item.setId(0);
-			billItemsRepository.save(item);
+		Bill managedBill = billRepository.findById(bill.getId()).orElse(null);
+		if (managedBill == null) {
+			throw new OHServiceException(new OHExceptionMessage("Bill '" + bill.getId() + "' not found."));
 		}
+		List<BillItems> currentItems = managedBill.getItems();
+		Set<Integer> incomingIds = new HashSet<>();
+		for (BillItems item : billItems) {
+			if (item.getId() != 0) {
+				incomingIds.add(item.getId());
+			}
+		}
+		currentItems.removeIf(currentItem -> !incomingIds.contains(currentItem.getId()));
+		Set<Integer> mergedIds = new HashSet<>();
+		for (BillItems item : billItems) {
+			BillItems managedItem = null;
+			if (item.getId() != 0 && mergedIds.add(item.getId())) {
+				managedItem = findBillItem(currentItems, item.getId());
+			}
+			if (managedItem != null) {
+				managedItem.setPrice(item.isPrice());
+				managedItem.setPriceID(item.getPriceID());
+				managedItem.setItemDescription(item.getItemDescription());
+				managedItem.setItemAmount(item.getItemAmount());
+				managedItem.setItemQuantity(item.getItemQuantity());
+			} else if (item.getId() == 0) {
+				item.setBill(managedBill);
+				currentItems.add(item);
+			} else {
+				currentItems.add(new BillItems(0, managedBill, item.isPrice(), item.getPriceID(), item.getItemDescription(), item.getItemAmount(),
+					item.getItemQuantity()));
+			}
+		}
+		billRepository.flush();
 	}
 
 	/**
-	 * Stores a list of {@link BillPayments} associated to a {@link Bill}.
-	 * 
+	 * Synchronizes the {@link BillPayments} of the specified {@link Bill} with the passed list. Payments with a matching id are updated in place, payments with
+	 * id {@code 0} are inserted as new rows and stored payments missing from the list are deleted (orphan removal).
+	 *
 	 * @param bill the bill.
 	 * @param payItems the bill payments.
-	 * @throws OHServiceException if an error occurs during the store procedure.
+	 * @throws OHServiceException if the bill is not found or an error occurs during the store procedure.
 	 */
 	public void newBillPayments(Bill bill, List<BillPayments> payItems) throws OHServiceException {
-		billPaymentRepository.deleteWhereId(bill.getId());
-		for (BillPayments payment : payItems) {
-			payment.setBill(bill);
-			payment.setId(0);
-			billPaymentRepository.save(payment);
+		Bill managedBill = billRepository.findById(bill.getId()).orElse(null);
+		if (managedBill == null) {
+			throw new OHServiceException(new OHExceptionMessage("Bill '" + bill.getId() + "' not found."));
 		}
+		List<BillPayments> currentPayments = managedBill.getPayments();
+		Set<Integer> incomingIds = new HashSet<>();
+		for (BillPayments payment : payItems) {
+			if (payment.getId() != 0) {
+				incomingIds.add(payment.getId());
+			}
+		}
+		currentPayments.removeIf(currentPayment -> !incomingIds.contains(currentPayment.getId()));
+		Set<Integer> mergedIds = new HashSet<>();
+		for (BillPayments payment : payItems) {
+			BillPayments managedPayment = null;
+			if (payment.getId() != 0 && mergedIds.add(payment.getId())) {
+				managedPayment = findBillPayment(currentPayments, payment.getId());
+			}
+			if (managedPayment != null) {
+				managedPayment.setDate(payment.getDate());
+				managedPayment.setAmount(payment.getAmount());
+				managedPayment.setUser(payment.getUser());
+			} else if (payment.getId() == 0) {
+				payment.setBill(managedBill);
+				currentPayments.add(payment);
+			} else {
+				currentPayments.add(new BillPayments(0, managedBill, payment.getDate(), payment.getAmount(), payment.getUser()));
+			}
+		}
+		billRepository.flush();
+	}
+
+	private BillItems findBillItem(List<BillItems> items, int id) {
+		for (BillItems item : items) {
+			if (item.getId() == id) {
+				return item;
+			}
+		}
+		return null;
+	}
+
+	private BillPayments findBillPayment(List<BillPayments> payments, int id) {
+		for (BillPayments payment : payments) {
+			if (payment.getId() == id) {
+				return payment;
+			}
+		}
+		return null;
 	}
 
 	/**
-	 * Updates the specified {@link Bill}.
-	 * 
+	 * Updates the specified {@link Bill}. The scalar fields of the stored bill are updated from the passed object; the associated {@link BillItems} and
+	 * {@link BillPayments} are left untouched (use {@link #newBillItems} and {@link #newBillPayments} to update them).
+	 *
 	 * @param updateBill the bill to update.
 	 * @return the updated Bill object
 	 * @throws OHServiceException if an error occurs during the update.
 	 */
 	public Bill updateBill(Bill updateBill) throws OHServiceException {
-		return billRepository.save(updateBill);
+		Bill managedBill = billRepository.findById(updateBill.getId()).orElse(null);
+		if (managedBill == null) {
+			return billRepository.save(updateBill);
+		}
+		managedBill.setDate(updateBill.getDate());
+		managedBill.setUpdate(updateBill.getUpdate());
+		managedBill.setIsList(updateBill.isList());
+		managedBill.setPriceList(updateBill.getPriceList());
+		managedBill.setListName(updateBill.getListName());
+		managedBill.setIsPatient(updateBill.isPatient());
+		managedBill.setBillPatient(updateBill.getBillPatient());
+		managedBill.setPatName(updateBill.getPatName());
+		managedBill.setStatus(updateBill.getStatus());
+		managedBill.setAmount(updateBill.getAmount());
+		managedBill.setBalance(updateBill.getBalance());
+		managedBill.setUser(updateBill.getUser());
+		managedBill.setAdmission(updateBill.getAdmission());
+		return billRepository.save(managedBill);
 	}
 
 	/**

--- a/src/test/java/org/isf/accounting/Tests.java
+++ b/src/test/java/org/isf/accounting/Tests.java
@@ -1,6 +1,6 @@
 /*
  * Open Hospital (www.open-hospital.org)
- * Copyright © 2006-2024 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ * Copyright © 2006-2026 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
  *
  * Open Hospital is a free and open source software for healthcare data management.
  *

--- a/src/test/java/org/isf/accounting/Tests.java
+++ b/src/test/java/org/isf/accounting/Tests.java
@@ -314,7 +314,7 @@ class Tests extends OHCoreTestCase {
 		billItems.add(existingFromGui);
 		billItems.add(newItemFromGui);
 
-		// when: we call the service that internally does delete + re-insert
+		// when: we call the service that merges the list with the stored items
 		accountingIoOperation.newBillItems(bill, billItems);
 
 		// then: for that bill we now have exactly two items
@@ -326,10 +326,15 @@ class Tests extends OHCoreTestCase {
 			.extracting(i -> i.getBill().getId())
 			.containsOnly(bill.getId());
 
-		// and none of them keeps the old id (they've been re-inserted)
+		// and the resent item keeps its original id (updated in place, not re-inserted)
 		assertThat(persisted)
 			.extracting(BillItems::getId)
-			.doesNotContain(existingId);
+			.contains(existingId);
+
+		// while the new item got a freshly generated id
+		assertThat(persisted)
+			.filteredOn(item -> item.getId() != existingId)
+			.hasSize(1);
 	}
 
 	@Test
@@ -346,7 +351,7 @@ class Tests extends OHCoreTestCase {
 		existingFromGui.setAmount(existingPayment.getAmount());
 		existingFromGui.setDate(existingPayment.getDate());
 		existingFromGui.setUser(existingPayment.getUser());
-		existingFromGui.setBill(bill); // oppure null, tanto lo setti in newBillPayments
+		existingFromGui.setBill(bill);
 
 		// and: a second (new) payment created by the GUI (id = null / 0)
 		BillPayments newPayment = testBillPayments.setup(null, false);
@@ -356,7 +361,7 @@ class Tests extends OHCoreTestCase {
 		billPayments.add(existingFromGui); // existing, with original id
 		billPayments.add(newPayment); // new, with no id
 
-		// when: we call the service that internally does delete + re-insert
+		// when: we call the service that merges the list with the stored payments
 		accountingIoOperation.newBillPayments(bill, billPayments);
 
 		// then: for that bill we now have exactly two payments
@@ -368,10 +373,157 @@ class Tests extends OHCoreTestCase {
 			.extracting(p -> p.getBill().getId())
 			.containsOnly(bill.getId());
 
-		// and none of them keeps the old id (they've been re-inserted)
+		// and the resent payment keeps its original id (updated in place, not re-inserted)
 		assertThat(persisted)
 			.extracting(BillPayments::getId)
-			.doesNotContain(existingId);
+			.contains(existingId);
+
+		// while the new payment got a freshly generated id
+		assertThat(persisted)
+			.filteredOn(payment -> payment.getId() != existingId)
+			.hasSize(1);
+	}
+
+	@Test
+	void testIoNewBillItemsOrphanRemoval() throws Exception {
+		// given: an existing bill with two items already stored
+		int firstId = setupTestBillItems(false);
+		BillItems firstItem = accountingBillItemsIoOperationRepository.findById(firstId).orElse(null);
+		assertThat(firstItem).isNotNull();
+		Bill bill = firstItem.getBill();
+		BillItems secondItem = testBillItems.setup(bill, false);
+		bill.getItems().add(secondItem);
+		accountingBillItemsIoOperationRepository.saveAndFlush(secondItem);
+		int secondId = secondItem.getId();
+
+		// when: the GUI resends only the first item
+		BillItems firstFromGui = testBillItems.setup(null, false);
+		firstFromGui.setId(firstId);
+		List<BillItems> billItems = new ArrayList<>();
+		billItems.add(firstFromGui);
+		accountingIoOperation.newBillItems(bill, billItems);
+
+		// then: the missing item has been removed and the survivor keeps its id
+		List<BillItems> persisted = accountingIoOperation.getItems(bill.getId());
+		assertThat(persisted)
+			.extracting(BillItems::getId)
+			.containsExactly(firstId);
+		assertThat(accountingBillItemsIoOperationRepository.findById(secondId)).isEmpty();
+	}
+
+	@Test
+	void testIoNewBillItemsMixedUpdateInsert() throws Exception {
+		// given: an existing bill with one item already stored
+		int existingId = setupTestBillItems(false);
+		BillItems existingItem = accountingBillItemsIoOperationRepository.findById(existingId).orElse(null);
+		assertThat(existingItem).isNotNull();
+		Bill bill = existingItem.getBill();
+
+		// when: the GUI resends the existing item with modified fields plus a new one
+		BillItems existingFromGui = testBillItems.setup(null, false);
+		existingFromGui.setId(existingId);
+		existingFromGui.setItemAmount(99.9);
+		existingFromGui.setItemQuantity(3);
+		BillItems newItemFromGui = testBillItems.setup(null, false);
+		List<BillItems> billItems = new ArrayList<>();
+		billItems.add(existingFromGui);
+		billItems.add(newItemFromGui);
+		accountingIoOperation.newBillItems(bill, billItems);
+
+		// then: the existing row has been updated in place and the new one inserted
+		List<BillItems> persisted = accountingIoOperation.getItems(bill.getId());
+		assertThat(persisted).hasSize(2);
+		BillItems updatedItem = accountingBillItemsIoOperationRepository.findById(existingId).orElse(null);
+		assertThat(updatedItem).isNotNull();
+		assertThat(updatedItem.getItemAmount()).isCloseTo(99.9, offset(0.001));
+		assertThat(updatedItem.getItemQuantity()).isEqualTo(3);
+	}
+
+	@Test
+	void testIoNewBillPaymentsOrphanRemoval() throws Exception {
+		// given: an existing bill with two payments already stored
+		int firstId = setupTestBillPayments(false);
+		BillPayments firstPayment = accountingBillPaymentIoOperationRepository.findById(firstId).orElse(null);
+		assertThat(firstPayment).isNotNull();
+		Bill bill = firstPayment.getBill();
+		BillPayments secondPayment = testBillPayments.setup(bill, false);
+		bill.getPayments().add(secondPayment);
+		accountingBillPaymentIoOperationRepository.saveAndFlush(secondPayment);
+		int secondId = secondPayment.getId();
+
+		// when: the GUI resends only the first payment
+		BillPayments firstFromGui = testBillPayments.setup(null, false);
+		firstFromGui.setId(firstId);
+		List<BillPayments> billPayments = new ArrayList<>();
+		billPayments.add(firstFromGui);
+		accountingIoOperation.newBillPayments(bill, billPayments);
+
+		// then: the missing payment has been removed and the survivor keeps its id
+		List<BillPayments> persisted = accountingIoOperation.getPayments(bill.getId());
+		assertThat(persisted)
+			.extracting(BillPayments::getId)
+			.containsExactly(firstId);
+		assertThat(accountingBillPaymentIoOperationRepository.findById(secondId)).isEmpty();
+	}
+
+	@Test
+	void testIoNewBillPaymentsMixedUpdateInsert() throws Exception {
+		// given: an existing bill with one payment already stored
+		int existingId = setupTestBillPayments(false);
+		BillPayments existingPayment = accountingBillPaymentIoOperationRepository.findById(existingId).orElse(null);
+		assertThat(existingPayment).isNotNull();
+		Bill bill = existingPayment.getBill();
+
+		// when: the GUI resends the existing payment with a modified amount plus a new one
+		BillPayments existingFromGui = testBillPayments.setup(null, false);
+		existingFromGui.setId(existingId);
+		existingFromGui.setAmount(99.9);
+		BillPayments newPaymentFromGui = testBillPayments.setup(null, false);
+		List<BillPayments> billPayments = new ArrayList<>();
+		billPayments.add(existingFromGui);
+		billPayments.add(newPaymentFromGui);
+		accountingIoOperation.newBillPayments(bill, billPayments);
+
+		// then: the existing row has been updated in place and the new one inserted
+		List<BillPayments> persisted = accountingIoOperation.getPayments(bill.getId());
+		assertThat(persisted).hasSize(2);
+		BillPayments updatedPayment = accountingBillPaymentIoOperationRepository.findById(existingId).orElse(null);
+		assertThat(updatedPayment).isNotNull();
+		assertThat(updatedPayment.getAmount()).isCloseTo(99.9, offset(0.001));
+	}
+
+	@Test
+	void testIoNewBillPaymentsEmptyListRemovesAll() throws Exception {
+		// given: an existing bill with one payment already stored
+		int existingId = setupTestBillPayments(false);
+		BillPayments existingPayment = accountingBillPaymentIoOperationRepository.findById(existingId).orElse(null);
+		assertThat(existingPayment).isNotNull();
+		Bill bill = existingPayment.getBill();
+
+		// when: an empty list is sent
+		accountingIoOperation.newBillPayments(bill, new ArrayList<>());
+
+		// then: all the payments of the bill are gone
+		assertThat(accountingIoOperation.getPayments(bill.getId())).isEmpty();
+	}
+
+	@Test
+	void testIoDeleteBillCascadesToItemsAndPayments() throws Exception {
+		// given: a stored bill with one item and one payment
+		int billId = setupTestBillWithItems(false);
+		Bill bill = accountingBillIoOperationRepository.findById(billId).orElse(null);
+		assertThat(bill).isNotNull();
+		BillPayments billPayment = testBillPayments.setup(bill, false);
+		bill.getPayments().add(billPayment);
+		accountingBillPaymentIoOperationRepository.saveAndFlush(billPayment);
+
+		// when: the bill is deleted
+		accountingIoOperation.deleteBill(bill);
+
+		// then: its items and payments are deleted as well
+		assertThat(accountingBillIoOperationRepository.findById(billId)).isEmpty();
+		assertThat(accountingBillItemsIoOperationRepository.findAll()).isEmpty();
+		assertThat(accountingBillPaymentIoOperationRepository.findAll()).isEmpty();
 	}
 
 	@Test
@@ -832,6 +984,30 @@ class Tests extends OHCoreTestCase {
 	}
 
 	@Test
+	void mgrUpdateBillDetachedBillDoesNotWipeChildren() throws Exception {
+		// given: a stored bill with one item
+		int billId = setupTestBillWithItems(false);
+		Bill storedBill = accountingBillIoOperationRepository.findById(billId).orElse(null);
+		assertThat(storedBill).isNotNull();
+		List<BillItems> storedItems = billBrowserManager.getItems(billId);
+		assertThat(storedItems).hasSize(1);
+		int itemId = storedItems.get(0).getId();
+
+		// and: a detached copy of the bill built like the GUI does (constructor, empty collections)
+		Bill detachedBill = new Bill(billId, storedBill.getDate(), storedBill.getUpdate(), storedBill.isList(), storedBill.getPriceList(),
+			storedBill.getListName(), storedBill.isPatient(), storedBill.getBillPatient(), storedBill.getPatName(), storedBill.getStatus(),
+			storedBill.getAmount(), storedBill.getBalance(), storedBill.getUser(), storedBill.getAdmission());
+
+		// when: the bill is updated without resending the items
+		billBrowserManager.updateBill(detachedBill, new ArrayList<>(), new ArrayList<>());
+
+		// then: the stored item is still there with its original id
+		assertThat(billBrowserManager.getItems(billId))
+			.extracting(BillItems::getId)
+			.containsExactly(itemId);
+	}
+
+	@Test
 	void mgrDeleteBill() throws Exception {
 		int id = setupTestBill(true);
 		Bill bill = accountingBillIoOperationRepository.findById(id).orElse(null);
@@ -872,6 +1048,7 @@ class Tests extends OHCoreTestCase {
 		PriceList priceList = testPriceList.setup(false);
 		Bill bill = testBill.setup(priceList, patient, null, usingSet);
 		BillItems billItem = testBillItems.setup(bill, usingSet);
+		bill.getItems().add(billItem);
 		priceListIoOperationRepository.saveAndFlush(priceList);
 		patientIoOperationRepository.saveAndFlush(patient);
 		accountingBillIoOperationRepository.saveAndFlush(bill);
@@ -893,6 +1070,7 @@ class Tests extends OHCoreTestCase {
 		PriceList priceList = testPriceList.setup(false);
 		Bill bill = testBill.setup(priceList, patient, null, usingSet);
 		BillPayments billPayment = testBillPayments.setup(bill, usingSet);
+		bill.getPayments().add(billPayment);
 		priceListIoOperationRepository.saveAndFlush(priceList);
 		patientIoOperationRepository.saveAndFlush(patient);
 		accountingBillIoOperationRepository.saveAndFlush(bill);
@@ -917,6 +1095,7 @@ class Tests extends OHCoreTestCase {
 		patientIoOperationRepository.saveAndFlush(patient);
 		accountingBillIoOperationRepository.saveAndFlush(bill);
 		BillItems billItem = testBillItems.setup(bill, usingSet);
+		bill.getItems().add(billItem);
 		accountingBillItemsIoOperationRepository.saveAndFlush(billItem);
 		return bill.getId();
 	}

--- a/src/test/java/org/isf/accounting/Tests.java
+++ b/src/test/java/org/isf/accounting/Tests.java
@@ -422,7 +422,7 @@ class Tests extends OHCoreTestCase {
 		// when: the GUI resends the existing item with modified fields plus a new one
 		BillItems existingFromGui = testBillItems.setup(null, false);
 		existingFromGui.setId(existingId);
-		existingFromGui.setItemAmount(99.9);
+		existingFromGui.setItemAmount(new BigDecimal("99.9"));
 		existingFromGui.setItemQuantity(3);
 		BillItems newItemFromGui = testBillItems.setup(null, false);
 		List<BillItems> billItems = new ArrayList<>();
@@ -435,7 +435,7 @@ class Tests extends OHCoreTestCase {
 		assertThat(persisted).hasSize(2);
 		BillItems updatedItem = accountingBillItemsIoOperationRepository.findById(existingId).orElse(null);
 		assertThat(updatedItem).isNotNull();
-		assertThat(updatedItem.getItemAmount()).isCloseTo(99.9, offset(0.001));
+		assertThat(updatedItem.getItemAmount()).isEqualByComparingTo(new BigDecimal("99.9"));
 		assertThat(updatedItem.getItemQuantity()).isEqualTo(3);
 	}
 
@@ -477,7 +477,7 @@ class Tests extends OHCoreTestCase {
 		// when: the GUI resends the existing payment with a modified amount plus a new one
 		BillPayments existingFromGui = testBillPayments.setup(null, false);
 		existingFromGui.setId(existingId);
-		existingFromGui.setAmount(99.9);
+		existingFromGui.setAmount(new BigDecimal("99.9"));
 		BillPayments newPaymentFromGui = testBillPayments.setup(null, false);
 		List<BillPayments> billPayments = new ArrayList<>();
 		billPayments.add(existingFromGui);
@@ -489,7 +489,7 @@ class Tests extends OHCoreTestCase {
 		assertThat(persisted).hasSize(2);
 		BillPayments updatedPayment = accountingBillPaymentIoOperationRepository.findById(existingId).orElse(null);
 		assertThat(updatedPayment).isNotNull();
-		assertThat(updatedPayment.getAmount()).isCloseTo(99.9, offset(0.001));
+		assertThat(updatedPayment.getAmount()).isEqualByComparingTo(new BigDecimal("99.9"));
 	}
 
 	@Test


### PR DESCRIPTION
See [OP-1395](https://openhospital.atlassian.net/browse/OP-1395).

`Bill` now owns its items and payments through `@OneToMany(cascade = ALL, orphanRemoval = true)` collections (getters only, so the DTO mapper can never write them); the two `deleteWhereId` `@Modifying` queries are removed; `newBillItems`/`newBillPayments` are rewritten as a merge-sync (id 0 = insert, matching id = update in place, missing = orphan-removed — no more `setId(0)`); `updateBill` is load-and-copy; `newBill` rejects a nonzero id. Signatures are unchanged, so manager, API and GUI callers compile untouched.

Behavior changes to review (money path):
- Merge semantics: retained rows keep their database ids and audit columns (previously delete-all + reinsert). Tests updated accordingly.
- `updateBill` no longer compares the caller-supplied `@Version` lock for detached callers (last-write-wins; `@Version` still guards concurrent transactions). The GUI always sent lock 0, so the old path could spuriously fail repeated edits.
- `newBill` with a nonzero id now fails fast ("already exists") — it was an accidental scalar upsert, and with cascading collections a detached merge could have orphan-deleted stored rows.

Deliberate deviations from the ticket text:
- Child->bill stays EAGER: `getBills(List<BillPayments>)` returns bills the GUI renders detached; LAZY would throw LazyInitializationException.
- `optional = false` not applied: `BLI_ID_BILL`/`BLP_ID_BILL` are nullable in the production schema, and the implied inner join would hide legacy orphan rows. A NOT NULL migration could be a follow-up.
- `deleteBill` now also cascades at JPA level (row-by-row), correct on H2 as well as MariaDB.

Verified: full core suite green (2455 tests); API and GUI at develop compile unchanged against this core (no callers of the removed methods — grep + compile check); live end-to-end on MariaDB through `PUT /bills/{id}`: retained item kept its id with the updated amount, omitted items were orphan-removed from the table, the new item got a fresh IDENTITY id, totals recalculated correctly.


[OP-1395]: https://openhospital.atlassian.net/browse/OP-1395?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ