### PR TITLE
OP-1457 Fix the two statements that make the demo data fail to load

### DIFF
--- a/sql/load_demo_data.sql
+++ b/sql/load_demo_data.sql
@@ -5027,7 +5027,7 @@ INSERT INTO `oh_medicaldsrstockmovward` VALUES (96,'F','2026-02-09 13:08:00',1,4
 INSERT INTO `oh_medicaldsrstockmovward` VALUES (97,'F','2026-02-09 13:12:00',1,665,62,0,'Agnes Marie Namukasa',40,1,'pieces','admin',NULL,NULL,'LT2602','2026-02-09 13:12:00','admin','2026-02-09 13:12:00',1);
 INSERT INTO `oh_medicaldsrstockmovward` VALUES (98,'I','2026-02-28 13:00:00',1,501,34,0,'Mario Rossi',108,1,'pieces','admin',NULL,NULL,'LT2603','2026-02-28 13:00:00','admin','2026-02-28 13:00:00',1);
 INSERT INTO `oh_medicaldsrstockmovward` VALUES (99,'I','2026-02-28 13:04:00',1,469,51,0,'Quinley Arden',414,1,'pieces','admin',NULL,NULL,'LT2604','2026-02-28 13:04:00','admin','2026-02-28 13:04:00',1);
-INSERT INTO `oh_medicaldsrstockmovward` VALUES (100,'I','2026-02-28 13:08:00',1,470,49,0,'Leddy Everette',415,3,'pieces','admin',NULL,NULL,'LT2605','2026-02-28 13:08:00','admin','2026-…5462 tokens truncated…-01 12:00:00','admin','2026-08-01 12:00:00',1,0);
+INSERT INTO `oh_medicaldsrstockmovward` VALUES (100,'I','2026-02-28 13:08:00',1,470,49,0,'Leddy Everette',415,3,'pieces','admin',NULL,NULL,'LT2605','2026-02-28 13:08:00','admin','2026-02-28 13:08:00',1);
 INSERT INTO `oh_medicaldsrstockmovward` VALUES (101,'I','2026-02-28 13:12:00',1,424,27,0,'Tiedemann Hayden',99,1,'pieces','admin',NULL,NULL,'LT2606','2026-02-28 13:12:00','admin','2026-02-28 13:12:00',1);
 INSERT INTO `oh_medicaldsrstockmovward` VALUES (102,'I','2026-02-28 13:16:00',1,522,67,0,'Harry Colterson',103,2,'pieces','admin',NULL,NULL,'LT2607','2026-02-28 13:16:00','admin','2026-02-28 13:16:00',1);
 INSERT INTO `oh_medicaldsrstockmovward` VALUES (103,'M','2026-03-19 13:00:00',1,363,38,0,'Tichenor Alita',105,3,'pieces','admin',NULL,NULL,'LT2608','2026-03-19 13:00:00','admin','2026-03-19 13:00:00',1);

--- a/sql/load_demo_data.sql
+++ b/sql/load_demo_data.sql
@@ -5062,7 +5062,6 @@ INSERT INTO `oh_medicaldsrstockmovward` VALUES (131,'F','2026-07-11 13:08:00',1,
 INSERT INTO `oh_medicaldsrstockmovward` VALUES (132,'F','2026-07-11 13:12:00',1,571,21,0,'Johanna Furly',177,3,'pieces','admin',NULL,NULL,'LT2612','2026-07-11 13:12:00','admin','2026-07-11 13:12:00',1);
 INSERT INTO `oh_medicaldsrstockmovward` VALUES (133,'F','2026-07-11 13:16:00',1,553,28,0,'Yellen Unison',50,1,'pieces','admin',NULL,NULL,'LT2613','2026-07-11 13:16:00','admin','2026-07-11 13:16:00',1);
 INSERT INTO `oh_medicaldsrstockmovward` VALUES (134,'F','2026-07-11 13:20:00',1,679,48,0,'Rebecca Marie Acheampong',151,2,'pieces','admin',NULL,NULL,'LT2614','2026-07-11 13:20:00','admin','2026-07-11 13:20:00',1);
-INSERT INTO `oh_medicaldsrward` VALUES ('C',415,10,3,'LT2520','admin','2025-11-06 11:04:00','admin','2025-11-06 13:04:00',1,0);
 /*!40000 ALTER TABLE `oh_medicaldsrstockmovward` ENABLE KEYS */;
 UNLOCK TABLES;
 


### PR DESCRIPTION
Two one-line fixes to `sql/load_demo_data.sql` on `release_1_15_1`. They are in the same file and adjacent, and the demo database only loads cleanly with both, so they come as one PR — one commit per issue: OP-1457 and OP-1458.

### What is wrong

Building a demo database from the shipped `sql/` currently prints two errors:

```
ERROR 1136 (21S01) at line 5030 in file: 'load_demo_data.sql': Column count doesn't match value count at row 1
ERROR 1100 (HY000) at line 5065 in file: 'load_demo_data.sql': Table 'oh_medicaldsrward' was not locked with LOCK TABLES
```

**Line 5030 (OP-1457).** The row for ward stock movement 100 was assembled from truncated console output: where `MMVN_LAST_MODIFIED_DATE` belongs it holds the literal text of a truncation marker, and four values of debris trail it. The INSERT is rejected, the movement never loads, and ward stock `I / 415 / LT2605` is left recording three units out with nothing to account for them — the only row in the dataset where stock and movements disagree.

Only the first seventeen values were salvageable. The last two columns are restored from the convention the table's other 133 rows follow without exception: last modified equals created equals the movement date, modified by is `admin`, active is `1`.

Worth flagging for anyone reviewing the diff: the debris starts one value *earlier* than the arity suggests, so dropping three trailing values to make the count fit would leave `'admin'` in `MMVN_LAST_MODIFIED_DATE` and a timestamp in `MMVN_ACTIVE`. Under the dump's own non-strict `SQL_MODE` that loads silently as a zero date and an inactive movement — the same defect, harder to see.

**Line 5065 (OP-1458).** An `INSERT INTO oh_medicaldsrward` sits inside the `LOCK TABLES oh_medicaldsrstockmovward` block. The identical row is inserted in its proper place further down, so only the stray copy goes and the loaded data is unchanged.

### Verification

Demo database rebuilt from scratch through `create_all_demo.sql` on MariaDB 10.6 (`--lower-case-table-names=1`):

- before: 2 errors, movement 100 missing, one ward stock row inconsistent
- after: **0 errors**, movement 100 present between 99 and 101, **0** ward stock rows disagreeing with their movements

Also checked, to be sure the fix is complete and nothing else was disturbed: every INSERT in the file re-counted against its table's column count across all 64 tables (no other mismatch), no other statement inside a wrong `LOCK TABLES` block, no other pasted tool-output artifact in the repository, and a table-by-table checksum between the two databases showing `oh_medicaldsrstockmovward` as the only difference.

### Two things deliberately not done here

- **`--complete-insert`.** Regenerating the dump with explicit column names would remove this class of error entirely, since a mismatch would fail at the named column rather than by arity. It rewrites the whole file, so it belongs in its own change if you want it.
- **`develop`.** Not affected: it carries no `oh_medicaldsrstockmovward` demo rows at all. The fix will need carrying over whenever the release branch merges forward.

### Separately

The reason these reached a published package is that the load reports success anyway — through `create_all_demo.sql` the client prints the errors, carries on and exits `0`, and `oh.sh` only tests the exit status. Raised as OP-1459, not addressed here.

Happy to close this if the demo data is already being reworked and it is easier to fold the two lines into that work — just say so.
