### PR TITLE
OP-1430 Expose the password policy from the core manager

### DIFF
--- a/src/main/java/org/isf/menu/manager/UserBrowsingManager.java
+++ b/src/main/java/org/isf/menu/manager/UserBrowsingManager.java
@@ -1,6 +1,6 @@
 /*
  * Open Hospital (www.open-hospital.org)
- * Copyright © 2006-2025 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ * Copyright © 2006-2026 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
  *
  * Open Hospital is a free and open source software for healthcare data management.
  *

--- a/src/main/java/org/isf/menu/manager/UserBrowsingManager.java
+++ b/src/main/java/org/isf/menu/manager/UserBrowsingManager.java
@@ -23,7 +23,6 @@ package org.isf.menu.manager;
 
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.isf.generaldata.GeneralData;
@@ -199,6 +198,33 @@ public class UserBrowsingManager {
 	 */
 	public int getPasswordLeaseDays() {
 		return GeneralData.PASSWORDLEASE;
+	}
+
+	/**
+	 * Returns whether the strong-password policy ({@link GeneralData#STRONGPASSWORD}) is enabled.
+	 *
+	 * @return {@code true} when the strength policy is enforced, {@code false} otherwise
+	 */
+	public boolean isStrongPasswordEnabled() {
+		return GeneralData.STRONGPASSWORD;
+	}
+
+	/**
+	 * Returns the configured minimum password length ({@link GeneralData#STRONGLENGTH}).
+	 *
+	 * @return the minimum length, or {@code 0} when no minimum-length policy is enforced
+	 */
+	public int getPasswordMinLength() {
+		return GeneralData.STRONGLENGTH;
+	}
+
+	/**
+	 * Returns the regular expression a password must match when the strong-password policy is enabled.
+	 *
+	 * @return the strength regular expression
+	 */
+	public String getPasswordStrengthRegex() {
+		return PASSWORD_STRENGTH_REGEX;
 	}
 
 	/**
@@ -467,8 +493,19 @@ public class UserBrowsingManager {
 	}
 
 	/**
+	 * The regular expression a password must match to be considered strong (when {@link GeneralData#STRONGPASSWORD} is
+	 * enabled): at least one digit, one letter, one special character and no white spaces.
+	 */
+	private static final String PASSWORD_STRENGTH_REGEX = "^(?=.*[0-9])" // a digit must occur at least once
+		+ "(?=.*[a-zA-Z])" // a lower case or upper case alphabetic must occur at least once
+		+ "(?=.*[\\\\_$&+,:;=\\\\?@#|/'<>.^*()%!-])" // a special character that must occur at least once
+		+ "(?=\\S+$).+$"; // white spaces not allowed
+
+	private static final Pattern PASSWORD_STRENGTH_PATTERN = Pattern.compile(PASSWORD_STRENGTH_REGEX);
+
+	/**
 	 * Tests whether a password meets the requirement for various characters being present
-	 * 
+	 *
 	 * @param password The given password
 	 * @return {@code true} if password is meets the minimum requirements, {@code false} otherwise.
 	 */
@@ -479,14 +516,7 @@ public class UserBrowsingManager {
 		if (!GeneralData.STRONGPASSWORD) {
 			return true;
 		}
-
-		String regex = "^(?=.*[0-9])" // a digit must occur at least once
-			+ "(?=.*[a-zA-Z])" // a lower case or upper case alphabetic must occur at least once
-			+ "(?=.*[\\\\_$&+,:;=\\\\?@#|/'<>.^*()%!-])" // a special character that must occur at least once
-			+ "(?=\\S+$).+$"; // white spaces not allowed
-		Pattern pattern = Pattern.compile(regex);
-		Matcher matcher = pattern.matcher(password);
-		return matcher.matches();
+		return PASSWORD_STRENGTH_PATTERN.matcher(password).matches();
 	}
 
 	/**

--- a/src/test/java/org/isf/menu/TestUserBrowsingManager.java
+++ b/src/test/java/org/isf/menu/TestUserBrowsingManager.java
@@ -1,6 +1,6 @@
 /*
  * Open Hospital (www.open-hospital.org)
- * Copyright © 2006-2024 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ * Copyright © 2006-2026 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
  *
  * Open Hospital is a free and open source software for healthcare data management.
  *

--- a/src/test/java/org/isf/menu/TestUserBrowsingManager.java
+++ b/src/test/java/org/isf/menu/TestUserBrowsingManager.java
@@ -110,6 +110,28 @@ class TestUserBrowsingManager extends OHCoreTestCase {
 	}
 
 	@Test
+	void passwordPolicyAccessorsReflectConfiguration() {
+		GeneralData.STRONGPASSWORD = true;
+		GeneralData.STRONGLENGTH = 8;
+		assertThat(userBrowsingManager.isStrongPasswordEnabled()).isTrue();
+		assertThat(userBrowsingManager.getPasswordMinLength()).isEqualTo(8);
+
+		GeneralData.STRONGPASSWORD = false;
+		GeneralData.STRONGLENGTH = 0;
+		assertThat(userBrowsingManager.isStrongPasswordEnabled()).isFalse();
+		assertThat(userBrowsingManager.getPasswordMinLength()).isZero();
+	}
+
+	@Test
+	void passwordStrengthRegexMatchesEnforcedPolicy() {
+		String regex = userBrowsingManager.getPasswordStrengthRegex();
+		assertThat(regex).isNotBlank();
+		// the exposed regex must accept/reject the same passwords the strength check enforces
+		assertThat("abcdef1@".matches(regex)).isTrue();
+		assertThat("abcdefgh".matches(regex)).isFalse();
+	}
+
+	@Test
 	void testIncreaseFailedAttempts() throws Exception {
 		String userName = setupTestUser(false);
 		User user = userBrowsingManager.getUserByName(userName);


### PR DESCRIPTION
Part of OP-1430 (align password validation with a single, backend-owned policy): https://openhospital.atlassian.net/browse/OP-1430

Extracts the strength regex from `UserBrowsingManager.isPasswordStrong` into a reusable `PASSWORD_STRENGTH_REGEX` constant + a pre-compiled `Pattern` (cheap perf win, and it becomes introspectable), and adds three accessors — `isStrongPasswordEnabled()`, `getPasswordMinLength()`, `getPasswordStrengthRegex()` — mirroring the existing `getPasswordLeaseDays()`, so the API layer can serve the effective password policy without reaching into `GeneralData` statics.

No behaviour change: `isPasswordStrong`/`isPasswordValid` are functionally unchanged. Unit tests cover the accessors and assert the exposed regex accepts/rejects the same passwords the strength check enforces.

Companion PRs: api informatici/openhospital-api#607 · ui informatici/openhospital-ui#783
Builds on OP-896 (merged).
