### PR TITLE
OP-1421 Fix initial lock value in native insert

### DIFF
--- a/src/main/java/org/isf/medicalstockward/model/MedicalWard.java
+++ b/src/main/java/org/isf/medicalstockward/model/MedicalWard.java
@@ -59,7 +59,7 @@ public class MedicalWard extends Auditable<String> implements Comparable<Object>
 	 * Lock control
 	 */
 	@Version
-	@Column(name = "MDSRWRD_LOCK", columnDefinition = "INT(11) NOT NULL DEFAULT 0")
+	@Column(name = "MDSRWRD_LOCK")
 	private int lock;
 
 	@Transient

--- a/src/main/java/org/isf/medicalstockward/service/MedicalStockWardIoOperationRepository.java
+++ b/src/main/java/org/isf/medicalstockward/service/MedicalStockWardIoOperationRepository.java
@@ -62,7 +62,7 @@ public interface MedicalStockWardIoOperationRepository extends JpaRepository<Med
 	void updateOutQuantity(@Param("quantity") Double quantity, @Param("ward") String ward, @Param("medical") int medical, @Param("lot") String lot);
 
 	@Modifying
-	@Query(value = "INSERT INTO OH_MEDICALDSRWARD (MDSRWRD_WRD_ID_A, MDSRWRD_MDSR_ID, MDSRWRD_IN_QTI, MDSRWRD_OUT_QTI, MDSRWRD_LT_ID_A) VALUES (?, ?, ?, '0', ?)", nativeQuery = true)
+	@Query(value = "INSERT INTO OH_MEDICALDSRWARD (MDSRWRD_WRD_ID_A, MDSRWRD_MDSR_ID, MDSRWRD_IN_QTI, MDSRWRD_OUT_QTI, MDSRWRD_LT_ID_A, MDSRWRD_LOCK) VALUES (?, ?, ?, '0', ?, 0)", nativeQuery = true)
 	void insertMedicalWard(@Param("ward") String ward, @Param("medical") int medical, @Param("quantity") Double quantity, @Param("lot") String lot);
 
 	@Query(value = "SELECT * FROM OH_MEDICALDSRWARD WHERE MDSRWRD_WRD_ID_A = :ward", nativeQuery = true)


### PR DESCRIPTION
See OP-1421.

Remove the columnDefinition from MedicalWard version field to keep the mapping Hibernate-friendly.