### PR TITLE
Reject negative bill item values

### DIFF
--- a/src/main/java/org/isf/accounting/manager/BillBrowserManager.java
+++ b/src/main/java/org/isf/accounting/manager/BillBrowserManager.java
@@ -85,6 +85,12 @@ public class BillBrowserManager {
 		if (billItems.isEmpty()) {
 			errors.add(new OHExceptionMessage(MessageBundle.getMessage("angal.newbill.abillmustcontainatleastoneitem.msg")));
 		}
+		if (billItems.stream().anyMatch(item -> item.getItemAmount() == null || item.getItemAmount().compareTo(BigDecimal.ZERO) < 0)) {
+			errors.add(new OHExceptionMessage("Bill item amounts must be zero or greater."));
+		}
+		if (billItems.stream().anyMatch(item -> item.getItemQuantity() < 0)) {
+			errors.add(new OHExceptionMessage("Bill item quantities must be zero or greater."));
+		}
 		if (billDate.isAfter(today)) {
 			errors.add(new OHExceptionMessage(MessageBundle.getMessage("angal.newbill.billsinthefuturearenotallowed.msg")));
 		}

--- a/src/test/java/org/isf/accounting/Tests.java
+++ b/src/test/java/org/isf/accounting/Tests.java
@@ -47,6 +47,7 @@ import org.isf.priceslist.model.PriceList;
 import org.isf.priceslist.service.PricesListIoOperationRepository;
 import org.isf.utils.exception.OHDataValidationException;
 import org.isf.utils.exception.OHException;
+import org.isf.utils.exception.model.OHExceptionMessage;
 import org.isf.utils.time.TimeTools;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -983,6 +984,34 @@ class Tests extends OHCoreTestCase {
 
 		assertThat(updated.getAmount()).isEqualByComparingTo(new BigDecimal("202.0"));
 		assertThat(updated.getBalance()).isEqualByComparingTo(new BigDecimal("191.9"));
+	}
+
+	@Test
+	void mgrUpdateBillRejectsNegativeItemAmount() throws Exception {
+		int id = setupTestBillWithItems(false);
+		Bill bill = accountingBillIoOperationRepository.findById(id).orElse(null);
+		assertThat(bill).isNotNull();
+		BillItems item = testBillItems.setup(null, false);
+		item.setItemAmount(new BigDecimal("-1.00"));
+
+		assertThatThrownBy(() -> billBrowserManager.updateBill(bill, List.of(item), new ArrayList<>()))
+			.isInstanceOfSatisfying(OHDataValidationException.class, exception -> assertThat(exception.getMessages())
+				.extracting(OHExceptionMessage::getMessage)
+				.contains("Bill item amounts must be zero or greater."));
+	}
+
+	@Test
+	void mgrUpdateBillRejectsNegativeItemQuantity() throws Exception {
+		int id = setupTestBillWithItems(false);
+		Bill bill = accountingBillIoOperationRepository.findById(id).orElse(null);
+		assertThat(bill).isNotNull();
+		BillItems item = testBillItems.setup(null, false);
+		item.setItemQuantity(-1);
+
+		assertThatThrownBy(() -> billBrowserManager.updateBill(bill, List.of(item), new ArrayList<>()))
+			.isInstanceOfSatisfying(OHDataValidationException.class, exception -> assertThat(exception.getMessages())
+				.extracting(OHExceptionMessage::getMessage)
+				.contains("Bill item quantities must be zero or greater."));
 	}
 
 	@Test


### PR DESCRIPTION
## What

- reject bill items with a null or negative amount
- reject bill items with a negative quantity
- enforce the invariant in `BillBrowserManager` before bill writes
- add update regressions for both manipulated fields

## Why

Bill totals are recalculated from item amount multiplied by quantity. Negative values were accepted during bill updates and could therefore corrupt the bill amount and balance.

## Security impact

Malformed bill items now fail with `OHDataValidationException` before the bill or its items are updated. The check lives in the domain manager so it protects REST and non-REST callers. Zero remains allowed to avoid changing existing business semantics beyond the confirmed negative-value vulnerability.

## Checks

- `./mvnw -q -Dtest=org.isf.accounting.Tests test` (61 tests)
- `git diff --check`