### PR TITLE
OP-1403 Add optional startup compilation of stale JRXML reports

### DIFF
--- a/src/main/java/org/isf/generaldata/GeneralData.java
+++ b/src/main/java/org/isf/generaldata/GeneralData.java
@@ -1,6 +1,6 @@
 /*
  * Open Hospital (www.open-hospital.org)
- * Copyright © 2006-2024 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ * Copyright © 2006-2026 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
  *
  * Open Hospital is a free and open source software for healthcare data management.
  *
@@ -41,6 +41,7 @@ public final class GeneralData extends ConfigurationProperties {
 	public static boolean AUTOMATICLOT_OUT;
 	public static boolean AUTOMATICLOTWARD_TOWARD;
 	public static boolean LOTWITHCOST;
+	public static boolean AUTOCOMPILEJRXML;
 	public static String PATIENTSHEET;
 	public static String VISITSHEET;
 	public static String EXAMINATIONCHART;
@@ -101,6 +102,7 @@ public final class GeneralData extends ConfigurationProperties {
 	private static final boolean DEFAULT_AUTOMATICLOT_OUT = true;
 	private static final boolean DEFAULT_AUTOMATICLOTWARD_TOWARD = true;
 	private static final boolean DEFAULT_LOTWITHCOST = false;
+	private static final boolean DEFAULT_AUTOCOMPILEJRXML = false;
 	private static final String DEFAULT_PATIENTSHEET = "patient_clinical_sheet";
 	private static final String DEFAULT_VISITSHEET = "WardVisits";
 	private static final String DEFAULT_EXAMINATIONCHART = "patient_examination";
@@ -169,6 +171,7 @@ public final class GeneralData extends ConfigurationProperties {
 		AUTOMATICLOT_OUT = myGetProperty("AUTOMATICLOT_OUT", DEFAULT_AUTOMATICLOT_OUT);
 		AUTOMATICLOTWARD_TOWARD = myGetProperty("AUTOMATICLOTWARD_TOWARD", DEFAULT_AUTOMATICLOTWARD_TOWARD);
 		LOTWITHCOST = myGetProperty("LOTWITHCOST", DEFAULT_LOTWITHCOST);
+		AUTOCOMPILEJRXML = myGetProperty("AUTOCOMPILEJRXML", DEFAULT_AUTOCOMPILEJRXML);
 		PATIENTSHEET = myGetProperty("PATIENTSHEET", DEFAULT_PATIENTSHEET);
 		VISITSHEET = myGetProperty("VISITSHEET", DEFAULT_VISITSHEET);
 		EXAMINATIONCHART = myGetProperty("EXAMINATIONCHART", DEFAULT_EXAMINATIONCHART);

--- a/src/main/java/org/isf/stat/manager/JasperReportCompiler.java
+++ b/src/main/java/org/isf/stat/manager/JasperReportCompiler.java
@@ -1,0 +1,140 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2026 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.isf.stat.manager;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import net.sf.jasperreports.engine.JasperCompileManager;
+
+/**
+ * Optional automatic compilation of JasperReports templates ({@code .jrxml}) into their compiled form ({@code .jasper}),
+ * see OP-1403.
+ * <p>
+ * Open Hospital ships and loads precompiled {@code .jasper} files. When a {@code .jrxml} is edited on disk but its
+ * {@code .jasper} is not regenerated, report generation fails at runtime with a stale (or missing) compiled report. This
+ * helper scans the report folders and (re)compiles every template whose {@code .jasper} is missing or older than the
+ * source, so that keeping the {@code .jrxml} up to date is enough.
+ * <p>
+ * It is meant to be triggered at application startup, guarded by a configuration flag
+ * ({@code GeneralData.AUTOCOMPILEJRXML}), and it is a no-op when every compiled report is already up to date.
+ * <p>
+ * <b>Security:</b> JRXML templates can contain executable expressions, so automatic compilation must only be enabled when
+ * the report files are trusted (i.e. not writable by untrusted users).
+ */
+public final class JasperReportCompiler {
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(JasperReportCompiler.class);
+
+	private static final String JRXML_EXTENSION = ".jrxml";
+	private static final String JASPER_EXTENSION = ".jasper";
+
+	private JasperReportCompiler() {
+	}
+
+	/**
+	 * Scans the given folders (recursively) and compiles every report whose {@code .jasper} is missing or older than its
+	 * {@code .jrxml}. A template that fails to compile is logged and skipped, so a single broken report does not stop the
+	 * others.
+	 *
+	 * @param folders the report folders to scan (e.g. {@code rpt_base}, {@code rpt_extra}, {@code rpt_stat}); {@code null}
+	 *                or non-existent folders are ignored.
+	 * @return the number of reports (re)compiled.
+	 */
+	public static int compileStaleReports(List<String> folders) {
+		if (folders == null) {
+			return 0;
+		}
+		int compiled = 0;
+		for (String folder : folders) {
+			compiled += compileStaleReports(folder == null ? null : new File(folder));
+		}
+		return compiled;
+	}
+
+	/**
+	 * Scans a single folder (recursively) and compiles every report whose {@code .jasper} is missing or older than its
+	 * {@code .jrxml}.
+	 *
+	 * @param folder the report folder to scan; when it is {@code null} or not a directory the method does nothing.
+	 * @return the number of reports (re)compiled in this folder.
+	 */
+	public static int compileStaleReports(File folder) {
+		if (folder == null || !folder.isDirectory()) {
+			LOGGER.debug("Skipping report folder '{}': not an existing directory.", folder);
+			return 0;
+		}
+		int compiled = 0;
+		int failed = 0;
+		for (File jrxml : listJrxmlFiles(folder)) {
+			File jasper = new File(jrxml.getParentFile(), jasperNameOf(jrxml));
+			if (isUpToDate(jasper, jrxml)) {
+				continue;
+			}
+			try {
+				JasperCompileManager.compileReportToFile(jrxml.getAbsolutePath(), jasper.getAbsolutePath());
+				compiled++;
+				LOGGER.info("Compiled report '{}'.", jrxml.getPath());
+			} catch (Exception exception) {
+				failed++;
+				LOGGER.warn("Unable to compile report '{}': {}", jrxml.getPath(), exception.getMessage());
+			}
+		}
+		if (compiled > 0 || failed > 0) {
+			LOGGER.info("Report compilation in '{}': {} compiled, {} failed.", folder.getPath(), compiled, failed);
+		}
+		return compiled;
+	}
+
+	private static List<File> listJrxmlFiles(File folder) {
+		List<File> result = new ArrayList<>();
+		collectJrxmlFiles(folder, result);
+		return result;
+	}
+
+	private static void collectJrxmlFiles(File folder, List<File> result) {
+		File[] entries = folder.listFiles();
+		if (entries == null) {
+			return;
+		}
+		for (File entry : entries) {
+			if (entry.isDirectory()) {
+				collectJrxmlFiles(entry, result);
+			} else if (entry.getName().toLowerCase().endsWith(JRXML_EXTENSION)) {
+				result.add(entry);
+			}
+		}
+	}
+
+	private static boolean isUpToDate(File jasper, File jrxml) {
+		return jasper.exists() && jasper.lastModified() >= jrxml.lastModified();
+	}
+
+	private static String jasperNameOf(File jrxml) {
+		String name = jrxml.getName();
+		return name.substring(0, name.length() - JRXML_EXTENSION.length()) + JASPER_EXTENSION;
+	}
+}

