### PR TITLE
OP-1429 Make the operation result compulsory on insert

### DIFF
--- a/src/main/java/org/isf/operation/manager/OperationRowBrowserManager.java
+++ b/src/main/java/org/isf/operation/manager/OperationRowBrowserManager.java
@@ -1,6 +1,6 @@
 /*
  * Open Hospital (www.open-hospital.org)
- * Copyright © 2006-2025 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ * Copyright © 2006-2026 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
  *
  * Open Hospital is a free and open source software for healthcare data management.
  *

--- a/src/main/java/org/isf/operation/manager/OperationRowBrowserManager.java
+++ b/src/main/java/org/isf/operation/manager/OperationRowBrowserManager.java
@@ -60,12 +60,12 @@ public class OperationRowBrowserManager {
 	}
 
 	public OperationRow updateOperationRow(OperationRow opRow) throws OHServiceException {
-		validateOperationRow(opRow);
+		validateOperationRow(opRow, false);
 		return ioOperations.updateOperationRow(opRow);
 	}
 
 	public OperationRow newOperationRow(OperationRow opRow) throws OHServiceException {
-		validateOperationRow(opRow);
+		validateOperationRow(opRow, true);
 		return ioOperations.newOperationRow(opRow);
 	}
 
@@ -73,9 +73,10 @@ public class OperationRowBrowserManager {
 	 * Verify if the {@link OperationRow} is valid for CRUD and throw an exception with the list of errors, if any.
 	 *
 	 * @param opRow the {@link OperationRow} to validate
+	 * @param insert {@code true} if the operation row is being inserted, {@code false} if updated
 	 * @throws OHDataValidationException if the {@link OperationRow} is not valid
 	 */
