### PR TITLE
OP-1461 Report an unknown log folder instead of throwing a NullPointerException

### DIFF
--- a/src/main/java/org/isf/utils/log/LogUtil.java
+++ b/src/main/java/org/isf/utils/log/LogUtil.java
@@ -1,6 +1,6 @@
 /*
  * Open Hospital (www.open-hospital.org)
- * Copyright © 2006-2024 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ * Copyright © 2006-2026 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
  *
  * Open Hospital is a free and open source software for healthcare data management.
  *
@@ -63,11 +63,29 @@ public class LogUtil {
 	/**
 	 * Opens the application log file ({@code openhospital.log}) folder with the System default file explorer.
 	 *
-	 * @throws IOException 
+	 * @throws IOException when the folder is unknown, so that the caller can report it instead of failing
 	 */
 	public static void openLogFileLocation() throws IOException {
-		File logFile = new File(getLogFileAbsolutePath());
-		Desktop.getDesktop().open(new File(logFile.getParent()));
+		Desktop.getDesktop().open(logFileFolder(getLogFileAbsolutePath()));
+	}
+
+	/**
+	 * Resolves the folder holding the given log file path.
+	 *
+	 * @param logFilePath the configured log file path, {@code null} when no file appender is configured
+	 * @return the folder holding the log file
+	 * @throws IOException when the path is unknown or has no folder
+	 */
+	static File logFileFolder(String logFilePath) throws IOException {
+		if (logFilePath == null) {
+			throw new IOException("No file appender is configured: there is no log file to show.");
+		}
+		// a bare file name has no parent, but it is written in the working directory
+		File folder = new File(logFilePath).getAbsoluteFile().getParentFile();
+		if (folder == null) {
+			throw new IOException("Cannot determine the folder holding " + logFilePath + '.');
+		}
+		return folder;
 	}
 
 }

--- a/src/main/java/org/isf/utils/log/LogUtil.java
+++ b/src/main/java/org/isf/utils/log/LogUtil.java
@@ -66,7 +66,8 @@ public class LogUtil {
 	 * @throws IOException when the folder is unknown, so that the caller can report it instead of failing
 	 */
 	public static void openLogFileLocation() throws IOException {
-		Desktop.getDesktop().open(logFileFolder(getLogFileAbsolutePath()));
+		File folder = logFileFolder(getLogFileAbsolutePath());
+		Desktop.getDesktop().open(folder);
 	}
 
 	/**

--- a/src/test/java/org/isf/utils/log/TestLogUtil.java
+++ b/src/test/java/org/isf/utils/log/TestLogUtil.java
@@ -1,6 +1,6 @@
 /*
  * Open Hospital (www.open-hospital.org)
- * Copyright © 2006-2024 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ * Copyright © 2006-2026 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
  *
  * Open Hospital is a free and open source software for healthcare data management.
  *
@@ -22,6 +22,10 @@
 package org.isf.utils.log;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.io.File;
+import java.io.IOException;
 
 import org.junit.jupiter.api.Test;
 
@@ -31,5 +35,25 @@ class TestLogUtil {
 	void testGetLogFileAbsolutePath() {
 		// depending on the testing setup the value is either null or the value in the properties file
 		assertThat(LogUtil.getLogFileAbsolutePath()).isIn(null, "logs/openhospital.log");
+	}
+
+	@Test
+	void testLogFileFolderReportsAnUnknownPathInsteadOfFailing() {
+		// getLogFileAbsolutePath() returns null whenever no file appender is configured
+		assertThatThrownBy(() -> LogUtil.logFileFolder(null))
+						.isInstanceOf(IOException.class)
+						.hasMessageContaining("no log file");
+	}
+
+	@Test
+	void testLogFileFolderResolvesABareFileNameAgainstTheWorkingDirectory() throws IOException {
+		assertThat(LogUtil.logFileFolder("openhospital.log"))
+						.isEqualTo(new File(System.getProperty("user.dir")));
+	}
+
+	@Test
+	void testLogFileFolderKeepsTheFolderOfAPathThatHasOne() throws IOException {
+		assertThat(LogUtil.logFileFolder("logs/openhospital.log"))
+						.isEqualTo(new File(System.getProperty("user.dir"), "logs"));
 	}
 }


### PR DESCRIPTION
## [OP-1461](https://openhospital.atlassian.net/browse/OP-1461)

Opening the log folder from the GUI kills the action with an unhandled exception on the event dispatch thread, and the user is told nothing:

```
Exception in thread "AWT-EventQueue-0" java.lang.RuntimeException: java.lang.reflect.InvocationTargetException
	at org.isf.menu.gui.MainMenu.launchApp(MainMenu.java:445)
Caused by: java.lang.NullPointerException
	at java.base/java.io.File.<init>(Unknown Source)
	at org.isf.utils.log.LogUtil.openLogFileLocation(LogUtil.java:70)
	at org.isf.help.LogViewer.<init>(LogViewer.java:46)
```

`openLogFileLocation()` dereferenced two values that can legitimately be null:

* `getLogFileAbsolutePath()` returns null when none of the root logger's appenders writes to a file — `TestLogUtil` already says as much, *"depending on the testing setup the value is either null or the value in the properties file"*;
* `getParent()` returns null for a file name with no folder, so `appender.rolling.fileName=openhospital.log` reaches the same crash by another route.

## What changed

The resolution moved into `logFileFolder(String)`, which throws `IOException` — the exception the caller already handles — when the path is unknown, and resolves a bare file name against the working directory, where the file is actually written.

## Verified

`TestLogUtil` covers the three cases, 4 tests green:

```
Tests run: 4, Failures: 0, Errors: 0, Skipped: 0 -- in org.isf.utils.log.TestLogUtil
```

The GUI side is in openhospital-gui and needs this merged first, since the null is produced here.

Found while testing the v1.15.1 package: a `log4j2-spring.properties` left with its `LOG_DEST` placeholder configures no file appender, and the Log Viewer entry throws.

[OP-1461]: https://openhospital.atlassian.net/browse/OP-1461?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