--- a/src/main/java/org/isf/stat/manager/JasperReportCompiler.java
+++ b/src/main/java/org/isf/stat/manager/JasperReportCompiler.java
@@ -22,13 +22,20 @@
 package org.isf.stat.manager;
 
 import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.List;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import net.sf.jasperreports.engine.JRException;
 import net.sf.jasperreports.engine.JasperCompileManager;
+import net.sf.jasperreports.engine.JasperReport;
+import net.sf.jasperreports.engine.util.JRLoader;
+import net.sf.jasperreports.engine.xml.JRXmlWriter;
 
 /**
  * Optional automatic compilation of JasperReports templates ({@code .jrxml}) into their compiled form ({@code .jasper}),
@@ -107,6 +114,28 @@ public final class JasperReportCompiler {
 			LOGGER.info("Report compilation in '{}': {} compiled, {} failed.", folder.getPath(), compiled, failed);
 		}
 		return compiled;
+	}
+
+	/**
+	 * Migrates a legacy (JasperReports 6) report to the current JasperReports 7 format headless, i.e. without Jaspersoft
+	 * Studio. A compiled report already carries a JasperReports 7 model, so this loads the committed {@code .jasper}, writes
+	 * it back with {@link JRXmlWriter} as a JasperReports 7 {@code .jrxml} (no legacy namespace) and recompiles it with the
+	 * pom's JasperReports version. It is the way to convert the templates Open Hospital still ships in the legacy JR6 XML
+	 * format — which {@link JasperCompileManager} cannot compile from source directly — after which
+	 * {@link #compileStaleReports(List)} keeps their {@code .jasper} up to date.
+	 *
+	 * @param compiledReport the committed {@code .jasper} to migrate.
+	 * @param outputJrxml    where the JasperReports 7 {@code .jrxml} is written.
+	 * @param outputJasper   where the recompiled {@code .jasper} is written.
+	 * @throws JRException if the report cannot be loaded or recompiled.
+	 * @throws IOException if the {@code .jrxml} cannot be written.
+	 */
+	public static void migrateToJasperReports7(File compiledReport, File outputJrxml, File outputJasper) throws JRException, IOException {
+		JasperReport report = (JasperReport) JRLoader.loadObject(compiledReport);
+		String jrxml = JRXmlWriter.writeReport(report, StandardCharsets.UTF_8.name());
+		Files.write(outputJrxml.toPath(), jrxml.getBytes(StandardCharsets.UTF_8));
+		JasperCompileManager.compileReportToFile(outputJrxml.getAbsolutePath(), outputJasper.getAbsolutePath());
+		LOGGER.info("Migrated report '{}' to JasperReports 7: '{}'.", compiledReport.getPath(), outputJrxml.getPath());
 	}
 
 	private static List<File> listJrxmlFiles(File folder) {

--- a/src/test/java/org/isf/stat/TestJasperReportCompiler.java
+++ b/src/test/java/org/isf/stat/TestJasperReportCompiler.java
@@ -117,6 +117,24 @@ class TestJasperReportCompiler {
 		assertThat(JasperReportCompiler.compileStaleReports(List.of(new File(reportFolder, "does-not-exist").getPath()))).isZero();
 	}
 
+	@Test
+	void testMigratesCompiledReportToJasperReports7() throws Exception {
+		// a compiled report already holds a JasperReports 7 model, whatever the source format was
+		write("report.jrxml", VALID_JRXML);
+		JasperReportCompiler.compileStaleReports(List.of(reportFolder.getPath()));
+		File jasper = new File(reportFolder, "report.jasper");
+		assertThat(jasper).exists();
+
+		File outJrxml = new File(reportFolder, "migrated.jrxml");
+		File outJasper = new File(reportFolder, "migrated.jasper");
+		JasperReportCompiler.migrateToJasperReports7(jasper, outJrxml, outJasper);
+
+		// round-tripping produces a JasperReports 7 jrxml (no legacy namespace) that recompiles cleanly
+		assertThat(outJasper).exists();
+		String jrxml = new String(Files.readAllBytes(outJrxml.toPath()), StandardCharsets.UTF_8);
+		assertThat(jrxml).doesNotContain("jasperreports.sourceforge.net").contains("<element ");
+	}
+
 	private File write(String name, String content) throws Exception {
 		File file = new File(reportFolder, name);
 		Files.write(file.toPath(), content.getBytes(StandardCharsets.UTF_8));

--- a/src/test/java/org/isf/stat/TestJasperReportCompiler.java
+++ b/src/test/java/org/isf/stat/TestJasperReportCompiler.java
@@ -1,0 +1,125 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2026 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.isf.stat;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.List;
+
+import org.isf.stat.manager.JasperReportCompiler;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class TestJasperReportCompiler {
+
+	/**
+	 * A minimal, valid JasperReports 7 template: no XML namespace and band children wrapped in {@code <element kind="…">}.
+	 */
+	private static final String VALID_JRXML = """
+			<?xml version="1.0" encoding="UTF-8"?>
+			<jasperReport name="TestAutoCompile" pageWidth="595" pageHeight="842" columnWidth="555" leftMargin="20" rightMargin="20" topMargin="20" bottomMargin="20" uuid="1a2b3c4d-0000-0000-0000-000000000001">
+				<detail>
+					<band height="20">
+						<element kind="staticText" x="0" y="0" width="555" height="20" uuid="1a2b3c4d-0000-0000-0000-000000000002">
+							<text><![CDATA[OP-1403 auto-compile test]]></text>
+						</element>
+					</band>
+				</detail>
+			</jasperReport>
+			""";
+
+	/**
+	 * A legacy JasperReports 6 template: it declares the old XML namespace and therefore cannot be compiled by
+	 * JasperReports 7.
+	 */
+	private static final String LEGACY_JRXML = """
+			<?xml version="1.0" encoding="UTF-8"?>
+			<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" name="Legacy" pageWidth="595" pageHeight="842" columnWidth="555" uuid="1a2b3c4d-0000-0000-0000-000000000003"/>
+			""";
+
+	@TempDir
+	File reportFolder;
+
+	@Test
+	void testCompilesMissingReport() throws Exception {
+		write("report.jrxml", VALID_JRXML);
+		File jasper = new File(reportFolder, "report.jasper");
+		assertThat(jasper).doesNotExist();
+
+		int compiled = JasperReportCompiler.compileStaleReports(List.of(reportFolder.getPath()));
+
+		assertThat(compiled).isEqualTo(1);
+		assertThat(jasper).exists();
+	}
+
+	@Test
+	void testSkipsUpToDateReport() throws Exception {
+		write("report.jrxml", VALID_JRXML);
+		assertThat(JasperReportCompiler.compileStaleReports(List.of(reportFolder.getPath()))).isEqualTo(1);
+
+		// a second run finds the .jasper not older than the .jrxml and recompiles nothing
+		assertThat(JasperReportCompiler.compileStaleReports(List.of(reportFolder.getPath()))).isZero();
+	}
+
+	@Test
+	void testRecompilesStaleReport() throws Exception {
+		File jrxml = write("report.jrxml", VALID_JRXML);
+		File jasper = new File(reportFolder, "report.jasper");
+		JasperReportCompiler.compileStaleReports(List.of(reportFolder.getPath()));
+		assertThat(jasper).exists();
+
+		// make the compiled report older than its source
+		assertThat(jasper.setLastModified(1_000L)).isTrue();
+		assertThat(jrxml.setLastModified(2_000L)).isTrue();
+
+		assertThat(JasperReportCompiler.compileStaleReports(List.of(reportFolder.getPath()))).isEqualTo(1);
+		assertThat(jasper.lastModified()).isGreaterThan(1_000L);
+	}
+
+	@Test
+	void testFailingReportIsSkippedAndDoesNotStopTheOthers() throws Exception {
+		write("legacy.jrxml", LEGACY_JRXML);
+		write("good.jrxml", VALID_JRXML);
+
+		int compiled = JasperReportCompiler.compileStaleReports(List.of(reportFolder.getPath()));
+
+		// only the valid report is compiled; the legacy one fails (logged) without stopping the scan or throwing
+		assertThat(compiled).isEqualTo(1);
+		assertThat(new File(reportFolder, "good.jasper")).exists();
+		assertThat(new File(reportFolder, "legacy.jasper")).doesNotExist();
+	}
+
+	@Test
+	void testNullAndMissingFoldersAreIgnored() {
+		assertThat(JasperReportCompiler.compileStaleReports((List<String>) null)).isZero();
+		assertThat(JasperReportCompiler.compileStaleReports(List.of(new File(reportFolder, "does-not-exist").getPath()))).isZero();
+	}
+
+	private File write(String name, String content) throws Exception {
+		File file = new File(reportFolder, name);
+		Files.write(file.toPath(), content.getBytes(StandardCharsets.UTF_8));
+		return file;
+	}
+}


### PR DESCRIPTION
## OP-1403

Adds an opt-in mechanism to (re)compile JasperReports templates (`.jrxml`) into their compiled form (`.jasper`), so that a template edited on disk does not require a manual recompilation and does not fail at report time with a stale or missing `.jasper`.

### Changes
- New `org.isf.stat.manager.JasperReportCompiler`: scans the given report folders (recursively) and (re)compiles every `.jrxml` whose `.jasper` is missing or older than the template. A template that fails to compile is logged and skipped, so a single broken report does not stop the others.
- New configuration flag `GeneralData.AUTOCOMPILEJRXML` (default `false`) that guards the feature.
- Unit test `TestJasperReportCompiler`: compiles a valid JasperReports 7 template, skips up-to-date and recompiles stale reports, and verifies a failing template does not stop the others.

### Notes
- No new dependency: the project's JasperReports 7.0.6 already compiles templates at runtime.
- The compiler expects templates in the JasperReports 7 format; legacy JasperReports 6 templates must be migrated first (e.g. with Jaspersoft Studio).
- Security: JRXML templates can contain executable expressions, so the feature is disabled by default and must only be enabled when the report files are trusted.

The GUI startup hook and the setting are in openhospital-gui; the documentation is in openhospital-doc.