-	protected void validateOperationRow(OperationRow opRow) throws OHServiceException {
+	protected void validateOperationRow(OperationRow opRow, boolean insert) throws OHServiceException {
 		List<OHExceptionMessage> errors = new ArrayList<>();
 		if (opRow.getOperation() == null) {
 			errors.add(new OHExceptionMessage(MessageBundle.getMessage("angal.operationrow.pleaseinsertanoperation.msg")));
@@ -86,10 +87,12 @@ public class OperationRowBrowserManager {
 		} else if (prescriber.length() > 150) {
 			errors.add(new OHExceptionMessage(MessageBundle.formatMessage("angal.operationrow.theprescriberistoolongmaxchars.fmt.msg", 150)));
 		}
+		// opResult is mandatory on insert only: legacy rows may have an empty result and the GUI re-submits
+		// every existing row on each save, so requiring it on update would make such rows unsavable
 		String opResult = opRow.getOpResult();
-		if (opResult == null || opResult.isEmpty()) {
+		if (insert && (opResult == null || opResult.isEmpty())) {
 			errors.add(new OHExceptionMessage(MessageBundle.getMessage("angal.operationrow.pleaseselectaresult.msg")));
-		} else if (opResult.length() > 250) {
+		} else if (opResult != null && opResult.length() > 250) {
 			errors.add(new OHExceptionMessage(MessageBundle.formatMessage("angal.operationrow.theresultistoolongmaxchars.fmt.msg", 250)));
 		}
 		if (opRow.getOpDate() == null) {

--- a/src/main/java/org/isf/operation/manager/OperationRowBrowserManager.java
+++ b/src/main/java/org/isf/operation/manager/OperationRowBrowserManager.java
@@ -86,10 +86,10 @@ public class OperationRowBrowserManager {
 		} else if (prescriber.length() > 150) {
 			errors.add(new OHExceptionMessage(MessageBundle.formatMessage("angal.operationrow.theprescriberistoolongmaxchars.fmt.msg", 150)));
 		}
-		// opResult is optional at this layer: legacy rows and non-GUI callers may have none.
-		// The desktop GUI additionally requires it for new/edited rows (OperationRowBase/OperationRowAdm/OperationRowOpd).
 		String opResult = opRow.getOpResult();
-		if (opResult != null && opResult.length() > 250) {
+		if (opResult == null || opResult.isEmpty()) {
+			errors.add(new OHExceptionMessage(MessageBundle.getMessage("angal.operationrow.pleaseselectaresult.msg")));
+		} else if (opResult.length() > 250) {
 			errors.add(new OHExceptionMessage(MessageBundle.formatMessage("angal.operationrow.theresultistoolongmaxchars.fmt.msg", 250)));
 		}
 		if (opRow.getOpDate() == null) {

--- a/src/test/java/org/isf/operation/Tests.java
+++ b/src/test/java/org/isf/operation/Tests.java
@@ -1,6 +1,6 @@
 /*
  * Open Hospital (www.open-hospital.org)
- * Copyright © 2006-2024 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ * Copyright © 2006-2026 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
  *
  * Open Hospital is a free and open source software for healthcare data management.
  *

--- a/src/test/java/org/isf/operation/Tests.java
+++ b/src/test/java/org/isf/operation/Tests.java
@@ -463,9 +463,29 @@ class Tests extends OHCoreTestCase {
 		operationRow.setOperation(null);
 		operationRow.setPrescriber("");
 		operationRow.setOpDate(null);
-		// opResult and remarks are optional: leaving them empty must not, by itself, trigger validation
+		// remarks is optional: leaving it empty must not, by itself, trigger validation
 		operationRow.setOpResult("");
 		operationRow.setRemarks("");
+		assertThatThrownBy(() -> operationRowBrowserManager.newOperationRow(operationRow))
+			.isInstanceOf(OHDataValidationException.class);
+	}
+
+	@Test
+	void testMgrValidateOperationRowEmptyResult() throws Exception {
+		OperationType operationType = testOperationType.setup(false);
+		Operation operation = testOperation.setup(operationType, true);
+		OperationRow operationRow = testOperationRow.setup(operation, true);
+		operationRow.setOpResult("");
+		assertThatThrownBy(() -> operationRowBrowserManager.newOperationRow(operationRow))
+			.isInstanceOf(OHDataValidationException.class);
+	}
+
+	@Test
+	void testMgrValidateOperationRowNullResult() throws Exception {
+		OperationType operationType = testOperationType.setup(false);
+		Operation operation = testOperation.setup(operationType, true);
+		OperationRow operationRow = testOperationRow.setup(operation, true);
+		operationRow.setOpResult(null);
 		assertThatThrownBy(() -> operationRowBrowserManager.newOperationRow(operationRow))
 			.isInstanceOf(OHDataValidationException.class);
 	}

--- a/src/test/java/org/isf/operation/Tests.java
+++ b/src/test/java/org/isf/operation/Tests.java
@@ -967,6 +967,18 @@ class Tests extends OHCoreTestCase {
 	}
 
 	@Test
+	void testMgrUpdateOperationRowEmptyResultAllowedForLegacyRows() throws Exception {
+		// legacy rows saved before the result became mandatory may have an empty result and the GUI
+		// re-submits every existing row on each save, so updates must tolerate an empty result
+		int id = setupTestOperationRow(false);
+		OperationRow operationRow = operationRowIoOperationRepository.findById(id);
+		operationRow.setOpResult("");
+		assertThat(operationRowBrowserManager.updateOperationRow(operationRow)).isNotNull();
+		operationRow = operationRowIoOperationRepository.findById(id);
+		assertThat(operationRow.getOpResult()).isEmpty();
+	}
+
+	@Test
 	void testMgrRowNewOperationRow() throws Exception {
 		OperationType operationType = testOperationType.setup(false);
 		Operation operation = testOperation.setup(operationType, true);


### PR DESCRIPTION
Part of OP-1429 (Improve the Operations management GUI in the admission workflow): https://openhospital.atlassian.net/browse/OP-1429

Spun off from OP-1404. Makes the operation-row **result mandatory on insert** in `OperationRowBrowserManager.validateOperationRow`: `newOperationRow` rejects an empty/null result, while `updateOperationRow` keeps it length-checked only, so legacy rows (and the GUI re-submitting every existing row on each save) stay editable. Uses the existing `angal.operationrow.pleaseselectaresult.msg` key added by OP-1404.

Unit tests: empty/null result rejected on insert, empty result tolerated on update.

Companion PRs: gui informatici/openhospital-gui#2235 · doc informatici/openhospital-doc#293
